### PR TITLE
In the refactoring process, of the column search system, an error rel…

### DIFF
--- a/src/Engines/QueryBuilderEngine.php
+++ b/src/Engines/QueryBuilderEngine.php
@@ -278,10 +278,10 @@ class QueryBuilderEngine extends BaseEngine implements DataTableEngineContract
                 } else {
                     $column = $this->castColumn($column);
                     if ($this->isCaseInsensitive()) {
-                        $this->compileColumnSearch($i, $column, $keyword, true);
+                        $this->compileColumnSearch($i, $column, $keyword, false);
                     } else {
                         $col = strstr($column, '(') ? $this->connection->raw($column) : $column;
-                        $this->compileColumnSearch($i, $col, $keyword, false);
+                        $this->compileColumnSearch($i, $col, $keyword, true);
                     }
                 }
 


### PR DESCRIPTION
…ated to a case-sensitivity check led to a wrong interpretation and therefore to an incorrect behaviour of the logic.

If the isCaseInsensitive function is true, the compileColumnSearch function is called with the flag caseSensitive set to true, clearly wrong.
The same issue occurs if the isCaseInsensitive function is false.

Now the boolean flag caseSensitive is set correctly for both if-else blocks.