### PR TITLE
Allow global search to work with custom filter callback.

### DIFF
--- a/src/Contracts/DataTableEngineContract.php
+++ b/src/Contracts/DataTableEngineContract.php
@@ -36,9 +36,10 @@ interface DataTableEngineContract
      * Overrides global search.
      *
      * @param \Closure $callback
+     * @param bool $globalSearch
      * @return $this
      */
-    public function filter(\Closure $callback);
+    public function filter(\Closure $callback, $globalSearch = false);
 
     /**
      * Perform global search.

--- a/src/Engines/BaseEngine.php
+++ b/src/Engines/BaseEngine.php
@@ -597,10 +597,10 @@ abstract class BaseEngine implements DataTableEngineContract
     {
         if ($this->autoFilter && $this->request->isSearchable()) {
             $this->filtering();
-        } else {
-            if (is_callable($this->filterCallback)) {
-                call_user_func($this->filterCallback, $this->filterCallbackParameters);
-            }
+        }
+
+        if (is_callable($this->filterCallback)) {
+            call_user_func($this->filterCallback, $this->filterCallbackParameters);
         }
 
         $this->columnSearch();
@@ -716,11 +716,11 @@ abstract class BaseEngine implements DataTableEngineContract
      *
      * @param  \Closure $callback
      * @param  mixed $parameters
-     * @return void
+     * @param  bool $autoFilter
      */
-    public function overrideGlobalSearch(\Closure $callback, $parameters)
+    public function overrideGlobalSearch(\Closure $callback, $parameters, $autoFilter = false)
     {
-        $this->autoFilter               = false;
+        $this->autoFilter               = $autoFilter;
         $this->isFilterApplied          = true;
         $this->filterCallback           = $callback;
         $this->filterCallbackParameters = $parameters;

--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -61,11 +61,12 @@ class CollectionEngine extends BaseEngine
      * Overrides global search.
      *
      * @param \Closure $callback
+     * @param bool $globalSearch
      * @return $this
      */
-    public function filter(Closure $callback)
+    public function filter(Closure $callback, $globalSearch = false)
     {
-        $this->overrideGlobalSearch($callback, $this);
+        $this->overrideGlobalSearch($callback, $this, $globalSearch);
 
         return $this;
     }

--- a/src/Engines/QueryBuilderEngine.php
+++ b/src/Engines/QueryBuilderEngine.php
@@ -53,11 +53,12 @@ class QueryBuilderEngine extends BaseEngine
      * Overrides global search
      *
      * @param \Closure $callback
+     * @param bool $globalSearch
      * @return $this
      */
-    public function filter(Closure $callback)
+    public function filter(Closure $callback, $globalSearch = false)
     {
-        $this->overrideGlobalSearch($callback, $this->query);
+        $this->overrideGlobalSearch($callback, $this->query, $globalSearch);
 
         return $this;
     }


### PR DESCRIPTION
This PR will allow global search to work along with filter callback.
Addresses issues like: https://github.com/yajra/laravel-datatables/issues/94

### Usage
Just add `true` as the second parameter of `filter()` method:
```php
public function filter(\Closure $callback, $globalSearch = false);
```

### Example Snippet:
```php
public function ajax()
{
    return $this->datatables
        ->queryBuilder($this->query())
        ->filter(function (Builder $query) {
            if ($type = $this->request()->get('name')) {
                $query->where('name', $type);
            }
        }, true)
        ->make(true);
}
```
