### PR TITLE
[Feature] orderColumn

### DIFF
--- a/src/yajra/Datatables/Engines/BaseEngine.php
+++ b/src/yajra/Datatables/Engines/BaseEngine.php
@@ -59,7 +59,7 @@ abstract class BaseEngine implements DataTableEngine
     protected $columns = [];
 
     /**
-     * DT columns definitions container (add/edit/remove).
+     * DT columns definitions container (add/edit/remove/filter/order).
      *
      * @var array
      */
@@ -68,6 +68,7 @@ abstract class BaseEngine implements DataTableEngine
         'edit'   => [],
         'excess' => ['rn', 'row_num'],
         'filter' => [],
+        'order'  => [],
     ];
 
     /**
@@ -497,6 +498,20 @@ abstract class BaseEngine implements DataTableEngine
     {
         $params                             = func_get_args();
         $this->columnDef['filter'][$column] = ['method' => $method, 'parameters' => array_splice($params, 2)];
+
+        return $this;
+    }
+
+    /**
+     * Override default column ordering.
+     *
+     * @param string $column
+     * @param string $sql
+     * @return $this
+     */
+    public function orderColumn($column, $sql)
+    {
+        $this->columnDef['order'][$column] = ['method' => 'orderByRaw', 'parameters' => [$sql, []]];
 
         return $this;
     }

--- a/src/yajra/Datatables/Engines/BaseEngine.php
+++ b/src/yajra/Datatables/Engines/BaseEngine.php
@@ -507,11 +507,13 @@ abstract class BaseEngine implements DataTableEngine
      *
      * @param string $column
      * @param string $sql
+     * @param array $bindings
      * @return $this
+     * @internal string $1 Special variable that returns the requested order direction of the column.
      */
-    public function orderColumn($column, $sql)
+    public function orderColumn($column, $sql, $bindings = [])
     {
-        $this->columnDef['order'][$column] = ['method' => 'orderByRaw', 'parameters' => [$sql, []]];
+        $this->columnDef['order'][$column] = ['method' => 'orderByRaw', 'parameters' => [$sql, $bindings]];
 
         return $this;
     }

--- a/src/yajra/Datatables/Engines/BaseEngine.php
+++ b/src/yajra/Datatables/Engines/BaseEngine.php
@@ -24,6 +24,13 @@ abstract class BaseEngine implements DataTableEngine
 {
 
     /**
+     * Datatables Request object.
+     *
+     * @var \yajra\Datatables\Request
+     */
+    public $request;
+
+    /**
      * Database connection used.
      *
      * @var \Illuminate\Database\Connection
@@ -43,13 +50,6 @@ abstract class BaseEngine implements DataTableEngine
      * @var \Illuminate\Database\Query\Builder
      */
     protected $builder;
-
-    /**
-     * Datatables Request object.
-     *
-     * @var \yajra\Datatables\Request
-     */
-    public $request;
 
     /**
      * Array of result columns/fields.
@@ -542,13 +542,20 @@ abstract class BaseEngine implements DataTableEngine
     {
         $this->totalRecords = $this->count();
 
-        $this->orderRecords( ! $orderFirst);
+        $this->orderRecords(! $orderFirst);
         $this->filterRecords();
         $this->orderRecords($orderFirst);
         $this->paginate();
 
         return $this->render($mDataSupport);
     }
+
+    /**
+     * Count results.
+     *
+     * @return integer
+     */
+    abstract public function count();
 
     /**
      * Sort records.
@@ -562,6 +569,13 @@ abstract class BaseEngine implements DataTableEngine
             $this->ordering();
         }
     }
+
+    /**
+     * Perform sorting of columns.
+     *
+     * @return void
+     */
+    abstract public function ordering();
 
     /**
      * Perform necessary filters.
@@ -583,20 +597,6 @@ abstract class BaseEngine implements DataTableEngine
     }
 
     /**
-     * Count results.
-     *
-     * @return integer
-     */
-    abstract public function count();
-
-    /**
-     * Perform sorting of columns.
-     *
-     * @return void
-     */
-    abstract public function ordering();
-
-    /**
      * Perform global search.
      *
      * @return void
@@ -611,13 +611,6 @@ abstract class BaseEngine implements DataTableEngine
     abstract public function columnSearch();
 
     /**
-     * Perform pagination
-     *
-     * @return void
-     */
-    abstract public function paging();
-
-    /**
      * Apply pagination.
      *
      * @return void
@@ -628,6 +621,13 @@ abstract class BaseEngine implements DataTableEngine
             $this->paging();
         }
     }
+
+    /**
+     * Perform pagination
+     *
+     * @return void
+     */
+    abstract public function paging();
 
     /**
      * Render json response.

--- a/src/yajra/Datatables/Engines/QueryBuilderEngine.php
+++ b/src/yajra/Datatables/Engines/QueryBuilderEngine.php
@@ -89,8 +89,9 @@ class QueryBuilderEngine extends BaseEngine implements DataTableEngine
                     if (isset($this->columnDef['filter'][$column])) {
                         $method     = Helper::getOrMethod($this->columnDef['filter'][$column]['method']);
                         $parameters = $this->columnDef['filter'][$column]['parameters'];
-                        $this->compileColumnQuery($this->getQueryBuilder($query), $method, $parameters, $column,
-                            $keyword);
+                        $this->compileColumnQuery(
+                            $this->getQueryBuilder($query), $method, $parameters, $column, $keyword
+                        );
                     } else {
                         $this->compileGlobalSearch($this->getQueryBuilder($query), $column, $keyword);
                     }


### PR DESCRIPTION
### orderColumn

Added orderColumn feature allowing users to override the default ordering of a column. Laravel's orderByRaw is used by default. An internal parameter '$1' is available which returns the requested order of the column.

```php
//**
 * Override default column ordering.
 *
 * @param string $column
 * @param string $sql
 * @param array $bindings
 * @return $this
 * @internal string $1 Special variable that returns the requested order direction of the column.
 */
public function orderColumn($column, $sql, $bindings = [])
```

### Usage:

Example code will hijack remember_token ordering and use order by name instead.
```php
return Datatables::of(User::select('*'))
    ->orderColumn('remember_token', 'name $1')
    ->make(true);
```
