### PR TITLE
Fix to Str::lower() on array

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "league/fractal": "~0.12",
         "laravelcollective/html": "~5.0",
         "maatwebsite/excel": "^2.0",
-        "dompdf/dompdf": "^0.7"
+        "dompdf/dompdf": "^0.6.1"
     },
     "require-dev": {
         "mockery/mockery": "~0.9",

--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -155,6 +155,7 @@ class CollectionEngine extends BaseEngine
                     }
 
                     if ($this->isCaseInsensitive()) {
+                        $value = is_array($value) ? json_decode(json_encode($value), true) : $value;
                         $found[] = Str::contains(Str::lower($value), Str::lower($keyword));
                     } else {
                         $found[] = Str::contains($value, $keyword);
@@ -188,6 +189,7 @@ class CollectionEngine extends BaseEngine
                         $value = Arr::get($data, $column);
 
                         if ($this->isCaseInsensitive()) {
+                            $value = is_array($value) ? json_decode(json_encode($value), true) : $value;
                             return strpos(Str::lower($value), Str::lower($keyword)) !== false;
                         } else {
                             return strpos($value, $keyword) !== false;


### PR DESCRIPTION
### Summary of problem or feature request
With eager loaded relationships on a collection, searching a column containing relationships fails due to `Str::lower()` expecting a string, but an array is being passed.  Converting array to json_decoded string works.


### Code snippet of problem
`Str::lower($value)`

Fix:
`$value = is_array($value) ? json_decode(json_encode($value), true) : $value;`

### System details

- Operating System: Ubuntu
- PHP Version: 7.0.10
- Laravel Version: Laravel 5.2.x
- Laravel-Datatables Version: 6.18.0