### PR TITLE
[7.0] Fix column name added when relation is belongsToMany.

### DIFF
--- a/src/Engines/QueryBuilderEngine.php
+++ b/src/Engines/QueryBuilderEngine.php
@@ -561,7 +561,7 @@ class QueryBuilderEngine extends BaseEngine
                     $foreign = $pivot . '.' . $tablePK;
                     $other   = $related->getQualifiedKeyName();
 
-                    $lastQuery->addSelect($table . '.' . $eachRelation);
+                    $lastQuery->addSelect($table . '.' . $relationColumn);
                     $this->performJoin($table, $foreign, $other);
 
                     break;


### PR DESCRIPTION
Fix #1094
