### PR TITLE
Support regex column searches when using CollectionEngine

### DIFF
--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -189,13 +189,13 @@ class CollectionEngine extends BaseEngine
                         $value = Arr::get($data, $column);
 
                         if ($this->isCaseInsensitive()) {
-                            if($regex) {
-                                return preg_match('/' . Str::lower($keyword) . '/', Str::lower($value)) == 1;
+                            if ($regex) {
+                                return preg_match('/' . $keyword . '/i', $value) == 1;
                             } else {
                                 return strpos(Str::lower($value), Str::lower($keyword)) !== false;
                             }
                         } else {
-                            if($regex) {
+                            if ($regex) {
                                 return preg_match('/' . $keyword . '/', $value) == 1;
                             } else {
                                 return strpos($value, $keyword) !== false;

--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -177,20 +177,29 @@ class CollectionEngine extends BaseEngine
         for ($i = 0, $c = count($columns); $i < $c; $i++) {
             if ($this->request->isColumnSearchable($i)) {
                 $this->isFilterApplied = true;
+                $regex = $this->request->isRegex($i);
 
                 $column  = $this->getColumnName($i);
                 $keyword = $this->request->columnKeyword($i);
 
                 $this->collection = $this->collection->filter(
-                    function ($row) use ($column, $keyword) {
+                    function ($row) use ($column, $keyword, $regex) {
                         $data = $this->serialize($row);
 
                         $value = Arr::get($data, $column);
 
                         if ($this->isCaseInsensitive()) {
-                            return strpos(Str::lower($value), Str::lower($keyword)) !== false;
+                            if($regex) {
+                                return preg_match('/' . Str::lower($keyword) . '/', Str::lower($value)) == 1;
+                            } else {
+                                return strpos(Str::lower($value), Str::lower($keyword)) !== false;
+                            }
                         } else {
-                            return strpos($value, $keyword) !== false;
+                            if($regex) {
+                                return preg_match('/' . $keyword . '/', $value) == 1;
+                            } else {
+                                return strpos($value, $keyword) !== false;
+                            }
                         }
                     }
                 );


### PR DESCRIPTION
The QueryBuilderEngine has support for using Oracle queries to search for regular expressions when a columns 'regex' flag is enabled. This update adds similar functionality to the CollectionEngine using PHP's built-in preg functions.