### PR TITLE
use post request for export and print buttons

### DIFF
--- a/src/resources/views/script.blade.php
+++ b/src/resources/views/script.blade.php
@@ -1,1 +1,6 @@
+// add csrf token, need for post requests
+$.extend(true, $.fn.dataTable.defaults, {
+    csrf_token : '{{ csrf_token() }}'
+});
+
 (function(window,$){window.LaravelDataTables=window.LaravelDataTables||{};window.LaravelDataTables["%1$s"]=$("#%1$s").DataTable(%2$s);})(window,jQuery);


### PR DESCRIPTION
I've changed the behaviour of the export and print buttons to use a post instead of get request.
I got some issues with long urls as i have to many filters and columns in my datatable.

As jquery post does not support downloading files, i've used a xhr function i've found [here](http://stackoverflow.com/questions/16086162/handle-file-download-from-ajax-post).

Laravel requires a csrf token for post requests, so i've added that to the script.blade.php file (i'm not sure if this is the best solution).

I've tested the excel, csv, pdf and print button in Firefox and Google Chrome.

I had to change my routes file also to handle the get and post request to the datatable:

`Route::match(['get', 'post'], '/', function () { ... });`

Fixes issue #348
