### PR TITLE
If filtered total > total records, use total records.

### DIFF
--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -91,7 +91,7 @@ class CollectionEngine extends BaseEngine
      */
     public function totalCount()
     {
-        return $this->totalRecords ? $this->totalRecords : $this->count();
+        return $this->totalRecords ? $this->totalRecords : $this->collection->count();
     }
 
     /**
@@ -101,7 +101,7 @@ class CollectionEngine extends BaseEngine
      */
     public function count()
     {
-        return $this->collection->count();
+        return $this->collection->count() > $this->totalRecords ? $this->totalRecords : $this->collection->count();
     }
 
     /**


### PR DESCRIPTION
This PR fixes scenario that may occur when you manually set the total records and the paging will exceed the expected total.