### PR TITLE
[Proposal] Whitelist & Blacklist Feature

### DIFF
--- a/src/Engines/BaseEngine.php
+++ b/src/Engines/BaseEngine.php
@@ -70,6 +70,7 @@ abstract class BaseEngine implements DataTableEngineContract
         'order'     => [],
         'escape'    => [],
         'blacklist' => ['password', 'remember_token'],
+        'whitelist' => '*',
     ];
 
     /**
@@ -755,6 +756,38 @@ abstract class BaseEngine implements DataTableEngineContract
         $this->columnDef['blacklist'] = $blacklist;
 
         return $this;
+    }
+
+    /**
+     * Update list of columns that is not allowed for search/sort.
+     *
+     * @param  string|array $whitelist
+     * @return $this
+     */
+    public function whitelist($whitelist = '*')
+    {
+        $this->columnDef['whitelist'] = $whitelist;
+
+        return $this;
+    }
+
+    /**
+     * Check if column is blacklisted.
+     *
+     * @param string $column
+     * @return bool
+     */
+    protected function isBlacklisted($column)
+    {
+        if (in_array($column, $this->columnDef['blacklist'])) {
+            return true;
+        }
+
+        if ($this->columnDef['whitelist'] === '*' || in_array($column, $this->columnDef['whitelist'])) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/Engines/BaseEngine.php
+++ b/src/Engines/BaseEngine.php
@@ -63,12 +63,13 @@ abstract class BaseEngine implements DataTableEngineContract
      * @var array
      */
     protected $columnDef = [
-        'append' => [],
-        'edit'   => [],
-        'excess' => ['rn', 'row_num'],
-        'filter' => [],
-        'order'  => [],
-        'escape' => [],
+        'append'    => [],
+        'edit'      => [],
+        'excess'    => ['rn', 'row_num'],
+        'filter'    => [],
+        'order'     => [],
+        'escape'    => [],
+        'blacklist' => ['password', 'remember_token'],
     ];
 
     /**
@@ -739,6 +740,19 @@ abstract class BaseEngine implements DataTableEngineContract
     public function order(\Closure $closure)
     {
         $this->orderCallback = $closure;
+
+        return $this;
+    }
+
+    /**
+     * Update list of columns that is not allowed for search/sort.
+     *
+     * @param  array $blacklist
+     * @return $this
+     */
+    public function blacklist(array $blacklist)
+    {
+        $this->columnDef['blacklist'] = $blacklist;
 
         return $this;
     }

--- a/src/Engines/QueryBuilderEngine.php
+++ b/src/Engines/QueryBuilderEngine.php
@@ -106,6 +106,10 @@ class QueryBuilderEngine extends BaseEngine
                 foreach ($this->request->searchableColumnIndex() as $index) {
                     $columnName = $this->getColumnName($index);
 
+                    if (in_array($columnName, $this->columnDef['blacklist'])) {
+                        continue;
+                    }
+
                     if (isset($this->columnDef['filter'][$columnName])) {
                         $method     = Helper::getOrMethod($this->columnDef['filter'][$columnName]['method']);
                         $parameters = $this->columnDef['filter'][$columnName]['parameters'];
@@ -366,6 +370,11 @@ class QueryBuilderEngine extends BaseEngine
 
         foreach ($this->request->orderableColumns() as $orderable) {
             $column = $this->getColumnName($orderable['column'], true);
+
+            if (in_array($column, $this->columnDef['blacklist'])) {
+                continue;
+            }
+
             if (isset($this->columnDef['order'][$column])) {
                 $method     = $this->columnDef['order'][$column]['method'];
                 $parameters = $this->columnDef['order'][$column]['parameters'];

--- a/src/Engines/QueryBuilderEngine.php
+++ b/src/Engines/QueryBuilderEngine.php
@@ -104,26 +104,26 @@ class QueryBuilderEngine extends BaseEngine
             function ($query) {
                 $keyword = $this->setupKeyword($this->request->keyword());
                 foreach ($this->request->searchableColumnIndex() as $index) {
-                    $columnName = $this->getColumnName($index);
+                    $column = $this->getColumnName($index);
 
-                    if (in_array($columnName, $this->columnDef['blacklist'])) {
+                    if ($this->isBlacklisted($column)) {
                         continue;
                     }
 
-                    if (isset($this->columnDef['filter'][$columnName])) {
-                        $method     = Helper::getOrMethod($this->columnDef['filter'][$columnName]['method']);
-                        $parameters = $this->columnDef['filter'][$columnName]['parameters'];
+                    if (isset($this->columnDef['filter'][$column])) {
+                        $method     = Helper::getOrMethod($this->columnDef['filter'][$column]['method']);
+                        $parameters = $this->columnDef['filter'][$column]['parameters'];
                         $this->compileColumnQuery(
                             $this->getQueryBuilder($query),
                             $method,
                             $parameters,
-                            $columnName,
+                            $column,
                             $keyword
                         );
                     } else {
-                        if (count(explode('.', $columnName)) > 1) {
+                        if (count(explode('.', $column)) > 1) {
                             $eagerLoads     = $this->getEagerLoads();
-                            $parts          = explode('.', $columnName);
+                            $parts          = explode('.', $column);
                             $relationColumn = array_pop($parts);
                             $relation       = implode('.', $parts);
                             if (in_array($relation, $eagerLoads)) {
@@ -134,10 +134,10 @@ class QueryBuilderEngine extends BaseEngine
                                     $keyword
                                 );
                             } else {
-                                $this->compileGlobalSearch($this->getQueryBuilder($query), $columnName, $keyword);
+                                $this->compileGlobalSearch($this->getQueryBuilder($query), $column, $keyword);
                             }
                         } else {
-                            $this->compileGlobalSearch($this->getQueryBuilder($query), $columnName, $keyword);
+                            $this->compileGlobalSearch($this->getQueryBuilder($query), $column, $keyword);
                         }
                     }
 
@@ -371,7 +371,7 @@ class QueryBuilderEngine extends BaseEngine
         foreach ($this->request->orderableColumns() as $orderable) {
             $column = $this->getColumnName($orderable['column'], true);
 
-            if (in_array($column, $this->columnDef['blacklist'])) {
+            if ($this->isBlacklisted($column)) {
                 continue;
             }
 

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -238,7 +238,7 @@ class Helper
             if ($value instanceof DateTime) {
                 $row[$key] = $value->format('Y-m-d H:i:s');
             } else {
-                if (is_string($value)) {
+                if (is_object($value)) {
                     $row[$key] = (string) $value;
                 } else {
                     $row[$key] = $value;


### PR DESCRIPTION
This PR will add `blacklist` and `whitelist` feature that addresses concerns where user can search en sort on fields that are not specified in the query like issue #260.

### USAGE
```php
$users = User::query();

return Datatables::of($users)
    ->whitelist('*')
    ->blacklist(['password', 'email'])
    ->make(true);
```

In case both functions are used at the same time, blacklist will be prioritized.