### PR TITLE
Fixed row variables (like DT_RowClass) was not set

### DIFF
--- a/src/yajra/Datatables/Processors/DataProcessor.php
+++ b/src/yajra/Datatables/Processors/DataProcessor.php
@@ -72,12 +72,12 @@ class DataProcessor
             $data  = Helper::convertToArray($row);
             $value = $this->addColumns($data, $row);
             $value = $this->editColumns($value, $row);
-            $value = $this->setupRowVariables($value, $row);
             if ( ! $object) {
                 $value = Arr::flatten($this->removeExcessColumns($value));
             } else {
                 $value = $this->removeExcessColumns($value);
             }
+            $value = $this->setupRowVariables($value, $row);
             $this->output[] = $value;
         }
 


### PR DESCRIPTION
Updated DataProcessor.php to fix row variable names (returned row array keys, for example, DT_RowClass) was set to numeric key.