### PR TITLE
Adding Multiple Table Rendering Feature

### DIFF
--- a/src/Datatables.php
+++ b/src/Datatables.php
@@ -105,6 +105,48 @@ class Datatables
     }
 
     /**
+     * Process dataTables needed render output.
+     *
+     * @param array $tables
+     * @param string $view
+     * @param array $data
+     * @param array $mergeData
+     * @return \Illuminate\Http\JsonResponse|\Illuminate\View\View
+     */
+    public function renderMultiple(array $tables, $view, $data = [], $mergeData = [])
+    {
+        $tableId = $this->request->input('tableId');
+
+        if ($this->request->ajax() && $this->request->wantsJson()) {
+            return $this->getTableFromId($tables, $tableId)->ajax();
+        }
+
+        $action = $this->request->get('action');
+
+        if (in_array($action, ['print', 'csv', 'excel', 'pdf'])) {
+            if ($action == 'print') {
+                return $this->getTableFromId($tables, $tableId)->printPreview();
+            }
+
+            return call_user_func_array([$this->getTableFromId($tables, $tableId), $action], []);
+        }
+
+        $tables = array_map(function($table) {;
+            return $table->html();
+        }, $tables);
+
+        return view($view, $data, $mergeData)->with($tables);
+    }
+
+    private function getTableFromId($tables, $tableId)
+    {
+        if (!array_key_exists($tableId, $tables)) {
+            throw new \Exception("Table {$tableId} is not defined in multiple renderer.");
+        }
+        return $tables[$tableId];
+    }
+
+    /**
      * Get html builder instance.
      *
      * @return \Yajra\Datatables\Html\Builder

--- a/src/Datatables.php
+++ b/src/Datatables.php
@@ -131,13 +131,21 @@ class Datatables
             return call_user_func_array([$this->getTableFromId($tables, $tableId), $action], []);
         }
 
-        $tables = array_map(function($table) {;
+        $tables = array_map(function($table) {
+            if (!$table->hasCustomId()) {
+                $table->setId($this->createCustomIdFor($table));
+            }
             return $table->html();
         }, $tables);
 
         return view($view, $data, $mergeData)->with($tables);
     }
 
+    private function createCustomIdFor($table)
+    {
+        return (new \ReflectionClass($table))->getShortName();
+    }
+    
     private function getTableFromId($tables, $tableId)
     {
         if (!array_key_exists($tableId, $tables)) {

--- a/src/Datatables.php
+++ b/src/Datatables.php
@@ -143,7 +143,7 @@ class Datatables
 
     private function createCustomIdFor($table)
     {
-        return (new \ReflectionClass($table))->getShortName();
+        return camel_case((new \ReflectionClass($table))->getShortName());
     }
     
     private function getTableFromId($tables, $tableId)


### PR DESCRIPTION
Hi, I added support for rendering 2 tables in a single page.

The idea was pretty simple. 

I had 2 tables in `/users`, `ActiveUsersDataTable` and `InactiveUsersDataTable`.

- I added and `id` field to use in html part of the datatable so that the ids won't conflict.
- I added `?tableId=TableID` to each request so that we can define which table we're querying with the ajax request to the backend.
- I edited the `server-side.buttons.js` to allow urls with a query parameter.
