### PR TITLE
Add option to create a table footer from builder defined via column def

### DIFF
--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -182,6 +182,7 @@ class Builder
         foreach ($parameters['columns'] as $i => $column) {
             unset($parameters['columns'][$i]['exportable']);
             unset($parameters['columns'][$i]['printable']);
+            unset($parameters['columns'][$i]['footer']);
 
             if (isset($column['render'])) {
                 $columnFunctions[$i]                 = $column['render'];
@@ -396,6 +397,7 @@ class Builder
             'searchable'     => false,
             'exportable'     => false,
             'printable'      => true,
+            'footer'         => '&nbsp;',
         ], $attributes);
         $this->collection->push(new Column($attributes));
 
@@ -419,13 +421,25 @@ class Builder
      * Generate DataTable's table html.
      *
      * @param  array $attributes
+     * @param bool $footer
      * @return string
      */
-    public function table(array $attributes = [])
+    public function table(array $attributes = [], $footer = false)
     {
         $this->tableAttributes = array_merge($this->tableAttributes, $attributes);
 
-        return '<table ' . $this->html->attributes($this->tableAttributes) . '></table>';
+        $footerHtml = '';
+        if ($footer) {
+            $footerHtml = '<tfoot>';
+            $footerHtml .= '<tr>';
+            foreach ($this->collection->all() as $column) {
+                $footerHtml .= '<td>' . $column->footer . '</td>';
+            }
+            $footerHtml .= '</tr>';
+            $footerHtml .= '</tfoot>';
+        }
+
+        return '<table ' . $this->html->attributes($this->tableAttributes) . '>' . $footerHtml . '</table>';
     }
 
     /**

--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -469,7 +469,7 @@ class Builder
     {
         $footer = [];
         foreach ($this->collection->toArray() as $row) {
-            $footer[] = '<td>' . $row['footer'] . '</td>';
+            $footer[] = '<th>' . $row['footer'] . '</th>';
         }
 
         return $footer;

--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -397,7 +397,7 @@ class Builder
             'searchable'     => false,
             'exportable'     => false,
             'printable'      => true,
-            'footer'         => '&nbsp;',
+            'footer'         => '',
         ], $attributes);
         $this->collection->push(new Column($attributes));
 

--- a/src/Html/Column.php
+++ b/src/Html/Column.php
@@ -22,6 +22,7 @@ class Column extends Fluent
         $attributes['searchable'] = isset($attributes['searchable']) ? $attributes['searchable'] : true;
         $attributes['exportable'] = isset($attributes['exportable']) ? $attributes['exportable'] : true;
         $attributes['printable']  = isset($attributes['printable']) ? $attributes['printable'] : true;
+        $attributes['footer']     = isset($attributes['footer']) ? $attributes['footer'] : '';
 
         // Allow methods override attribute value
         foreach ($attributes as $attribute => $value) {

--- a/src/Html/Column.php
+++ b/src/Html/Column.php
@@ -22,7 +22,7 @@ class Column extends Fluent
         $attributes['searchable'] = isset($attributes['searchable']) ? $attributes['searchable'] : true;
         $attributes['exportable'] = isset($attributes['exportable']) ? $attributes['exportable'] : true;
         $attributes['printable']  = isset($attributes['printable']) ? $attributes['printable'] : true;
-        $attributes['footer']     = isset($attributes['footer']) ? $attributes['footer'] : '&nbsp;';
+        $attributes['footer']     = isset($attributes['footer']) ? $attributes['footer'] : '';
 
         // Allow methods override attribute value
         foreach ($attributes as $attribute => $value) {

--- a/src/Html/Column.php
+++ b/src/Html/Column.php
@@ -22,7 +22,7 @@ class Column extends Fluent
         $attributes['searchable'] = isset($attributes['searchable']) ? $attributes['searchable'] : true;
         $attributes['exportable'] = isset($attributes['exportable']) ? $attributes['exportable'] : true;
         $attributes['printable']  = isset($attributes['printable']) ? $attributes['printable'] : true;
-        $attributes['footer']     = isset($attributes['footer']) ? $attributes['footer'] : '';
+        $attributes['footer']     = isset($attributes['footer']) ? $attributes['footer'] : '&nbsp;';
 
         // Allow methods override attribute value
         foreach ($attributes as $attribute => $value) {

--- a/tests/HtmlBuilderTest.php
+++ b/tests/HtmlBuilderTest.php
@@ -42,6 +42,71 @@ class HtmlBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $builder->generateScripts());
     }
 
+    public function test_generate_table_html_with_empty_footer()
+    {
+        $builder = app(Builder::class);
+        $builder->html->shouldReceive('attributes')->times(8)->andReturn('id="foo"');
+        $builder->form->shouldReceive('checkbox')
+                      ->once()
+                      ->andReturn('<input type="checkbox "id"="dataTablesCheckbox"/>');
+
+        $builder->addCheckbox(['id' => 'foo'])
+                ->columns(['foo', 'bar' => ['data' => 'foo']])
+                ->addColumn(['name' => 'id', 'data' => 'id', 'title' => 'Id'])
+                ->add(new Column(['name' => 'a', 'data' => 'a', 'title' => 'A']))
+                ->addAction(['title' => 'Options'])
+                ->ajax('ajax-url')
+                ->parameters(['bFilter' => false]);
+        $table = $builder->table(['id' => 'foo'], true);
+        $expected = '<table id="foo"><thead><tr><th id="foo"><input type="checkbox "id"="dataTablesCheckbox"/></th><th id="foo">Foo</th><th id="foo">Bar</th><th id="foo">Id</th><th id="foo">A</th><th id="foo">Options</th></tr></thead><tfoot><tr><th></th><th></th><th></th><th></th><th></th><th></th></tr></tfoot></table>';
+        $this->assertEquals($expected, $table);
+
+        $builder->view->shouldReceive('make')->times(2)->andReturn($builder->view);
+        $builder->config->shouldReceive('get')->times(2)->andReturn('datatables::script');
+        $template = file_get_contents(__DIR__ . '/../src/resources/views/script.blade.php');
+        $builder->view->shouldReceive('render')->times(2)->andReturn(trim($template));
+        $builder->html->shouldReceive('attributes')->once()->andReturn();
+
+        $script   = $builder->scripts();
+        $expected = '<script>(function(window,$){window.LaravelDataTables=window.LaravelDataTables||{};window.LaravelDataTables["foo"]=$("#foo").DataTable({"serverSide":true,"processing":true,"ajax":"ajax-url","columns":[{"defaultContent":"<input type=\"checkbox\" id=\"foo\"\/>","title":"<input type=\"checkbox \"id\"=\"dataTablesCheckbox\"\/>","data":"checkbox","name":"checkbox","orderable":false,"searchable":false,"width":"10px","id":"foo"},{"name":"foo","data":"foo","title":"Foo","orderable":true,"searchable":true},{"name":"bar","data":"foo","title":"Bar","orderable":true,"searchable":true},{"name":"id","data":"id","title":"Id","orderable":true,"searchable":true},{"name":"a","data":"a","title":"A","orderable":true,"searchable":true},{"defaultContent":"","data":"action","name":"action","title":"Options","render":null,"orderable":false,"searchable":false}],"bFilter":false});})(window,jQuery);</script>' . PHP_EOL;
+        $this->assertEquals($expected, $script);
+
+        $expected = '(function(window,$){window.LaravelDataTables=window.LaravelDataTables||{};window.LaravelDataTables["foo"]=$("#foo").DataTable({"serverSide":true,"processing":true,"ajax":"ajax-url","columns":[{"defaultContent":"<input type=\"checkbox\" id=\"foo\"\/>","title":"<input type=\"checkbox \"id\"=\"dataTablesCheckbox\"\/>","data":"checkbox","name":"checkbox","orderable":false,"searchable":false,"width":"10px","id":"foo"},{"name":"foo","data":"foo","title":"Foo","orderable":true,"searchable":true},{"name":"bar","data":"foo","title":"Bar","orderable":true,"searchable":true},{"name":"id","data":"id","title":"Id","orderable":true,"searchable":true},{"name":"a","data":"a","title":"A","orderable":true,"searchable":true},{"defaultContent":"","data":"action","name":"action","title":"Options","render":null,"orderable":false,"searchable":false}],"bFilter":false});})(window,jQuery);';
+        $this->assertEquals($expected, $builder->generateScripts());
+    }
+    public function test_generate_table_html_with_footer_content()
+    {
+        $builder = app(Builder::class);
+        $builder->html->shouldReceive('attributes')->times(8)->andReturn('id="foo"');
+        $builder->form->shouldReceive('checkbox')
+                      ->once()
+                      ->andReturn('<input type="checkbox "id"="dataTablesCheckbox"/>');
+
+        $builder->addCheckbox(['id' => 'foo', 'footer' => 'test'])
+                ->columns(['foo', 'bar' => ['data' => 'foo']])
+                ->addColumn(['name' => 'id', 'data' => 'id', 'title' => 'Id'])
+                ->add(new Column(['name' => 'a', 'data' => 'a', 'title' => 'A']))
+                ->addAction(['title' => 'Options'])
+                ->ajax('ajax-url')
+                ->parameters(['bFilter' => false]);
+        $table = $builder->table(['id' => 'foo'], true);
+        $expected = '<table id="foo"><thead><tr><th id="foo"><input type="checkbox "id"="dataTablesCheckbox"/></th><th id="foo">Foo</th><th id="foo">Bar</th><th id="foo">Id</th><th id="foo">A</th><th id="foo">Options</th></tr></thead><tfoot><tr><th>test</th><th></th><th></th><th></th><th></th><th></th></tr></tfoot></table>';
+        $this->assertEquals($expected, $table);
+
+        $builder->view->shouldReceive('make')->times(2)->andReturn($builder->view);
+        $builder->config->shouldReceive('get')->times(2)->andReturn('datatables::script');
+        $template = file_get_contents(__DIR__ . '/../src/resources/views/script.blade.php');
+        $builder->view->shouldReceive('render')->times(2)->andReturn(trim($template));
+        $builder->html->shouldReceive('attributes')->once()->andReturn();
+
+        $script   = $builder->scripts();
+        $expected = '<script>(function(window,$){window.LaravelDataTables=window.LaravelDataTables||{};window.LaravelDataTables["foo"]=$("#foo").DataTable({"serverSide":true,"processing":true,"ajax":"ajax-url","columns":[{"defaultContent":"<input type=\"checkbox\" id=\"foo\"\/>","title":"<input type=\"checkbox \"id\"=\"dataTablesCheckbox\"\/>","data":"checkbox","name":"checkbox","orderable":false,"searchable":false,"width":"10px","id":"foo"},{"name":"foo","data":"foo","title":"Foo","orderable":true,"searchable":true},{"name":"bar","data":"foo","title":"Bar","orderable":true,"searchable":true},{"name":"id","data":"id","title":"Id","orderable":true,"searchable":true},{"name":"a","data":"a","title":"A","orderable":true,"searchable":true},{"defaultContent":"","data":"action","name":"action","title":"Options","render":null,"orderable":false,"searchable":false}],"bFilter":false});})(window,jQuery);</script>' . PHP_EOL;
+        $this->assertEquals($expected, $script);
+
+        $expected = '(function(window,$){window.LaravelDataTables=window.LaravelDataTables||{};window.LaravelDataTables["foo"]=$("#foo").DataTable({"serverSide":true,"processing":true,"ajax":"ajax-url","columns":[{"defaultContent":"<input type=\"checkbox\" id=\"foo\"\/>","title":"<input type=\"checkbox \"id\"=\"dataTablesCheckbox\"\/>","data":"checkbox","name":"checkbox","orderable":false,"searchable":false,"width":"10px","id":"foo"},{"name":"foo","data":"foo","title":"Foo","orderable":true,"searchable":true},{"name":"bar","data":"foo","title":"Bar","orderable":true,"searchable":true},{"name":"id","data":"id","title":"Id","orderable":true,"searchable":true},{"name":"a","data":"a","title":"A","orderable":true,"searchable":true},{"defaultContent":"","data":"action","name":"action","title":"Options","render":null,"orderable":false,"searchable":false}],"bFilter":false});})(window,jQuery);';
+        $this->assertEquals($expected, $builder->generateScripts());
+    }
+
     /**
      * @return \Yajra\Datatables\Datatables
      */

