### PR TITLE
HasOne relation uses different methods to get foreign and other key

### DIFF
--- a/src/Engines/QueryBuilderEngine.php
+++ b/src/Engines/QueryBuilderEngine.php
@@ -4,6 +4,7 @@ namespace Yajra\Datatables\Engines;
 
 use Closure;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Str;
 use Yajra\Datatables\Helper;
@@ -486,9 +487,15 @@ class QueryBuilderEngine extends BaseEngine
                 $this->getQueryBuilder()->leftJoin($table, $pivot . '.' . $tablePK, '=', $tableFK);
             }
         } else {
-            $table   = $model->getRelated()->getTable();
-            $foreign = $model->getQualifiedForeignKey();
-            $other   = $model->getQualifiedOtherKeyName();
+            $table = $model->getRelated()->getTable();
+            if($model instanceof HasOne) {
+                $foreign = $model->getForeignKey();
+                $other = $model->getQualifiedParentKeyName();
+            } else {
+                $foreign = $model->getQualifiedForeignKey();
+                $other   = $model->getQualifiedOtherKeyName();
+            }
+
             if (! in_array($table, $joins)) {
                 $this->getQueryBuilder()->leftJoin($table, $foreign, '=', $other);
             }


### PR DESCRIPTION

This should fix any issues one might have when using a HasOne relation.
The API to get a foreign and other key are different then other relation types.

I believe it should also fix issue #567 
