### PR TITLE
Add count parameter to make()

### DIFF
--- a/src/Contracts/DataTableEngineContract.php
+++ b/src/Contracts/DataTableEngineContract.php
@@ -73,7 +73,8 @@ interface DataTableEngineContract
      *
      * @param bool $mDataSupport
      * @param bool $orderFirst
+     * @param null|int $count
      * @return \Illuminate\Http\JsonResponse
      */
-    public function make($mDataSupport = false, $orderFirst = false);
+    public function make($mDataSupport = false, $orderFirst = false, $count = null);
 }

--- a/src/Engines/BaseEngine.php
+++ b/src/Engines/BaseEngine.php
@@ -559,11 +559,14 @@ abstract class BaseEngine implements DataTableEngineContract
      *
      * @param bool $mDataSupport
      * @param bool $orderFirst
+     * @param null|int $count
      * @return \Illuminate\Http\JsonResponse
      */
-    public function make($mDataSupport = false, $orderFirst = false)
+    public function make($mDataSupport = false, $orderFirst = false, $count = null)
     {
-        $this->totalRecords = $this->totalCount();
+        if (is_null($this->totalRecords = $count)) {
+            $this->totalRecords = $this->totalCount();
+        };
 
         if ($this->totalRecords) {
             $this->orderRecords(! $orderFirst);

--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -225,10 +225,11 @@ class CollectionEngine extends BaseEngine
      *
      * @param bool $mDataSupport
      * @param bool $orderFirst
+     * @param null|int $count
      * @return \Illuminate\Http\JsonResponse
      */
-    public function make($mDataSupport = false, $orderFirst = true)
+    public function make($mDataSupport = false, $orderFirst = true, $count = null)
     {
-        return parent::make($mDataSupport, $orderFirst);
+        return parent::make($mDataSupport, $orderFirst, $count);
     }
 }

--- a/src/Engines/QueryBuilderEngine.php
+++ b/src/Engines/QueryBuilderEngine.php
@@ -67,13 +67,14 @@ class QueryBuilderEngine extends BaseEngine
      *
      * @param bool $mDataSupport
      * @param bool $orderFirst
+     * @param null|int $count
      * @return \Illuminate\Http\JsonResponse
      */
-    public function make($mDataSupport = false, $orderFirst = false)
+    public function make($mDataSupport = false, $orderFirst = false, $count = null)
     {
-        return parent::make($mDataSupport, $orderFirst);
+        return parent::make($mDataSupport, $orderFirst, $count);
     }
-
+    
     /**
      * Count total items.
      *
@@ -109,7 +110,8 @@ class QueryBuilderEngine extends BaseEngine
      * @param string $column
      * @return string
      */
-    protected function wrap($column) {
+    protected function wrap($column)
+    {
         return $this->connection->getQueryGrammar()->wrap($column);
     }
 


### PR DESCRIPTION
Added a $count parameter as the third argument to make(). This will let you count the records yourself to make sure the count query is as minimal as possible, especially when you have complicated queries. As this is nullable, everything works as it previously did.