### PR TITLE
Fix addColumn fails when order falls at end of array

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -19,7 +19,7 @@ class Helper
      */
     public static function includeInArray($item, $array)
     {
-        if ($item['order'] === false) {
+        if ($item['order'] === false || $item['order'] >= count($array)) {
             return array_merge($array, [$item['name'] => $item['content']]);
         } else {
             $count = 0;

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -44,6 +44,27 @@ class HelperTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $data);
     }
 
+    public function test_include_in_array_with_order_outside_of_array_length()
+    {
+        $data = [
+            'id'  => 1,
+            'foo' => 'bar',
+        ];
+        $item = [
+            'name'    => 'user',
+            'content' => 'John',
+            'order'   => 2,
+        ];
+
+        $data     = Helper::includeInArray($item, $data);
+        $expected = [
+            'id'   => 1,
+            'foo'  => 'bar',
+            'user' => 'John',
+        ];
+        $this->assertEquals($expected, $data);
+    }
+
     public function test_compile_content_blade()
     {
         $content = '{!! $id !!}';


### PR DESCRIPTION
Fix for Issue: yajra/laravel-datatables#385