### PR TITLE
Prevent unnecessary row count query

### DIFF
--- a/src/yajra/Datatables/Engine/BaseEngine.php
+++ b/src/yajra/Datatables/Engine/BaseEngine.php
@@ -117,6 +117,13 @@ class BaseEngine
     public $filteredRecords = 0;
 
     /**
+     * [internal] Track if any filter was applied for atleast one column
+     *
+     * @var bool
+     */
+    protected $isFilterApplied = false;
+
+    /**
      * Eloquent/Builder result object.
      *
      * @var mixed
@@ -374,6 +381,8 @@ class BaseEngine
                         $this->compileGlobalSearch($query, $column, $keyword);
                     }
                 }
+                
+                $this->isFilterApplied = true;
             }
         );
     }
@@ -774,6 +783,8 @@ class BaseEngine
                         $this->query->whereRaw($col . ' LIKE ?', [$keyword]);
                     }
                 }
+                
+                $this->isFilterApplied = true;
             }
         }
     }
@@ -785,7 +796,7 @@ class BaseEngine
      */
     public function getTotalFilteredRecords()
     {
-        return $this->filteredRecords = $this->count();
+        return $this->filteredRecords = $this->isFilterApplied ? $this->count() : $this->totalRecords;
     }
 
     /**


### PR DESCRIPTION
When data is loaded and filter isn't applied for any column, two identical row count queries are executed: 
```sql select count(*) as aggregate from (select '1' as row_count from `workers`) count_row_table```

The following fix will make engine to execute second count query (to calculate filtered records) only if filter was applied for at least one column.