### PR TITLE
Update QueryBuilderEngine.php

### DIFF
--- a/src/Engines/QueryBuilderEngine.php
+++ b/src/Engines/QueryBuilderEngine.php
@@ -85,7 +85,7 @@ class QueryBuilderEngine extends BaseEngine implements DataTableEngineContract
         $myQuery = clone $this->query;
         // if its a normal query ( no union, having and distinct word )
         // replace the select with static text to improve performance
-        if (! Str::contains(Str::lower($myQuery->toSql()), ['union', 'having', 'distinct'])) {
+        if (! Str::contains(Str::lower($myQuery->toSql()), ['union', 'having', 'distinct', 'as', 'order by', 'group by'])) {
             $row_count = $this->connection->getQueryGrammar()->wrap('row_count');
             $myQuery->select($this->connection->raw("'1' as {$row_count}"));
         }

--- a/src/Engines/QueryBuilderEngine.php
+++ b/src/Engines/QueryBuilderEngine.php
@@ -85,7 +85,7 @@ class QueryBuilderEngine extends BaseEngine implements DataTableEngineContract
         $myQuery = clone $this->query;
         // if its a normal query ( no union, having and distinct word )
         // replace the select with static text to improve performance
-        if (! Str::contains(Str::lower($myQuery->toSql()), ['union', 'having', 'distinct', 'as', 'order by', 'group by'])) {
+        if (! Str::contains(Str::lower($myQuery->toSql()), ['union', 'having', 'distinct', 'order by', 'group by'])) {
             $row_count = $this->connection->getQueryGrammar()->wrap('row_count');
             $myQuery->select($this->connection->raw("'1' as {$row_count}"));
         }


### PR DESCRIPTION
public function count(). If I use in SELECT same custom values, for example (count(samevalue)/count(other_same_value) as `3value`) and use in "group by" or  "order by" this value, I have error: Column not found: 1054 Unknown column '3value' in 'order clause' :(