### PR TITLE
Update Datatables.php

### DIFF
--- a/src/yajra/Datatables/Facade/Datatables.php
+++ b/src/yajra/Datatables/Facade/Datatables.php
@@ -11,6 +11,6 @@ class Datatables extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return 'Datatables';
+        return 'datatables';
     }
 }


### PR DESCRIPTION
Change the return string to 'datatables'; 

The previous  return string was  mismatched with the register function in DatatablesServiceProvider.php. 

There is also a need to update the 'Quick Installation,' under the Facade section: 

 'Datatables' => 'yajra\Datatables\Datatables',    //currently, incorrect

 'Datatables' => 'yajra\Datatables\Facades\Datatables',   //proposed