### PR TITLE
Export PDF enhancements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,9 @@
         "mockery/mockery": "~0.9",
         "phpunit/phpunit": "~4.0"
     },
+    "suggest": {
+        "barryvdh/laravel-snappy": "Allows exporting of dataTable to PDF using the print view."
+    },
     "autoload": {
         "psr-4": {
             "Yajra\\Datatables\\": "src/"

--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -308,7 +308,7 @@ abstract class DataTable implements DataTableContract, DataTableButtonsContract
      */
     public function pdf()
     {
-        if ('snappy' == Config::get('datatables.pdf_generator')) {
+        if ('snappy' == Config::get('datatables.pdf_generator', 'excel')) {
             return $this->snappyPdf();
         } else {
             $this->buildExcelFile()->download('pdf');

--- a/src/Services/DataTable.php
+++ b/src/Services/DataTable.php
@@ -3,6 +3,7 @@
 namespace Yajra\Datatables\Services;
 
 use Illuminate\Contracts\View\Factory;
+use Illuminate\Support\Facades\Config;
 use Maatwebsite\Excel\Classes\LaravelExcelWorksheet;
 use Maatwebsite\Excel\Writers\LaravelExcelWriter;
 use Yajra\Datatables\Contracts\DataTableButtonsContract;
@@ -303,11 +304,36 @@ abstract class DataTable implements DataTableContract, DataTableButtonsContract
     /**
      * Export results to PDF file.
      *
-     * @return void
+     * @return mixed
      */
     public function pdf()
     {
-        $this->buildExcelFile()->download('pdf');
+        if ('snappy' == Config::get('datatables.pdf_generator')) {
+            return $this->snappyPdf();
+        } else {
+            $this->buildExcelFile()->download('pdf');
+        }
+    }
+
+    /**
+     * PDF version of the table using print preview blade template.
+     *
+     * @return mixed
+     */
+    public function snappyPdf()
+    {
+        $data   = $this->getDataForPrint();
+        $snappy = app('snappy.pdf.wrapper');
+        $snappy->setOptions([
+            'no-outline'    => true,
+            'margin-left'   => '0',
+            'margin-right'  => '0',
+            'margin-top'    => '10mm',
+            'margin-bottom' => '10mm',
+        ])->setOrientation('landscape');
+
+        return $snappy->loadView($this->printPreview, compact('data'))
+                      ->download($this->getFilename() . ".pdf");
     }
 
     /**

--- a/src/Transformers/DataTransformer.php
+++ b/src/Transformers/DataTransformer.php
@@ -64,8 +64,12 @@ class DataTransformer
      */
     protected function decodeContent($data)
     {
-        $decoded = html_entity_decode(strip_tags($data), ENT_QUOTES, 'UTF-8');
+        try {
+            $decoded = html_entity_decode(strip_tags($data), ENT_QUOTES, 'UTF-8');
 
-        return str_replace("\xc2\xa0", ' ', $decoded);
+            return str_replace("\xc2\xa0", ' ', $decoded);
+        } catch (\Exception $e) {
+            return $data;
+        }
     }
 }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -67,4 +67,12 @@ return [
          */
         'model' => '',
     ],
+
+    /**
+     * PDF generator to be used when converting the table to pdf.
+     * Available generators: excel, snappy
+     * Snappy package: barryvdh/laravel-snappy
+     * Excel package: maatwebsite/excel
+     */
+    'pdf_generator' => 'excel'
 ];

--- a/src/resources/views/print.blade.php
+++ b/src/resources/views/print.blade.php
@@ -24,8 +24,10 @@
                 @endif
                 <tr>
                     @foreach($row as $key => $value)
-                        @if (is_string($value) || trim($value)==='' || is_numeric($value))
+                        @if(is_string($value) || is_numeric($value))
                             <td>{!! $value !!}</td>
+                        @else
+                            <td></td>
                         @endif
                     @endforeach
                 </tr>

--- a/src/resources/views/print.blade.php
+++ b/src/resources/views/print.blade.php
@@ -13,7 +13,7 @@
         </style>
     </head>
     <body>
-        <table class="table table-bordered table-condensed">
+        <table class="table table-bordered table-condensed table-striped">
             @foreach($data as $row)
                 @if ($row == reset($data)) 
                     <tr>


### PR DESCRIPTION
This PR will enhance the process of exporting dataTable to PDF with some minor bug fixes.

- Add support for snappy pdf via config.
- Add laravel-snappy on suggested packages.
- Add table stripes style.
- Fix printing template when value is an array.
- Fix issue when exporting pdf and data can't be decoded.
    - ErrorException in DataTransformer.php line 67:
       strip_tags() expects parameter 1 to be string, array given

Usage:
- Install [laravel-snappy](https://github.com/barryvdh/laravel-snappy).
- Update `datatables.php` config and use `snappy` as the pdf generator:

```php
    'pdf_generator' => 'snappy'
```