### PR TITLE
[7.0] Remove HtmlServiceProvider which is not being used.

### DIFF
--- a/src/DatatablesServiceProvider.php
+++ b/src/DatatablesServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Yajra\Datatables;
 
-use Collective\Html\HtmlServiceProvider;
 use Illuminate\Support\ServiceProvider;
 use League\Fractal\Manager;
 use League\Fractal\Serializer\DataArraySerializer;


### PR DESCRIPTION
Correct me if I'm missing something but this is not needed and used here as you already moved the HTML builder as an another plugin where you also register it [there](https://github.com/yajra/laravel-datatables-html/blob/master/src/HtmlServiceProvider.php#L52).