### PR TITLE
Support of using soft deletes trait in models.

### DIFF
--- a/src/Engines/BaseEngine.php
+++ b/src/Engines/BaseEngine.php
@@ -104,6 +104,14 @@ abstract class BaseEngine implements DataTableEngineContract
      * @var bool
      */
     protected $autoFilter = true;
+    
+    /**
+     * Select trashed records in count function for models with soft deletes trait.
+     * By default we do not select soft deleted records
+     *
+     * @var bool
+     */
+    protected $withTrashed = false;
 
     /**
      * Callback to override global search.
@@ -391,6 +399,19 @@ abstract class BaseEngine implements DataTableEngineContract
     {
         $this->columnDef['escape'] = $columns;
 
+        return $this;
+    }
+    
+    /**
+     * Change withTrashed flag value.
+     *
+     * @param bool $withTrashed
+     * @return $this
+     */
+    public function withTrashed($withTrashed = true)
+    {
+        $this->withTrashed = $withTrashed;
+        
         return $this;
     }
 

--- a/src/Engines/QueryBuilderEngine.php
+++ b/src/Engines/QueryBuilderEngine.php
@@ -407,7 +407,11 @@ class QueryBuilderEngine extends BaseEngine
      */
     private function modelUseSoftDeletes()
     {
-        return in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses($this->query->getModel()));
+        if ($this->query_type == 'eloquent') {
+            return in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses($this->query->getModel()));
+        }
+        
+        return false;
     }
     
     /**

--- a/src/Engines/QueryBuilderEngine.php
+++ b/src/Engines/QueryBuilderEngine.php
@@ -102,7 +102,7 @@ class QueryBuilderEngine extends BaseEngine
         }
     
         // check for select soft deleted records
-        if (!$this->withTrashed && $this->modelUseSoftDeletes()) {
+        if (! $this->withTrashed && $this->modelUseSoftDeletes()) {
             $myQuery->whereNull($myQuery->getModel()->getTable().'.deleted_at');
         }
 
@@ -407,18 +407,7 @@ class QueryBuilderEngine extends BaseEngine
      */
     private function modelUseSoftDeletes()
     {
-        $app = app();
-        
-        //check for laravel version
-        //in 4 and 5 versions SoftDeletes trait has a different names
-        //we can check only first number
-        if (strpos($app::VERSION, '5') === 0) {
-            $class = 'Illuminate\Database\Eloquent\SoftDeletes';
-        } else {
-            $class = 'Illuminate\Database\Eloquent\SoftDeletingTrait';
-        }
-        
-        return in_array($class, class_uses($this->query->getModel()));
+        return in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses($this->query->getModel()));
     }
     
     /**


### PR DESCRIPTION
This is required when a user uses a model with soft deletes trait (use Illuminate\Database\Eloquent\SoftDeletes), but does not include to select trashed items (withTrashed()), then the number of selected elements and elements in the pagination begins to differ.
Commit adds the ability to manage it and select or not deleted records in count function