### PR TITLE
[7.0] Add post button for exporting data to fix compatibility with IE.

### DIFF
--- a/src/resources/assets/buttons.server-side.js
+++ b/src/resources/assets/buttons.server-side.js
@@ -1,7 +1,66 @@
 (function ($, DataTable) {
     "use strict";
 
-    var _buildUrl = function(dt, action) {
+    var _buildParams = function (dt, action) {
+        var params = dt.ajax.params();
+        params.action = action;
+        params._token = $.fn.dataTable.defaults.csrf_token;
+
+        return params;
+    };
+
+    var _downloadFromUrl = function (url, params) {
+        var postUrl = url + '/export';
+        var xhr = new XMLHttpRequest();
+        xhr.open('POST', postUrl, true);
+        xhr.responseType = 'arraybuffer';
+        xhr.onload = function () {
+            if (this.status === 200) {
+                var filename = "";
+                var disposition = xhr.getResponseHeader('Content-Disposition');
+                if (disposition && disposition.indexOf('attachment') !== -1) {
+                    var filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
+                    var matches = filenameRegex.exec(disposition);
+                    if (matches != null && matches[1]) filename = matches[1].replace(/['"]/g, '');
+                }
+                var type = xhr.getResponseHeader('Content-Type');
+
+                var blob = new Blob([this.response], {type: type});
+                if (typeof window.navigator.msSaveBlob !== 'undefined') {
+                    // IE workaround for "HTML7007: One or more blob URLs were revoked by closing the blob for which they were created. These URLs will no longer resolve as the data backing the URL has been freed."
+                    window.navigator.msSaveBlob(blob, filename);
+                } else {
+                    var URL = window.URL || window.webkitURL;
+                    var downloadUrl = URL.createObjectURL(blob);
+
+                    if (filename) {
+                        // use HTML5 a[download] attribute to specify filename
+                        var a = document.createElement("a");
+                        // safari doesn't support this yet
+                        if (typeof a.download === 'undefined') {
+                            window.location = downloadUrl;
+                        } else {
+                            a.href = downloadUrl;
+                            a.download = filename;
+                            document.body.appendChild(a);
+                            a.click();
+                        }
+                    } else {
+                        window.location = downloadUrl;
+                    }
+
+                    setTimeout(function () {
+                        URL.revokeObjectURL(downloadUrl);
+                    }, 100); // cleanup
+                }
+            }
+        };
+        xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+        xhr.send($.param(params));
+    };
+
+
+    var _buildUrl = function (dt, action) {
         var url = dt.ajax.url() || '';
         var params = dt.ajax.params();
         params.action = action;
@@ -19,6 +78,22 @@
         action: function (e, dt, button, config) {
             var url = _buildUrl(dt, 'excel');
             window.location = url;
+        }
+    };
+
+    // Export post excel button
+    DataTable.ext.buttons.exportPostExcel = {
+        className: 'buttons-excel',
+
+        text: function (dt) {
+            return '<i class="fa fa-file-excel-o"></i> ' + dt.i18n('buttons.excel', 'Excel');
+        },
+
+        action: function (e, dt, button, config) {
+            var url = dt.ajax.url() || window.location.href;
+            var params = _buildParams(dt, 'excel');
+
+            _downloadFromUrl(url, params);
         }
     };
 
@@ -47,6 +122,22 @@
         }
     };
 
+    // Export post csv button
+    DataTable.ext.buttons.exportPostCsv = {
+        className: 'buttons-csv',
+
+        text: function (dt) {
+            return '<i class="fa fa-file-excel-o"></i> ' + dt.i18n('buttons.csv', 'CSV');
+        },
+
+        action: function (e, dt, button, config) {
+            var url = dt.ajax.url() || window.location.href;
+            var params = _buildParams(dt, 'csv');
+
+            _downloadFromUrl(url, params);
+        }
+    };
+
     DataTable.ext.buttons.pdf = {
         className: 'buttons-pdf',
 
@@ -57,6 +148,22 @@
         action: function (e, dt, button, config) {
             var url = _buildUrl(dt, 'pdf');
             window.location = url;
+        }
+    };
+
+    // Export post pdf button
+    DataTable.ext.buttons.exportPostPdf = {
+        className: 'buttons-pdf',
+
+        text: function (dt) {
+            return '<i class="fa fa-file-pdf-o"></i> ' + dt.i18n('buttons.pdf', 'PDF');
+        },
+
+        action: function (e, dt, button, config) {
+            var url = dt.ajax.url() || window.location.href;
+            var params = _buildParams(dt, 'pdf');
+
+            _downloadFromUrl(url, params);
         }
     };
 

--- a/src/resources/views/script.blade.php
+++ b/src/resources/views/script.blade.php
@@ -1,1 +1,5 @@
+// add csrf token, need for post requests
+$.extend(true, $.fn.dataTable.defaults, {
+    csrf_token : '{{ csrf_token() }}'
+});
 (function(window,$){window.LaravelDataTables=window.LaravelDataTables||{};window.LaravelDataTables["%1$s"]=$("#%1$s").DataTable(%2$s);})(window,jQuery);


### PR DESCRIPTION
Add export post buttons for Excel, CSV, PDF data. 
Supported Browsers: IE, Chrome, Firefox.

Please check laravel-datables demo for quick example :).
https://datatables.yajrabox.com/

Thanks for this great PR. @alex-LE
https://github.com/yajra/laravel-datatables/pull/671