### PR TITLE
[7.0] Do not use ::class to avoid IDE error when fractal is not installed.

### DIFF
--- a/src/config/datatables.php
+++ b/src/config/datatables.php
@@ -41,7 +41,7 @@ return [
         /**
          * Default fractal serializer.
          */
-        'serializer' => League\Fractal\Serializer\DataArraySerializer::class,
+        'serializer' => 'League\Fractal\Serializer\DataArraySerializer',
     ],
 
     /**


### PR DESCRIPTION
Do not use ::class to avoid IDE error when fractal is not installed.