### PR TITLE
[Proposal] Add smart search config option. Fix #423

### DIFF
--- a/src/Engines/BaseEngine.php
+++ b/src/Engines/BaseEngine.php
@@ -189,14 +189,28 @@ abstract class BaseEngine implements DataTableEngineContract
      */
     public function setupKeyword($value)
     {
-        $keyword = '%' . $value . '%';
-        if ($this->isWildcard()) {
-            $keyword = $this->wildcardLikeString($value);
-        }
-        // remove escaping slash added on js script request
-        $keyword = str_replace('\\', '%', $keyword);
+        if ($this->isSmartSearch()) {
+            $keyword = '%' . $value . '%';
+            if ($this->isWildcard()) {
+                $keyword = $this->wildcardLikeString($value);
+            }
+            // remove escaping slash added on js script request
+            $keyword = str_replace('\\', '%', $keyword);
 
-        return $keyword;
+            return $keyword;
+        }
+
+        return $value;
+    }
+
+    /**
+     * Check if DataTables uses smart search.
+     *
+     * @return bool
+     */
+    protected function isSmartSearch()
+    {
+        return Config::get('datatables.search.smart', true);
     }
 
     /**
@@ -765,6 +779,19 @@ abstract class BaseEngine implements DataTableEngineContract
     public function whitelist($whitelist = '*')
     {
         $this->columnDef['whitelist'] = $whitelist;
+
+        return $this;
+    }
+
+    /**
+     * Set smart search config at runtime.
+     *
+     * @param bool $bool
+     * @return $this
+     */
+    public function smart($bool = true)
+    {
+        Config::set('datatables.search.smart', $bool);
 
         return $this;
     }

--- a/src/Engines/QueryBuilderEngine.php
+++ b/src/Engines/QueryBuilderEngine.php
@@ -266,7 +266,7 @@ class QueryBuilderEngine extends BaseEngine
 
             $query->orWhereRaw($sql, [$keyword]);
         } else { // exact match
-            $query->orWhereRaw("$column like ?", $keyword);
+            $query->orWhereRaw("$column like ?", [$keyword]);
         }
     }
 
@@ -371,7 +371,7 @@ class QueryBuilderEngine extends BaseEngine
             $keyword = $caseSensitive ? $keyword : Str::lower($keyword);
             $this->query->whereRaw($sql, [$keyword]);
         } else { // exact match
-            $this->query->whereRaw("$column LIKE ?", $keyword);
+            $this->query->whereRaw("$column LIKE ?", [$keyword]);
         }
     }
 

--- a/src/Engines/QueryBuilderEngine.php
+++ b/src/Engines/QueryBuilderEngine.php
@@ -265,8 +265,8 @@ class QueryBuilderEngine extends BaseEngine
             }
 
             $query->orWhereRaw($sql, [$keyword]);
-        } else {
-            $query->orWhere($column, 'like', $keyword);
+        } else { // exact match
+            $query->orWhereRaw("$column like ?", $keyword);
         }
     }
 
@@ -370,8 +370,8 @@ class QueryBuilderEngine extends BaseEngine
             $sql     = $caseSensitive ? $column . ' LIKE ?' : 'LOWER(' . $column . ') LIKE ?';
             $keyword = $caseSensitive ? $keyword : Str::lower($keyword);
             $this->query->whereRaw($sql, [$keyword]);
-        } else {
-            $this->query->where($column, 'like', $keyword);
+        } else { // exact match
+            $this->query->whereRaw("$column LIKE ?", $keyword);
         }
     }
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -2,6 +2,7 @@
 
 return [
     'search' => [
+        'smart'            => true,
         'case_insensitive' => true,
         'use_wildcards'    => false,
     ],


### PR DESCRIPTION
This PR will add DataTables option to disable smart search via config or during runtime. Addresses issue #423.

## Via Runtime:
```php
        $users = User::select(['id', 'name', 'email', 'created_at', 'updated_at']);

        return Datatables::of($users)->smart(false)->make(true);
```

## Via Config file:
```php
    'search' => [
        'smart'            => true,
        'case_insensitive' => true,
        'use_wildcards'    => false,
    ],
```