### PR TITLE
Fix print header issue when two row are same value

### DIFF
--- a/src/resources/views/print.blade.php
+++ b/src/resources/views/print.blade.php
@@ -14,12 +14,14 @@
     </head>
     <body>
         <table class="table table-bordered table-condensed table-striped">
+            @php ($flag = true)
             @foreach($data as $row)
-                @if ($row == reset($data)) 
+                @if ($row == reset($data) && $flag)
                     <tr>
                         @foreach($row as $key => $value)
                             <th>{!! $key !!}</th>
                         @endforeach
+                        @php ($flag = false)
                     </tr>
                 @endif
                 <tr>


### PR DESCRIPTION
<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
getting issue when data like below 

Array
(

    [0] => Array
        (
            [Object] => Buyer
            [Sub Type] => Plot
        )

    [1] => Array
        (
            [Object] => Buyer
            [Sub Type] => Office Shop
        )

    [2] => Array
        (
            [Object] => Buyer
            [Sub Type] => Bunglow
        )

    [3] => Array
        (
            [Object] => Buyer
            [Sub Type] => Plot
        )

    [4] => Array
        (
            [Object] => Buyer
            [Sub Type] => Plot
        )

    [5] => Array
        (
            [Object] => Seller
            [Sub Type] => Plot
        )

    [6] => Array
        (
            [Object] => Seller
            [Sub Type] => Plot
        )

    [7] => Array
        (
            [Object] => Seller
            [Sub Type] => Plot
        )

    [8] => Array
        (
            [Object] => To Let
            [Sub Type] => Plot
        )

    [9] => Array
        (
            [Object] => Rent
            [Sub Type] => Flat
        )

)

first row repeated more time
if data like above then header repeated so i add flag for first row