### PR TITLE
collectionengine: fix sorting of relation columns by using seralize

### DIFF
--- a/src/yajra/Datatables/Engines/CollectionEngine.php
+++ b/src/yajra/Datatables/Engines/CollectionEngine.php
@@ -97,9 +97,9 @@ class CollectionEngine extends BaseEngine implements DataTableEngine
             $column           = $this->getColumnName($orderable['column']);
             $this->collection = $this->collection->sortBy(
                 function ($row) use ($column) {
-                    $row = Helper::castToArray($row);
+                    $data = $this->serialize($row);
 
-                    return Arr::get($row, $column);
+                    return Arr::get($data, $column);
                 }
             );
 


### PR DESCRIPTION
serialize seems to work (already does in filtering) for relation columns (flattening the relation to array and accessing the column with dot notation)