### PR TITLE
Fix regex query for pgsql.

### DIFF
--- a/src/Engines/QueryBuilderEngine.php
+++ b/src/Engines/QueryBuilderEngine.php
@@ -605,6 +605,9 @@ class QueryBuilderEngine extends BaseEngine
         if ($this->isOracleSql()) {
             $sql = ! $this->isCaseInsensitive() ? 'REGEXP_LIKE( ' . $column . ' , ? )' : 'REGEXP_LIKE( LOWER(' . $column . ') , ?, \'i\' )';
             $this->query->whereRaw($sql, [$keyword]);
+        } elseif ($this->database == 'pgsql') {
+            $sql = ! $this->isCaseInsensitive() ? $column . ' ~ ?' : $column . ' ~* ? ';
+            $this->query->whereRaw($sql, [$keyword]);
         } else {
             $sql = ! $this->isCaseInsensitive() ? $column . ' REGEXP ?' : 'LOWER(' . $column . ') REGEXP ?';
             $this->query->whereRaw($sql, [Str::lower($keyword)]);


### PR DESCRIPTION
Getting error when using pgsql database and activate the regex filtering.

```
SQLSTATE[42601]: Syntax error: 7 ERROR:  syntax error at or near "REGEXP"
LINE 1: ...s "row_count" from "categories" where LOWER(name) REGEXP $1)...
```

on postgreSQL there is no REGEXP command. We can use [POSIX regular expression](https://www.postgresql.org/docs/9.3/static/functions-matching.html#FUNCTIONS-POSIX-TABLE)
