### PR TITLE
Fix to allow join of eager loaded column based on a HasMany-relationship

### DIFF
--- a/src/Engines/QueryBuilderEngine.php
+++ b/src/Engines/QueryBuilderEngine.php
@@ -5,6 +5,7 @@ namespace Yajra\Datatables\Engines;
 use Closure;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Str;
 use Yajra\Datatables\Helper;
@@ -428,7 +429,7 @@ class QueryBuilderEngine extends BaseEngine
             }
         } else {
             $table = $model->getRelated()->getTable();
-            if ($model instanceof HasOne) {
+            if ($model instanceof HasOne || $model instanceof HasMany) {
                 $foreign = $model->getForeignKey();
                 $other   = $model->getQualifiedParentKeyName();
             } else {


### PR DESCRIPTION
Hi

I was having issues implementing column search for a column showing data from a eager loaded HasMany-relationship. Treating HasMany in the same way as HasOne fixed it for me as HasMany has the getForeignKey()-method as well.

See the issue i created: #732 
