### PR TITLE
Patch for fix ambiguous field error for relations.

### DIFF
--- a/src/Engines/QueryBuilderEngine.php
+++ b/src/Engines/QueryBuilderEngine.php
@@ -384,6 +384,7 @@ class QueryBuilderEngine extends BaseEngine
          * Ambiguous field error will appear
          * when query use join table and search with keyword.
          */
+        // Remove backtick that appear from MYSQL query.
         $column = str_replace('`', '', $column);
 
         // check . in field name for protect don't add table again
@@ -400,8 +401,8 @@ class QueryBuilderEngine extends BaseEngine
             // get table from query and add it.
             $column = $q->from.'.'.$column;
         }
-        // Add ` cover table and field name.
-        $column = '`' . str_replace('.', '`.`', $column) . '`';
+        // Add wrap cover table and field name.
+        $column = $this->wrap($column);
 
         /* end fix */
         

--- a/src/Engines/QueryBuilderEngine.php
+++ b/src/Engines/QueryBuilderEngine.php
@@ -378,6 +378,33 @@ class QueryBuilderEngine extends BaseEngine
         $column = $this->castColumn($column);
         $sql    = $column . ' LIKE ?';
 
+        /**
+         * Patch for fix about ambiguous field
+         *
+         * Ambiguous field error will appear
+         * when query use join table and search with keyword.
+         */
+        $column = str_replace('`', '', $column);
+
+        // check . in field name for protect don't add table again
+        // but as far as I tested, this function has single field name only.
+        if (strpos($column, '.') === false) {
+            // Alternative method to check
+            // instanceof \Illuminate\Database\Eloquent\Builder
+            if (method_exists($query, 'getQuery')) {
+                $q = $query->getQuery();
+            } else {
+                $q = $query;
+            }
+
+            // get table from query and add it.
+            $column = $q->from.'.'.$column;
+        }
+        // Add ` cover table and field name.
+        $column = '`' . str_replace('.', '`.`', $column) . '`';
+
+        /* end fix */
+        
         if ($this->isCaseInsensitive()) {
             $sql = 'LOWER(' . $column . ') LIKE ?';
         }

--- a/src/Engines/QueryBuilderEngine.php
+++ b/src/Engines/QueryBuilderEngine.php
@@ -384,8 +384,9 @@ class QueryBuilderEngine extends BaseEngine
          * Ambiguous field error will appear
          * when query use join table and search with keyword.
          */
-        // Remove backtick that appear from MYSQL query.
-        $column = str_replace('`', '', $column);
+        // Remove delimiter of column that appear from MYSQL query.
+        $column = str_replace(['`', '"', '[', ']'], '', $column);
+
 
         // check . in field name for protect don't add table again
         // but as far as I tested, this function has single field name only.


### PR DESCRIPTION
Ambiguous field error will appear when search and join relations together.

This patch will only get table from builder class and push it before column name.

_This patch need for next pull request that I about sort in nested relations._