### PR TITLE
Unset any bindings to select statement

### DIFF
--- a/src/yajra/Datatables/Datatables.php
+++ b/src/yajra/Datatables/Datatables.php
@@ -333,7 +333,11 @@ class Datatables
             $myQuery->select($this->connection->raw("'1' as row_count"));
         }
         
-        $bindings = $myQuery->getRawBindings();
+        if ($myQuery instanceof QueryBuilder) {
+            $bindings = $myQuery->getRawBindings();
+        } else {
+            $bindings = $myQuery->getQuery()->getRawBindings();
+        }
         unset($bindings['select']);
         $bindings = array_flatten($bindings);
 

--- a/src/yajra/Datatables/Datatables.php
+++ b/src/yajra/Datatables/Datatables.php
@@ -334,8 +334,8 @@ class Datatables
         }
         
         $bindings = $myQuery->getRawBindings();
-		unset($bindings['select']);
-		$bindings = array_flatten($bindings);
+        unset($bindings['select']);
+        $bindings = array_flatten($bindings);
 
         return $this->connection->table($this->connection->raw('(' . $myQuery->toSql() . ') count_row_table'))
             ->setBindings($bindings)->count();

--- a/src/yajra/Datatables/Datatables.php
+++ b/src/yajra/Datatables/Datatables.php
@@ -332,9 +332,13 @@ class Datatables
         if ( ! Str::contains(Str::lower($myQuery->toSql()), ['union', 'having', 'distinct'])) {
             $myQuery->select($this->connection->raw("'1' as row_count"));
         }
+        
+        $bindings = $myQuery->getRawBindings();
+		unset($bindings['select']);
+		$bindings = array_flatten($bindings);
 
         return $this->connection->table($this->connection->raw('(' . $myQuery->toSql() . ') count_row_table'))
-            ->setBindings($myQuery->getBindings())->count();
+            ->setBindings($bindings)->count();
     }
 
     /**

--- a/tests/DatatablesBuilder.php
+++ b/tests/DatatablesBuilder.php
@@ -199,7 +199,7 @@ class DatatablesBuilderTest extends PHPUnit_Framework_TestCase  {
 		$builder->getConnection()->shouldReceive('raw')->andReturn('(select id, name from users) count_row_table');
 		$builder->shouldReceive('select')->once()->andReturn($builder);
 		$builder->getConnection()->shouldReceive('table')->times(2)->andReturn($builder);
-		$builder->shouldReceive('getBindings')->times(2)->andReturn(array());
+		$builder->shouldReceive('getRawBindings')->times(2)->andReturn(array());
 		$builder->shouldReceive('setBindings')->times(2)->with(array())->andReturn($builder);
 		if ( ! $showAllRecords) {
 			$builder->shouldReceive('skip')->once()->andReturn($builder);


### PR DESCRIPTION
### Summary of problem that's solved by this PR

The method `$myQuery->getBindings()` ([src/yajra/Datatables/Datatables.php#L337](https://github.com/yajra/laravel-datatables/blob/599aab0541ff0cb64f44db3618978d2685a03afc/src/yajra/Datatables/Datatables.php#L337)) returns _all_ bindings, including any bindings to the select statement. But since the select statement is overwritten these bindings can be incorrect.


### Code snippet of problem that's solved by this PR

```php
public function getTableData()
{
	$query = \DB::table(\DB::raw('`calls` `call`'))
		->selectRaw('
			`call`.`id`,
			`call`.`created_at`,
			`company`.`name` AS `company_name`,
			`company`.`id` AS `company_id`,
			`call`.`short_description`,
			`call`.`estimated_hours`,
			`call`.`type`,
			`call`.`status`,
			`call`.`due_at`,
			`call`.`closed_at`,
			`assignee`.`id` AS `assignee_id`,
			CASE
				WHEN SUM(`time`.`hours`) IS NULL THEN 0
				ELSE SUM(`time`.`hours`)
			END AS `sum_hours`,
			`call`.`estimated_hours` - CASE
				WHEN SUM(`time`.`hours`) IS NULL THEN 0
				ELSE SUM(`time`.`hours`)
			END AS `diff_hours`,
			CASE
				WHEN `call`.`type` = ? THEN
					CASE
						WHEN `call`.`fixed_price` IS NOT NULL THEN `call`.`fixed_price` - `call`.`cost`
						WHEN `call`.`billable_hours` IS NOT NULL THEN `call`.`billable_hours` * `assignee`.`hourly_rate` - `call`.`cost`
						WHEN SUM(`time`.`hours`) IS NULL THEN 0 - `call`.`cost`
						ELSE SUM(`time`.`hours`) * `assignee`.`hourly_rate` - `call`.`cost`
					END
				ELSE 0 - `call`.`cost`
			END AS `margin`
		')
		->addBinding(Call::TYPE_INSTRUCTION, 'select')
		->leftJoin(\DB::raw('`companies` `company`'), 'call.company_id', '=', 'company.id')
		->leftJoin(\DB::raw('`time_registrations` `time`'), 'call.id', '=', 'time.call_id')
		->leftJoin(\DB::raw('`assignees` `assignee`'), 'call.assignee_id', '=', 'assignee.id')
		->groupBy('call.id');

	return Datatables::of($query)->make(true);
}
```