### PR TITLE
[7.0] Remove empty array. Fix #1160

### DIFF
--- a/src/Processors/DataProcessor.php
+++ b/src/Processors/DataProcessor.php
@@ -235,7 +235,7 @@ class DataProcessor
      */
     protected function escapeRow(array $row)
     {
-        $arrayDot = array_dot($row);
+        $arrayDot = array_filter(array_dot($row));
         foreach ($arrayDot as $key => $value) {
             if (! in_array($key, $this->rawColumns)) {
                 $arrayDot[$key] = e($value);


### PR DESCRIPTION
Remove array when escaping values.

Fix `htmlspecialchars() expects parameter 1 to be string, array given`.