### PR TITLE
[6.0] Formatting the attributes for Editor buttons.

### DIFF
--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -261,12 +261,15 @@ class Builder
 	protected function encodeEditorButtons(array $parameters)
 	{
 		$editorButtons = [];
-		foreach ($parameters['buttons'] as $i => $button) {
-			if (isset($button['editor'])) {
-				$editorButtons[$i] = $this->compileCallback($button['editor']);
-				$parameters['buttons'][$i]['editor']        = "#editor_button.{$i}#";
+		if (isset($parameters['buttons'])) {
+			foreach ($parameters['buttons'] as $i => $button) {
+				if (isset($button['editor'])) {
+					$editorButtons[$i] = $this->compileCallback($button['editor']);
+					$parameters['buttons'][$i]['editor']        = "#editor_button.{$i}#";
+				}
 			}
 		}
+
 
 		return [$editorButtons, $parameters];
 	}

--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -188,6 +188,12 @@ class Builder
         $json = $this->decodeColumnFunctions($columnFunctions, $json);
         $json = $this->decodeCallbackFunctions($callbackFunctions, $json);
 
+        /* 
+         * Formatting the attributes for Editor buttons. json_encode wraps the key and value both in double qoutes,
+         * remove the additional quotes around "editor" string
+         */
+        $json = preg_replace('/"(editor)"/','$1',$json);
+        
         return $json;
     }
 

--- a/src/Html/Builder.php
+++ b/src/Html/Builder.php
@@ -179,6 +179,7 @@ class Builder
         list($ajaxDataFunction, $parameters) = $this->encodeAjaxDataFunction($parameters);
         list($columnFunctions, $parameters) = $this->encodeColumnFunctions($parameters);
         list($callbackFunctions, $parameters) = $this->encodeCallbackFunctions($parameters);
+        list($editorButtons, $parameters) = $this->encodeEditorButtons($parameters);
 
         $json = json_encode($parameters);
 
@@ -187,12 +188,7 @@ class Builder
         $json = $this->decodeAjaxDataFunction($ajaxDataFunction, $json);
         $json = $this->decodeColumnFunctions($columnFunctions, $json);
         $json = $this->decodeCallbackFunctions($callbackFunctions, $json);
-
-        /* 
-         * Formatting the attributes for Editor buttons. json_encode wraps the key and value both in double qoutes,
-         * remove the additional quotes around "editor" string
-         */
-        $json = preg_replace('/"(editor)"/','$1',$json);
+        $json = $this->decodeEditorButtons($editorButtons, $json);
         
         return $json;
     }
@@ -255,6 +251,25 @@ class Builder
 
         return [$callbackFunctions, $parameters];
     }
+    
+    /**
+	 * Encode DataTables editor buttons.
+	 *
+	 * @param array $parameters
+	 * @return array
+	 */
+	protected function encodeEditorButtons(array $parameters)
+	{
+		$editorButtons = [];
+		foreach ($parameters['buttons'] as $i => $button) {
+			if (isset($button['editor'])) {
+				$editorButtons[$i] = $this->compileCallback($button['editor']);
+				$parameters['buttons'][$i]['editor']        = "#editor_button.{$i}#";
+			}
+		}
+
+		return [$editorButtons, $parameters];
+	}
 
     /**
      * Compile DataTable callback value.
@@ -312,6 +327,22 @@ class Builder
     {
         foreach ($callbackFunctions as $i => $function) {
             $json = str_replace("\"#callback_function.{$i}#\"", $function, $json);
+        }
+
+        return $json;
+    }
+    
+    /**
+     * Decode DataTables Editor buttons.
+     *
+     * @param array $editorButtons
+     * @param string $json
+     * @return string
+     */
+    protected function decodeEditorButtons(array $editorButtons, $json)
+    {
+        foreach ($editorButtons as $i => $function) {
+            $json = str_replace("\"#editor_button.{$i}#\"", $function, $json);
         }
 
         return $json;


### PR DESCRIPTION
The Editor buttons used for Datatables Editor when added to attribute list generates Javascript JSON code that has editor variable wrapped around with double quotes. which is treated as string in javascript instead of variable. This code change removes additionally added double quotes.

For more detailed information you can look at issue "Adding Editor buttons" #1095 
