### PR TITLE
[6.0] Add multiple transformer ability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
         "league/fractal": "~0.14",
         "laravelcollective/html": "~5.0",
         "maatwebsite/excel": "^2.0",
-        "dompdf/dompdf": "^0.7"
     },
     "require-dev": {
         "mockery/mockery": "~0.9",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "illuminate/filesystem": "~5.0",
         "league/fractal": "~0.14",
         "laravelcollective/html": "~5.0",
-        "maatwebsite/excel": "^2.0",
+        "maatwebsite/excel": "^2.0"
     },
     "require-dev": {
         "mockery/mockery": "~0.9",

--- a/src/Engines/BaseEngine.php
+++ b/src/Engines/BaseEngine.php
@@ -592,7 +592,9 @@ abstract class BaseEngine implements DataTableEngineContract
      */
     public function addTransformer($transformer)
     {
-        $this->transformers[] = $transformer;
+        if ($transformer!=null) {
+            $this->transformers[] = $transformer;
+        }
         return $this;
     }
 


### PR DESCRIPTION
In my scenario I have to separate general and unique transformation. So I implement multiple transformation ability in BaseEngine class. You can use like:

```
return $this->datatables
->eloquent($this->query())
->addTransformer(new GeneralTransformer($columnDefinitions))
->addTransformer(new OrderTransformer())
->make(true);

```

I keeped the setTransformer api for backward compatibility.
