### PR TITLE
Allow edit columns for nested arrays

### DIFF
--- a/src/Processors/DataProcessor.php
+++ b/src/Processors/DataProcessor.php
@@ -2,6 +2,7 @@
 
 namespace Yajra\Datatables\Processors;
 
+use Illuminate\Support\Arr;
 use Yajra\Datatables\Helper;
 
 /**
@@ -115,7 +116,7 @@ class DataProcessor
     {
         foreach ($this->editColumns as $key => $value) {
             $value['content']     = Helper::compileContent($value['content'], $data, $row);
-            $data[$value['name']] = $value['content'];
+            Arr::set($data, $value['name'], $value['content']);
         }
 
         return $data;


### PR DESCRIPTION
For example you have `User` and `Phone` models. `User` has one `Phone`.  `Phone` has `name` field
And you want to edit phone.name field. My pull request allow to do it:

```
$users = User::with('phone');
\Datatables::of($users)
  ->editColumn('phone.name', function($user) {
    return 'Name of phone is: ' . $user->phone->name;
  })
  ->make(true);
```