### PR TITLE
use orHavingRaw vs orWhereRaw

### DIFF
--- a/src/yajra/Datatables/Datatables.php
+++ b/src/yajra/Datatables/Datatables.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
 use Illuminate\View\Compilers\BladeCompiler;
+use DB;
 
 class Datatables
 {
@@ -424,12 +425,12 @@ class Datatables
                         $this->query->orHavingRaw(
                             'LOWER(' . $cast_begin . $column . $cast_end . ') LIKE ?',
                             [strtolower($keyword)]
-                        );
+                        )->groupBy(DB::raw($column));
                     } else {
                         $this->query->orHavingRaw(
                             $cast_begin . $column . $cast_end . ' LIKE ?',
                             [$keyword]
-                        );
+                        )->groupBy(DB::raw($column));
                     }
                 }
             }

--- a/src/yajra/Datatables/Datatables.php
+++ b/src/yajra/Datatables/Datatables.php
@@ -421,11 +421,15 @@ class Datatables
                     // wrap column possibly allow reserved words to be used as column
                     $column = $this->wrapColumn($column);
                     if ($this->isCaseInsensitive()) {
-                        $this->query->orHavingRaw('LOWER(' . $cast_begin . $column . $cast_end . ') LIKE ?',
-                            [strtolower($keyword)]);
+                        $this->query->orHavingRaw(
+                            'LOWER(' . $cast_begin . $column . $cast_end . ') LIKE ?',
+                            [strtolower($keyword)]
+                        );
                     } else {
-                        $having_query[] = $this->query->orHavingRaw($cast_begin . $column . $cast_end . ' LIKE ?',
-                            [$keyword]);
+                        $this->query->orHavingRaw(
+                            $cast_begin . $column . $cast_end . ' LIKE ?',
+                            [$keyword]
+                        );
                     }
                 }
             }

--- a/src/yajra/Datatables/Datatables.php
+++ b/src/yajra/Datatables/Datatables.php
@@ -422,15 +422,17 @@ class Datatables
                     // wrap column possibly allow reserved words to be used as column
                     $column = $this->wrapColumn($column);
                     if ($this->isCaseInsensitive()) {
-                        $this->query->orHavingRaw(
-                            'LOWER(' . $cast_begin . $column . $cast_end . ') LIKE ?',
-                            [strtolower($keyword)]
-                        )->groupBy(DB::raw($column));
+                        $this->query->groupBy(DB::raw($column))
+                            ->orHavingRaw(
+                                'LOWER(' . $cast_begin . $column . $cast_end . ') LIKE ?',
+                                [strtolower($keyword)]
+                            );
                     } else {
-                        $this->query->orHavingRaw(
-                            $cast_begin . $column . $cast_end . ' LIKE ?',
-                            [$keyword]
-                        )->groupBy(DB::raw($column));
+                        $this->query->groupBy(DB::raw($column))
+                            ->orHavingRaw(
+                                $cast_begin . $column . $cast_end . ' LIKE ?',
+                                [$keyword]
+                            );
                     }
                 }
             }


### PR DESCRIPTION
In the internal datatables search/filter: ``orWhereRaw`` wasn't able to find the 'select as' alias for ``$column``. ``orHavingRaw`` appears to have access to the alias.

The code is the same except ``where`` was removed and ``orWhereRaw`` replaced with ``orHavingRaw``