### PR TITLE
Add support for laravel-snappy when exporting to PDF.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,9 @@
         "mockery/mockery": "~0.9",
         "phpunit/phpunit": "~4.0"
     },
+    "suggest": {
+      "barryvdh/laravel-snappy": "Allows exporting dataTable to PDF using the print view."
+    },
     "autoload": {
         "psr-4": {
             "Yajra\\Datatables\\": "src/"

--- a/src/Services/SnappyDataTableTrait.php
+++ b/src/Services/SnappyDataTableTrait.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Yajra\Datatables\Services;
+
+/**
+ * Class SnappyDataTableTrait
+ *
+ * @package Yajra\Datatables\Services
+ * @author  Arjay Angeles <aqangeles@gmail.com>
+ */
+trait SnappyDataTableTrait
+{
+    /**
+     * PDF version of the table using print preview blade template.
+     *
+     * @return mixed
+     */
+    public function pdf()
+    {
+        $data   = $this->getDataForPrint();
+        $snappy = app('snappy.pdf.wrapper');
+        $snappy->setOptions([
+            'no-outline'    => true,
+            'margin-left'   => '0',
+            'margin-right'  => '0',
+            'margin-top'    => '10mm',
+            'margin-bottom' => '10mm',
+        ])->setOrientation('landscape');
+
+        return $snappy->loadView($this->printPreview, compact('data'))
+                      ->download($this->getFilename() . ".pdf");
+    }
+}


### PR DESCRIPTION
Add support for laravel-snappy when exporting to PDF. 

### How To Use:
- Install [laravel-snappy](https://github.com/barryvdh/laravel-snappy) via `composer require barryvdh/laravel-snappy`
- Register snappy provider: `Barryvdh\Snappy\ServiceProvider::class`.
- Install [wkhtmltopdf](wkhtmltopdf.org/downloads.html). (Requirements of laravel-snappy)
- `use SnappyDataTableTrait` on your DataTable class.
- Done...

Exporting of PDF will now use `laravel-snappy` instead of `laravel-excel` pdf export function which seems to fail most of the time especially when the data is large. Exporting via snappy will be the same as how you print the DataTable.