### PR TITLE
Update CollectionEngine.php to make dropdown-filter work.

### DIFF
--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -187,7 +187,12 @@ class CollectionEngine extends BaseEngine
                         $value = Arr::get($data, $column);
 
                         if ($this->isCaseInsensitive()) {
-                            return strpos(Str::lower($value), Str::lower($keyword)) !== false;
+                            // If ^ and $ present at the beginnning and end of the keyword then do the full match instead of partial match for dorpdown filter
+							if(!empty($keyword) && strlen($keyword) >= 3 && substr($keyword, 0, 1) == '^' && substr($keyword, strlen($keyword)-1, 1) == '$' ) {
+								return (Str::lower($value) == Str::lower(substr($keyword, 1, strlen($keyword)-2)));
+							} else {
+                            	return strpos(Str::lower($value), Str::lower($keyword)) !== false;
+							}
                         } else {
                             return strpos($value, $keyword) !== false;
                         }


### PR DESCRIPTION
<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->

Hello Arjay,

Thanks for developing such as a nice plugin. 

I was having an issue when using datatables  with column filters (for dropdown column filter), it was not returning empty record collection.

**\* If ^ and $ present at the beginnning and end of the keyword then do the full match instead of partial match for dorpdown filter. ***

Please check approve the pull request if you think it would improvise the plugin...

Thanks & Regards
Amitav
