### PR TITLE
Add model option to dataTable command.

### DIFF
--- a/src/Generators/DataTablesMakeCommand.php
+++ b/src/Generators/DataTablesMakeCommand.php
@@ -3,6 +3,8 @@
 namespace Yajra\Datatables\Generators;
 
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Class DataTablesMakeCommand.
@@ -24,7 +26,7 @@ class DataTablesMakeCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $description = 'Create a new DataTable Service class.';
+    protected $description = 'Create a new DataTable service class.';
 
     /**
      * The type of class being generated.
@@ -34,14 +36,31 @@ class DataTablesMakeCommand extends GeneratorCommand
     protected $type = 'DataTable';
 
     /**
-     * Get the default namespace for the class.
+     * The model class to be used by dataTable.
      *
-     * @param  string $rootNamespace
+     * @var string
+     */
+    protected $model;
+
+    /**
+     * DataTable export filename.
+     *
+     * @var string
+     */
+    protected $filename;
+
+    /**
+     * Build the class with the given name.
+     *
+     * @param  string $name
      * @return string
      */
-    protected function getDefaultNamespace($rootNamespace)
+    protected function buildClass($name)
     {
-        return $rootNamespace . '\DataTables';
+        $stub = $this->files->get($this->getStub());
+        $stub = $this->replaceNamespace($stub, $name)->replaceClass($stub, $name);
+
+        return $this->replaceModelImport($stub)->replaceModel($stub)->replaceFilename($stub);
     }
 
     /**
@@ -52,5 +71,138 @@ class DataTablesMakeCommand extends GeneratorCommand
     protected function getStub()
     {
         return __DIR__ . '/stubs/datatables.stub';
+    }
+
+    /**
+     * Replace model name.
+     *
+     * @param string $stub
+     * @return mixed
+     */
+    protected function replaceModel(&$stub)
+    {
+        $model = explode('\\', $this->model);
+        $model = array_pop($model);
+        $stub  = str_replace('ModelName', $model, $stub);
+
+        return $this;
+    }
+
+    /**
+     * Replace model import.
+     *
+     * @param string $stub
+     * @return $this
+     */
+    protected function replaceModelImport(&$stub)
+    {
+        $stub = str_replace(
+            'DummyModel', str_replace('\\\\', '\\', $this->model), $stub
+        );
+
+        return $this;
+    }
+
+    /**
+     * Replace the filename.
+     *
+     * @param string $stub
+     * @return string
+     */
+    protected function replaceFilename(&$stub)
+    {
+        $stub = str_replace(
+            'DummyFilename', $this->filename, $stub
+        );
+
+        return $stub;
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['model', null, InputOption::VALUE_NONE, 'Use the give name as the model.', null],
+        ];
+    }
+
+    /**
+     * Determine if the class already exists.
+     *
+     * @param  string $rawName
+     * @return bool
+     */
+    protected function alreadyExists($rawName)
+    {
+        $name = $this->parseName($rawName);
+
+        $this->setModel($rawName);
+        $this->setFilename($rawName);
+
+        return $this->files->exists($this->getPath($name));
+    }
+
+    /**
+     * Parse the name and format according to the root namespace.
+     *
+     * @param  string $name
+     * @return string
+     */
+    protected function parseName($name)
+    {
+        $rootNamespace = $this->laravel->getNamespace();
+
+        if (Str::startsWith($name, $rootNamespace)) {
+            return $name;
+        }
+
+        if (Str::contains($name, '/')) {
+            $name = str_replace('/', '\\', $name);
+        }
+
+        if (! Str::contains(Str::lower($name), 'datatable')) {
+            $name .= 'DataTable';
+        }
+
+        return $this->parseName($this->getDefaultNamespace(trim($rootNamespace, '\\')) . '\\' . $name);
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace . "\\" . $this->laravel['config']->get('datatables.namespace.base', 'DataTables');
+    }
+
+    /**
+     * Set the model to be used.
+     *
+     * @param string $name
+     */
+    protected function setModel($name)
+    {
+        $rootNamespace  = $this->laravel->getNamespace();
+        $modelNamespace = $this->laravel['config']->get('datatables.namespace.model');
+        $this->model    = $this->option('model')
+            ? $rootNamespace . "\\" . ($modelNamespace ? $modelNamespace . "\\" : "") . $name
+            : $rootNamespace . "\\User";
+    }
+
+    /**
+     * Set the filename for export.
+     *
+     * @param string $name
+     */
+    protected function setFilename($name)
+    {
+        $this->filename = Str::lower(Str::plural($name));
     }
 }

--- a/src/Generators/DataTablesMakeCommand.php
+++ b/src/Generators/DataTablesMakeCommand.php
@@ -126,7 +126,7 @@ class DataTablesMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['model', null, InputOption::VALUE_NONE, 'Use the give name as the model.', null],
+            ['model', null, InputOption::VALUE_NONE, 'Use the provided name as the model.', null],
         ];
     }
 

