### PR TITLE
Change how regex code is generated after a column search.

### DIFF
--- a/src/Engines/BaseEngine.php
+++ b/src/Engines/BaseEngine.php
@@ -855,4 +855,14 @@ abstract class BaseEngine implements DataTableEngineContract
 
         return $this;
     }
+	
+	/**
+     * Check if the current sql language is based on oracle syntax.
+     *
+     * @return bool
+     */
+    public function isOracleSql()
+    {
+        return Config::get('datatables.oracle_sql', false);
+    }
 }

--- a/src/Engines/QueryBuilderEngine.php
+++ b/src/Engines/QueryBuilderEngine.php
@@ -220,14 +220,22 @@ class QueryBuilderEngine extends BaseEngine implements DataTableEngineContract
                     $column = $this->castColumn($column);
                     if ($this->isCaseInsensitive()) {
                         if ($this->request->isRegex($i)) {
-                           $this->query->whereRaw(' REGEXP_LIKE( LOWER('.$column.') , ?, \'i\' )', [$keyword]);
+							if($this->isOracleSql()){
+								$this->query->whereRaw(' REGEXP_LIKE( LOWER('.$column.') , ?, \'i\' )', [$keyword]);
+							}else{
+								$this->query->whereRaw('LOWER(' . $column . ') REGEXP ?', [Str::lower($keyword)]);
+							}
                         } else {
                             $this->query->whereRaw('LOWER(' . $column . ') LIKE ?', [Str::lower($keyword)]);
                         }
                     } else {
                         $col = strstr($column, '(') ? $this->connection->raw($column) : $column;
                         if ($this->request->isRegex($i)) {
-                            $this->query->whereRaw(' REGEXP_LIKE( '.$col.' , ? )', [$keyword]);
+							if($this->isOracleSql()){
+								$this->query->whereRaw(' REGEXP_LIKE( '.$col.' , ? )', [$keyword]);
+							}else{
+								$this->query->whereRaw($col . ' REGEXP ?', [$keyword]);
+							}
                         } else {
                             $this->query->whereRaw($col . ' LIKE ?', [$keyword]);
                         }

--- a/src/Engines/QueryBuilderEngine.php
+++ b/src/Engines/QueryBuilderEngine.php
@@ -220,14 +220,14 @@ class QueryBuilderEngine extends BaseEngine implements DataTableEngineContract
                     $column = $this->castColumn($column);
                     if ($this->isCaseInsensitive()) {
                         if ($this->request->isRegex($i)) {
-                            $this->query->whereRaw('LOWER(' . $column . ') REGEXP ?', [Str::lower($keyword)]);
+                           $this->query->whereRaw(' REGEXP_LIKE( LOWER('.$column.') , ?, \'i\' )', [$keyword]);
                         } else {
                             $this->query->whereRaw('LOWER(' . $column . ') LIKE ?', [Str::lower($keyword)]);
                         }
                     } else {
                         $col = strstr($column, '(') ? $this->connection->raw($column) : $column;
                         if ($this->request->isRegex($i)) {
-                            $this->query->whereRaw($col . ' REGEXP ?', [$keyword]);
+                            $this->query->whereRaw(' REGEXP_LIKE( '.$col.' , ? )', [$keyword]);
                         } else {
                             $this->query->whereRaw($col . ' LIKE ?', [$keyword]);
                         }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -2,6 +2,8 @@
 
 return [
 
+	'oracle_sql' => false,
+
     'search'          => [
         'case_insensitive' => true,
         'use_wildcards'    => false,


### PR DESCRIPTION
Before this change, regex statements were generated with the MySQL operator 'REGEXP', which were leading to a Oracle error.
Now it uses the Oracle Database SQL function 'REGEXP_LIKE', as written in the Oracle Database Online Documentation, 10g Release 2 (10.2) .