### PR TITLE
SetTotalRecords in CollectionEngine

### DIFF
--- a/src/Engines/BaseEngine.php
+++ b/src/Engines/BaseEngine.php
@@ -186,9 +186,7 @@ abstract class BaseEngine implements DataTableEngineContract
      * @var array
      */
     private $appends = [];
-
-
-
+    
     /**
      * Setup search keyword.
      *

--- a/src/Engines/BaseEngine.php
+++ b/src/Engines/BaseEngine.php
@@ -174,11 +174,20 @@ abstract class BaseEngine implements DataTableEngineContract
     protected $orderCallback;
 
     /**
+     * Custom rewriting totals
+     *
+     * @var bool
+     */
+    protected $rewriteTotals = false;
+
+    /**
      * Array of data to append on json response.
      *
      * @var array
      */
     private $appends = [];
+
+
 
     /**
      * Setup search keyword.
@@ -960,6 +969,8 @@ abstract class BaseEngine implements DataTableEngineContract
      */
     public function setTotalRecords($total)
     {
+        $this->rewriteTotals = true;
+
         $this->totalRecords = $total;
 
         return $this;

--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -101,7 +101,7 @@ class CollectionEngine extends BaseEngine
      */
     public function count()
     {
-        return $this->collection->count();
+        return $this->totalRecords ? $this->totalRecords : $this->collection->count();
     }
 
     /**
@@ -205,10 +205,12 @@ class CollectionEngine extends BaseEngine
      */
     public function paging()
     {
-        $this->collection = $this->collection->slice(
-            $this->request['start'],
-            (int) $this->request['length'] > 0 ? $this->request['length'] : 10
-        );
+        if(!$this->rewriteTotals) {
+            $this->collection = $this->collection->slice(
+                $this->request['start'],
+                (int)$this->request['length'] > 0 ? $this->request['length'] : 10
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
Issue described in #702 
For now we can use SetTotalRecords when we using CollectionEngine.
Example:
```
        $offset = Input::get('start', null);
        $limit = Input::get('length', null);
        $dataSourceRows = DataSourceRow::whereDataSourceId($dataSourceId);
        $dataSourceRowsCount = $dataSourceRows->count() / $dataSourceColumnsCount;
        if (!is_null($offset) && !is_null($limit)) {
            $dataSourceRows->limit($limit * $dataSourceColumnsCount)
                           ->offset($offset * $dataSourceColumnsCount);
        }

        $rows = $dataSourceRows->orderBy('id')->get();

        foreach ($rows as $row) {
            $result[$row->row_id][$row->dataSourceColumns->title] = $row->value;
        }
        return Datatables::of(new Collection($result))
                         ->setTotalRecords($dataSourceRowsCount)
                         ->make(true);
```
We are retrieving data from model with a lot of items and with limits, doing some stuff with it and creating Collection with this data. Also we setting up totalRecords by manual with `setTotalRecords($dataSourceRowsCount)` and it retrieving us correct json data for the datatables.