### PR TITLE
[7.0] Add server-side error handler.

### DIFF
--- a/src/Engines/BaseEngine.php
+++ b/src/Engines/BaseEngine.php
@@ -517,7 +517,7 @@ abstract class BaseEngine implements DataTableEngineContract
 
             return new JsonResponse([
                 'draw'            => (int) $this->request->input('draw'),
-                'recordsTotal'    => 0,
+                'recordsTotal'    => (int) $this->totalRecords,
                 'recordsFiltered' => 0,
                 'data'            => [],
                 'error'           => $defaultError ? __($defaultError) : $exception->getMessage(),

--- a/src/Engines/BaseEngine.php
+++ b/src/Engines/BaseEngine.php
@@ -516,17 +516,19 @@ abstract class BaseEngine implements DataTableEngineContract
 
             return $this->render($mDataSupport);
         } catch (\Exception $exception) {
-            $log = new Exception($exception->getMessage(), $exception->getCode());
-            $this->getLogger()->error($log);
+            $error = config('datatables.error');
+            if ($error === 'throw') {
+                throw new Exception($exception->getMessage(), $code = 0, $exception);
+            }
 
-            $defaultError = config('datatables.error');
+            $this->getLogger()->error($exception);
 
             return new JsonResponse([
                 'draw'            => (int) $this->request->input('draw'),
                 'recordsTotal'    => (int) $this->totalRecords,
                 'recordsFiltered' => 0,
                 'data'            => [],
-                'error'           => $defaultError ? __($defaultError) : "Exception Message:\n\n" . $log->getMessage(),
+                'error'           => $error ? __($error) : "Exception Message:\n\n" . $exception->getMessage(),
             ]);
         }
     }

--- a/src/Engines/BaseEngine.php
+++ b/src/Engines/BaseEngine.php
@@ -6,6 +6,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Str;
 use League\Fractal\Resource\Collection;
 use Yajra\Datatables\Contracts\DataTableEngineContract;
+use Yajra\Datatables\Exception;
 use Yajra\Datatables\Helper;
 use Yajra\Datatables\Processors\DataProcessor;
 
@@ -510,7 +511,7 @@ abstract class BaseEngine implements DataTableEngineContract
             return $this->render($mDataSupport);
         } catch (\Exception $exception) {
             if ($this->isDebugging()) {
-                throw $exception;
+                throw new Exception($exception->getMessage(), $exception->getCode());
             }
 
             $defaultError = config('datatables.error');

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Yajra\Datatables;
+
+class Exception extends \Exception
+{
+}

--- a/src/config/datatables.php
+++ b/src/config/datatables.php
@@ -77,6 +77,6 @@ return [
      * 'throw'          - Throws a \Yajra\Datatables\Exception. You can then use your custom error handler if needed.
      * 'custom message' - Any friendly message to be displayed to the user. You can also use translation key.
      */
-    'error'          => null,
+    'error'          => env('DATATABLES_ERROR', null),
 
 ];

--- a/src/config/datatables.php
+++ b/src/config/datatables.php
@@ -72,8 +72,11 @@ return [
 
     /**
      * User friendly message to be displayed on user if error occurs.
-     * If set to null, the exception message will be used.
-     * Note: You can also use translation key.
+     * Possible values:
+     * null             - The exception message will be used on error response.
+     * 'throw'          - Throws a \Yajra\Datatables\Exception. You can then use your custom error handler if needed.
+     * 'custom message' - Any friendly message to be displayed to the user. You can also use translation key.
      */
-    'error' => null
+    'error'          => 'throw',
+
 ];

--- a/src/config/datatables.php
+++ b/src/config/datatables.php
@@ -77,6 +77,6 @@ return [
      * 'throw'          - Throws a \Yajra\Datatables\Exception. You can then use your custom error handler if needed.
      * 'custom message' - Any friendly message to be displayed to the user. You can also use translation key.
      */
-    'error'          => 'throw',
+    'error'          => null,
 
 ];

--- a/src/config/datatables.php
+++ b/src/config/datatables.php
@@ -69,4 +69,11 @@ return [
      * For MySQL, use '-%s %s'
      */
     'nulls_last_sql' => '%s %s NULLS LAST',
+
+    /**
+     * User friendly message to be displayed on user if error occurs.
+     * If set to null, the exception message will be used.
+     * Note: You can also use translation key.
+     */
+    'error' => null
 ];


### PR DESCRIPTION
* When app is in production, it is better to display a custom error message to the user.

* Implements server-side error handling as defined on https://datatables.net/manual/server-side.

> Optional: If an error occurs during the running of the server-side processing script, you can inform the user of this error by passing back the error message to be displayed using this parameter. Do not include if there is no error.

* Add dataTables exception class.