### PR TITLE
sort by a multi-line 'select as' query

### DIFF
--- a/src/yajra/Datatables/Datatables.php
+++ b/src/yajra/Datatables/Datatables.php
@@ -295,7 +295,7 @@ class Datatables
      */
     private function getColumnName($str)
     {
-        $matches = explode(' as ', $str);
+        $matches = explode(' as ', Str::lower($str));
 
         if (! empty($matches)) {
             return array_pop($matches);

--- a/src/yajra/Datatables/Datatables.php
+++ b/src/yajra/Datatables/Datatables.php
@@ -295,10 +295,10 @@ class Datatables
      */
     private function getColumnName($str)
     {
-        preg_match('#^(\S*?)\s+as\s+(\S*?)$#si', $str, $matches);
+        $matches = explode(' as ', $str);
 
         if (! empty($matches)) {
-            return $matches[2];
+            return array_pop($matches);
         } elseif (strpos($str, '.')) {
             $array = explode('.', $str);
 


### PR DESCRIPTION
Allow it to grab the last 'as' in a multi-line select query (within a select query). Also does one line.

Would solve something complicated like this:
```php
->select('table.begin_at', DB::raw('(SELECT table2.id FROM table as t ...) as file_id'))
```

We'll be on L4 for a while due to a large project, hope you don't mind the requests.