--- a/src/Generators/stubs/datatables.stub
+++ b/src/Generators/stubs/datatables.stub
@@ -21,7 +21,7 @@ class DummyClass extends DataTable
     }
 
     /**
-     * Get the query object to be processed by datatables.
+     * Get the query object to be processed by dataTables.
      *
      * @return \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder|\Illuminate\Support\Collection
      */

--- a/src/Generators/stubs/datatables.stub
+++ b/src/Generators/stubs/datatables.stub
@@ -2,13 +2,11 @@
 
 namespace DummyNamespace;
 
-use App\User;
+use DummyModel;
 use Yajra\Datatables\Services\DataTable;
 
 class DummyClass extends DataTable
 {
-    // protected $printPreview  = 'path.to.print.preview.view';
-
     /**
      * Display ajax response.
      *
@@ -29,7 +27,7 @@ class DummyClass extends DataTable
      */
     public function query()
     {
-        $users = User::query();
+        $users = ModelName::query();
 
         return $this->applyScopes($users);
     }
@@ -70,6 +68,6 @@ class DummyClass extends DataTable
      */
     protected function filename()
     {
-        return 'users';
+        return 'DummyFilename_' . time();
     }
 }

--- a/src/Generators/stubs/datatables.stub
+++ b/src/Generators/stubs/datatables.stub
@@ -27,9 +27,9 @@ class DummyClass extends DataTable
      */
     public function query()
     {
-        $users = ModelName::query();
+        $query = ModelName::query();
 
-        return $this->applyScopes($users);
+        return $this->applyScopes($query);
     }
 
     /**

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -4,7 +4,7 @@ return [
     /**
      * DataTables search options.
      */
-    'search' => [
+    'search'          => [
         /**
          * Smart search will enclose search keyword with wildcard string "%keyword%".
          * SQL: column LIKE "%keyword%"
@@ -27,7 +27,7 @@ return [
     /**
      * DataTables default fractal serializer.
      */
-    'fractal' => [
+    'fractal'         => [
         'serializer' => 'League\Fractal\Serializer\DataArraySerializer',
     ],
 
@@ -39,5 +39,32 @@ return [
     /**
      * DataTables internal index id response column name.
      */
-    'index_column' => 'DT_Row_Index',
+    'index_column'    => 'DT_Row_Index',
+
+    /**
+     * Namespaces used by the generator.
+     */
+    'namespace'       => [
+        /**
+         * Base namespace/directory to create the new file.
+         * This is appended on default Laravel namespace.
+         *
+         * Usage: php artisan datatables:make User
+         * Output: App\DataTables\UserDataTable
+         * With Model: App\User (default model)
+         * Export filename: users_timestamp
+         */
+        'base'  => 'DataTables',
+
+        /**
+         * Base namespace/directory where your model's are located.
+         * This is appended on default Laravel namespace.
+         *
+         * Usage: php artisan datatables:make Post --model
+         * Output: App\DataTables\PostDataTable
+         * With Model: App\Post
+         * Export filename: posts_timestamp
+         */
+        'model' => '',
+    ],
 ];


### PR DESCRIPTION
This PR will:
- Add model option to dataTable command.
- Make generator namespace configurable.
- Add filename in generator with timestamps.

Usage:
`php artisan datatables:make Post --model`

Output:
```php
<?php

namespace App\DataTables;

use App\Post;
use Yajra\Datatables\Services\DataTable;

class PostDataTable extends DataTable
{
    /**
     * Display ajax response.
     *
     * @return \Illuminate\Http\JsonResponse
     */
    public function ajax()
    {
        return $this->datatables
            ->eloquent($this->query())
            ->addColumn('action', 'path.to.action.view')
            ->make(true);
    }

    /**
     * Get the query object to be processed by dataTables.
     *
     * @return \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder|\Illuminate\Support\Collection
     */
    public function query()
    {
        $query = Post::query();

        return $this->applyScopes($query);
    }

    /**
     * Optional method if you want to use html builder.
     *
     * @return \Yajra\Datatables\Html\Builder
     */
    public function html()
    {
        return $this->builder()
                    ->columns($this->getColumns())
                    ->ajax('')
                    ->addAction(['width' => '80px'])
                    ->parameters($this->getBuilderParameters());
    }

    /**
     * Get columns.
     *
     * @return array
     */
    protected function getColumns()
    {
        return [
            'id',
            // add your columns
            'created_at',
            'updated_at',
        ];
    }

    /**
     * Get filename for export.
     *
     * @return string
     */
    protected function filename()
    {
        return 'posts_' . time();
    }
}
```