--- a/tests/HtmlBuilderTest.php
+++ b/tests/HtmlBuilderTest.php
@@ -74,6 +74,7 @@ class HtmlBuilderTest extends PHPUnit_Framework_TestCase
         $expected = '(function(window,$){window.LaravelDataTables=window.LaravelDataTables||{};window.LaravelDataTables["foo"]=$("#foo").DataTable({"serverSide":true,"processing":true,"ajax":"ajax-url","columns":[{"defaultContent":"<input type=\"checkbox\" id=\"foo\"\/>","title":"<input type=\"checkbox \"id\"=\"dataTablesCheckbox\"\/>","data":"checkbox","name":"checkbox","orderable":false,"searchable":false,"width":"10px","id":"foo"},{"name":"foo","data":"foo","title":"Foo","orderable":true,"searchable":true},{"name":"bar","data":"foo","title":"Bar","orderable":true,"searchable":true},{"name":"id","data":"id","title":"Id","orderable":true,"searchable":true},{"name":"a","data":"a","title":"A","orderable":true,"searchable":true},{"defaultContent":"","data":"action","name":"action","title":"Options","render":null,"orderable":false,"searchable":false}],"bFilter":false});})(window,jQuery);';
         $this->assertEquals($expected, $builder->generateScripts());
     }
+
     public function test_generate_table_html_with_footer_content()
     {
         $builder = app(Builder::class);


### PR DESCRIPTION
This PR will add an option to add a table footer via Builder. Footer contents will be defined via column definition.

## Usage
```php
$builder->columns([
    'id' => ['footer' => 'footer content']
]);

$dataTable->table([], true); // passing true as second parameter will draw the footer.
```