### PR TITLE
[7.0] Add support for 'where' in the relationship

### DIFF
--- a/src/Engines/QueryBuilderEngine.php
+++ b/src/Engines/QueryBuilderEngine.php
@@ -341,7 +341,7 @@ class QueryBuilderEngine extends BaseEngine
                 $relationMethod = "whereRaw";
             }
 
-            //owerwrite the first element of the binding - we expect the keyword to be located there
+            //overwrite the first element of the binding - we expect the keyword to be located there
             $bindings[0]  = $this->prepareKeyword($keyword);
             
             if ($relationType instanceof MorphToMany) {

--- a/src/Engines/QueryBuilderEngine.php
+++ b/src/Engines/QueryBuilderEngine.php
@@ -329,6 +329,7 @@ class QueryBuilderEngine extends BaseEngine
             $builder      = $chunk['builder'];
             $relationType = $chunk['relationType'];
             $query        = $chunk['query'];
+            $bindings     = $builder->getBindings();
             $builder      = "({$builder->toSql()}) >= 1";
 
             // Check if it last relation we will use orWhereRaw
@@ -340,10 +341,13 @@ class QueryBuilderEngine extends BaseEngine
                 $relationMethod = "whereRaw";
             }
 
+            //owerwrite the first element of the binding - we expect the keyword to be located there
+            $bindings[0]  = $this->prepareKeyword($keyword);
+            
             if ($relationType instanceof MorphToMany) {
                 $query->{$relationMethod}($builder, [$relationType->getMorphClass(), $this->prepareKeyword($keyword)]);
             } else {
-                $query->{$relationMethod}($builder, [$this->prepareKeyword($keyword)]);
+                $query->{$relationMethod}($builder, $bindings);
             }
         }
     }


### PR DESCRIPTION
Pull the existing bindings from the builder and prepare the first element based on our configuration. Doing so we also pull any extra bindings that the builder has.

Dow now this was tested ONLY with relationships similar to:

```php
        return $this->hasOne('App\FieldOption', 'sort_order', 'service')
            ->where('group_id', '=', '1');
```

