### PR TITLE
Add blacklist and whitelist feature.

### DIFF
--- a/src/Engines/BaseEngine.php
+++ b/src/Engines/BaseEngine.php
@@ -63,12 +63,14 @@ abstract class BaseEngine implements DataTableEngineContract
      * @var array
      */
     protected $columnDef = [
-        'append' => [],
-        'edit'   => [],
-        'excess' => ['rn', 'row_num'],
-        'filter' => [],
-        'order'  => [],
-        'escape' => [],
+        'append'    => [],
+        'edit'      => [],
+        'excess'    => ['rn', 'row_num'],
+        'filter'    => [],
+        'order'     => [],
+        'escape'    => [],
+        'blacklist' => ['password', 'remember_token'],
+        'whitelist' => '*',
     ];
 
     /**
@@ -741,6 +743,51 @@ abstract class BaseEngine implements DataTableEngineContract
         $this->orderCallback = $closure;
 
         return $this;
+    }
+
+    /**
+     * Update list of columns that is not allowed for search/sort.
+     *
+     * @param  array $blacklist
+     * @return $this
+     */
+    public function blacklist(array $blacklist)
+    {
+        $this->columnDef['blacklist'] = $blacklist;
+
+        return $this;
+    }
+
+    /**
+     * Update list of columns that is not allowed for search/sort.
+     *
+     * @param  string|array $whitelist
+     * @return $this
+     */
+    public function whitelist($whitelist = '*')
+    {
+        $this->columnDef['whitelist'] = $whitelist;
+
+        return $this;
+    }
+
+    /**
+     * Check if column is blacklisted.
+     *
+     * @param string $column
+     * @return bool
+     */
+    protected function isBlacklisted($column)
+    {
+        if (in_array($column, $this->columnDef['blacklist'])) {
+            return true;
+        }
+
+        if ($this->columnDef['whitelist'] === '*' || in_array($column, $this->columnDef['whitelist'])) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/Engines/QueryBuilderEngine.php
+++ b/src/Engines/QueryBuilderEngine.php
@@ -107,6 +107,10 @@ class QueryBuilderEngine extends BaseEngine
 
                 foreach ($this->request->searchableColumnIndex() as $index) {
                     $columnName = $this->getColumnName($index);
+                    if ($this->isBlacklisted($columnName)) {
+                        continue;
+                    }
+
                     // check if custom column filtering is applied
                     if (isset($this->columnDef['filter'][$columnName])) {
                         $columnDef = $this->columnDef['filter'][$columnName];
@@ -399,6 +403,11 @@ class QueryBuilderEngine extends BaseEngine
 
         foreach ($this->request->orderableColumns() as $orderable) {
             $column = $this->getColumnName($orderable['column'], true);
+
+            if ($this->isBlacklisted($column)) {
+                continue;
+            }
+
             if (isset($this->columnDef['order'][$column])) {
                 $method     = $this->columnDef['order'][$column]['method'];
                 $parameters = $this->columnDef['order'][$column]['parameters'];


### PR DESCRIPTION
This PR will add `blacklist` and `whitelist` feature that addresses concerns where user can search en sort on fields that are not specified in the query like issue #260.

### USAGE
```php
$users = User::query();

return Datatables::of($users)
    ->whitelist('*')
    ->blacklist(['password', 'email'])
    ->make(true);
```

In case both functions are used at the same time, blacklist will be prioritized.