### PR TITLE
[6.0] Add method to get or create a transformer serializer.

### DIFF
--- a/src/Engines/BaseEngine.php
+++ b/src/Engines/BaseEngine.php
@@ -680,7 +680,7 @@ abstract class BaseEngine implements DataTableEngineContract
             $fractal = app('datatables.fractal');
 
             if ($this->serializer) {
-                $fractal->setSerializer(new $this->serializer);
+                $fractal->setSerializer($this->createSerializer());
             }
 
             //Get transformer reflection
@@ -710,6 +710,20 @@ abstract class BaseEngine implements DataTableEngineContract
         }
 
         return new JsonResponse($output);
+    }
+
+    /**
+     * Get or create transformer serializer instance.
+     *
+     * @return \League\Fractal\Serializer\SerializerAbstract
+     */
+    protected function createSerializer()
+    {
+        if ($this->serializer instanceof \League\Fractal\Serializer\SerializerAbstract) {
+            return $this->serializer;
+        }
+
+        return new $this->serializer();
     }
 
     /**


### PR DESCRIPTION
This will allow the package to return the original serializer instance if new instance was passed.

```php
Datatables::of($query)->setSerializer(new ArraySerializer)->make(true);
```