### PR TITLE
Fix singleton

### DIFF
--- a/src/DatatablesServiceProvider.php
+++ b/src/DatatablesServiceProvider.php
@@ -83,6 +83,8 @@ class DatatablesServiceProvider extends ServiceProvider
             return new Datatables($this->app->make(Request::class));
         });
 
+        $this->app->alias('datatables', Datatables::class);
+
         $this->app->singleton('datatables.fractal', function () {
             $fractal = new Manager;
             $config  = $this->app['config'];


### PR DESCRIPTION
Adding alias for `Datatables` class, then `app('datatables')`, `app(Datatables::class)`, and method dependency of `Datatables` will be the same singleton instance.