### PR TITLE
Added Closure support for filterColumn method

### DIFF
--- a/src/Engines/BaseEngine.php
+++ b/src/Engines/BaseEngine.php
@@ -472,7 +472,7 @@ abstract class BaseEngine implements DataTableEngineContract
      * Override default column filter search.
      *
      * @param string $column
-     * @param string $method
+     * @param string|Closure $method
      * @return $this
      * @internal param $mixed ...,... All the individual parameters required for specified $method
      * @internal string $1 Special variable that returns the requested search keyword.


### PR DESCRIPTION
Hello,

with the following PR I have added a closure support for filterColumn method as a more advanced and flexible way of customising things.

Instead of writing like this:
```php
->filterColumn('id', 'whereRaw', 'interface_strings.interface_string_id = ?', [$request->get('columns')[0]['search']['value']])
```
we can now use like this ($keyword supplied to a closure is without wildcards - especially handy when we want to do an exact match):
```php
->filterColumn('id', function($query, $keyword) {
    $query->where('interface_strings.interface_string_id', $keyword);
})
```

Exact match issues specified in #217, #191 should be covered by this PR.

Looking forward!