### PR TITLE
add override auto filter and add ordering by nulls last

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -5,6 +5,11 @@ return [
     'search' => [
         'case_insensitive' => true,
         'use_wildcards'    => false,
+    ],
+
+    'order' => [
+        //first %s column, second %s order direction
+        'nulls_last_sql' => '%s %s NULLS LAST',
     ]
 
 ];


### PR DESCRIPTION
## Auto filter
Accept auto filter when we call filter function. Added to avoid the probleme of rapid search inbox with the personnel filter.
```
        return Datatables::of($activities)->filter(function ($query) {
            $input = Input::all();

            if(Input::has('rfs'))
                $query->where('refstan', 'ilike', '%'.Input::get('rfs').'%');

        }, true)->make(true);
```
## Order By Nulls Last
Order by nulls last function.

```
        return Datatables::of($activities)->orderByNullsLast()->make(true);
```