### PR TITLE
Add setter and getter for table attributes.

### DIFF
--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -129,6 +129,59 @@ class Builder
     }
 
     /**
+     * Sets HTML table attribute(s).
+     *
+     * @param string|array $attribute
+     * @param mixed $value
+     *
+     * @return $this
+     */
+    public function setTableAttribute($attribute, $value = null)
+    {
+        if (is_array($attribute)) {
+            $this->setTableAttributes($attribute);
+        } else {
+            $this->tableAttributes[$attribute] = $value;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Retrieves HTML table attribute value.
+     *
+     * @param string $attribute
+     *
+     * @return mixed
+     * @throws \Exception
+     */
+    public function getTableAttribute($attribute)
+    {
+        if (!array_key_exists($attribute, $this->tableAttributes)) {
+            throw new \Exception("Table attribute '{$attribute}' does not exist.");
+        }
+
+        return $this->tableAttributes[$attribute];
+    }
+
+    /**
+     * Sets multiple HTML table at once.
+     *
+     * @param array $attributes
+     *
+     * @return $this
+     */
+    public function setTableAttributes(array $attributes)
+    {
+        foreach ($attributes as $attribute => $value) {
+            $this->setTableAttribute($attribute, $value);
+        }
+
+        return $this;
+    }
+
+
+    /**
      * Get generated raw scripts.
      *
      * @return string

--- a/tests/HtmlBuilderTest.php
+++ b/tests/HtmlBuilderTest.php
@@ -108,6 +108,34 @@ class HtmlBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $builder->generateScripts());
     }
 
+    public function test_setting_table_attribute()
+    {
+        $builder = app(Builder::class);
+
+        $builder->setTableAttribute('attr', 'val');
+
+        $this->assertEquals('val', $builder->getTableAttribute('attr'));
+    }
+
+    public function test_settings_multiple_table_attributes()
+    {
+        $builder = app(Builder::class);
+
+        $builder->setTableAttribute(['prop1' => 'val1', 'prop2' => 'val2']);
+
+        $this->assertEquals('val1', $builder->getTableAttribute('prop1'));
+        $this->assertEquals('val2', $builder->getTableAttribute('prop2'));
+    }
+
+    public function test_getting_inexistent_table_attribute_throws()
+    {
+        $this->setExpectedExceptionRegExp(\Exception::class, '/Table attribute \'.+?\' does not exist\./');
+
+        $builder = app(Builder::class);
+
+        $builder->getTableAttribute('boohoo');
+    }
+
     /**
      * @return \Yajra\Datatables\Datatables
      */


### PR DESCRIPTION
<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->

Useful for settings attributes.
Maybe in the future, using `__set` and `__get`?