### PR TITLE
Search and order by raw columns

### DIFF
--- a/src/Engines/QueryBuilderEngine.php
+++ b/src/Engines/QueryBuilderEngine.php
@@ -243,6 +243,9 @@ class QueryBuilderEngine extends BaseEngine implements DataTableEngineContract
      */
     public function castColumn($column)
     {
+        if (substr($column,0,4) === 'raw_'){
+            $column = new Expression(substr($column,4));
+        }
         $column = $this->connection->getQueryGrammar()->wrap($column);
         if ($this->database === 'pgsql') {
             $column = 'CAST(' . $column . ' as TEXT)';
@@ -333,7 +336,8 @@ class QueryBuilderEngine extends BaseEngine implements DataTableEngineContract
                 if ($column === '*') {
                     $column = 'id';
                 }
-                $this->getQueryBuilder()->orderBy($column, $orderable['direction']);
+                $column = $this->castColumn($column);
+                $this->getQueryBuilder()->orderByRaw($column . $orderable['direction']);
             }
         }
     }


### PR DESCRIPTION
Make it posible to seacrh and order with raw column name.
You have to provide raw_ prefix in the name of the column
```
columns: [
  {data: 'concat', name: 'raw_concat(col1,col2)'},
]
```
