### PR TITLE
[6.0] Add support for onlyTrashed model scope. Fix #928

### DIFF
--- a/src/Engines/BaseEngine.php
+++ b/src/Engines/BaseEngine.php
@@ -104,14 +104,6 @@ abstract class BaseEngine implements DataTableEngineContract
      * @var bool
      */
     protected $autoFilter = true;
-    
-    /**
-     * Select trashed records in count function for models with soft deletes trait.
-     * By default we do not select soft deleted records
-     *
-     * @var bool
-     */
-    protected $withTrashed = false;
 
     /**
      * Callback to override global search.
@@ -401,19 +393,6 @@ abstract class BaseEngine implements DataTableEngineContract
     {
         $this->columnDef['escape'] = $columns;
 
-        return $this;
-    }
-    
-    /**
-     * Change withTrashed flag value.
-     *
-     * @param bool $withTrashed
-     * @return $this
-     */
-    public function withTrashed($withTrashed = true)
-    {
-        $this->withTrashed = $withTrashed;
-        
         return $this;
     }
 

--- a/src/Engines/EloquentEngine.php
+++ b/src/Engines/EloquentEngine.php
@@ -3,6 +3,7 @@
 namespace Yajra\Datatables\Engines;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
 use Yajra\Datatables\Request;
 
 /**
@@ -14,6 +15,22 @@ use Yajra\Datatables\Request;
 class EloquentEngine extends QueryBuilderEngine
 {
     /**
+     * Select trashed records in count function for models with soft deletes trait.
+     * By default we do not select soft deleted records
+     *
+     * @var bool
+     */
+    protected $withTrashed = false;
+
+    /**
+     * Select only trashed records in count function for models with soft deletes trait.
+     * By default we do not select soft deleted records
+     *
+     * @var bool
+     */
+    protected $onlyTrashed = false;
+
+    /**
      * @param mixed $model
      * @param \Yajra\Datatables\Request $request
      */
@@ -24,5 +41,73 @@ class EloquentEngine extends QueryBuilderEngine
 
         $this->query      = $builder;
         $this->query_type = 'eloquent';
+    }
+
+    /**
+     * Counts current query.
+     *
+     * @return int
+     */
+    public function count()
+    {
+        $myQuery = clone $this->query;
+        // if its a normal query ( no union, having and distinct word )
+        // replace the select with static text to improve performance
+        if (! Str::contains(Str::lower($myQuery->toSql()), ['union', 'having', 'distinct', 'order by', 'group by'])) {
+            $row_count = $this->wrap('row_count');
+            $myQuery->select($this->connection->raw("'1' as {$row_count}"));
+        }
+
+        // check for select soft deleted records
+        if (! $this->withTrashed && ! $this->onlyTrashed && $this->modelUseSoftDeletes()) {
+            $myQuery->whereNull($myQuery->getModel()->getQualifiedDeletedAtColumn());
+        }
+
+        if ($this->onlyTrashed && $this->modelUseSoftDeletes()) {
+            $myQuery->whereNotNull($myQuery->getModel()->getQualifiedDeletedAtColumn());
+        }
+
+        return $this->connection->table($this->connection->raw('(' . $myQuery->toSql() . ') count_row_table'))
+                                ->setBindings($myQuery->getBindings())->count();
+    }
+
+    /**
+     * Check if model use SoftDeletes trait
+     *
+     * @return boolean
+     */
+    protected function modelUseSoftDeletes()
+    {
+        if ($this->query_type == 'eloquent') {
+            return in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses($this->query->getModel()));
+        }
+
+        return false;
+    }
+
+    /**
+     * Change withTrashed flag value.
+     *
+     * @param bool $withTrashed
+     * @return $this
+     */
+    public function withTrashed($withTrashed = true)
+    {
+        $this->withTrashed = $withTrashed;
+
+        return $this;
+    }
+
+    /**
+     * Change onlyTrashed flag value.
+     *
+     * @param bool $onlyTrashed
+     * @return $this
+     */
+    public function onlyTrashed($onlyTrashed = true)
+    {
+        $this->onlyTrashed = $onlyTrashed;
+
+        return $this;
     }
 }

--- a/src/Engines/QueryBuilderEngine.php
+++ b/src/Engines/QueryBuilderEngine.php
@@ -102,11 +102,6 @@ class QueryBuilderEngine extends BaseEngine
             $myQuery->select($this->connection->raw("'1' as {$row_count}"));
         }
 
-        // check for select soft deleted records
-        if (! $this->withTrashed && $this->modelUseSoftDeletes()) {
-            $myQuery->whereNull($myQuery->getModel()->getQualifiedDeletedAtColumn());
-        }
-
         return $this->connection->table($this->connection->raw('(' . $myQuery->toSql() . ') count_row_table'))
                                 ->setBindings($myQuery->getBindings())->count();
     }
@@ -120,20 +115,6 @@ class QueryBuilderEngine extends BaseEngine
     protected function wrap($column)
     {
         return $this->connection->getQueryGrammar()->wrap($column);
-    }
-
-    /**
-     * Check if model use SoftDeletes trait
-     *
-     * @return boolean
-     */
-    private function modelUseSoftDeletes()
-    {
-        if ($this->query_type == 'eloquent') {
-            return in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses($this->query->getModel()));
-        }
-
-        return false;
     }
 
     /**


### PR DESCRIPTION
- Add support for onlyTrashed model scope. Fix #928
- Move withTrashed method to Eloquent engine.

### Usage

```php
$shops = Shop::select('shops.*')->onlyTrashed();        

return Datatables::of($shops)->onlyTrashed()->make(true);
```