### PR TITLE
Add orderColumns api helper.

### DIFF
--- a/src/Engines/BaseEngine.php
+++ b/src/Engines/BaseEngine.php
@@ -511,6 +511,23 @@ abstract class BaseEngine implements DataTableEngineContract
     }
 
     /**
+     * Order each given columns versus the given custom sql.
+     *
+     * @param array $columns
+     * @param string $sql
+     * @param array $bindings
+     * @return $this
+     */
+    public function orderColumns(array $columns, $sql, $bindings = [])
+    {
+        foreach ($columns as $column) {
+            $this->orderColumn($column, str_replace(':column', $column, $sql), $bindings);
+        }
+
+        return $this;
+    }
+
+    /**
      * Override default column ordering.
      *
      * @param string $column


### PR DESCRIPTION
This PR will add `orderColumns` api helper that can help us in cases where we want to apply a custom order sql for each columns.

## Use Case:
In some cases, we may want to sort our columns where null values will be last on display. To achieve this in dataTables we can use `orderColumn` for each column. Or we can use `orderColumns` and pass all the columns array to avoid duplication of codes.

For Oracle:
```php
$users = User::query();

return Datatables::of($users)
    ->orderColumns(['name', 'email'], ':column $1 nulls last')
    ->make(true);
```

For MySQL:

```php
->orderColumns(['name', 'email'], '-:column $1')
```

When using the service approach:

```php
->orderColumns(Arr::pluck($this->getColumns(), 'name'), ':column $1 nulls last')
```