### PR TITLE
[7.0] Use full keyword value on filterColumn api.

### DIFF
--- a/src/Engines/QueryBuilderEngine.php
+++ b/src/Engines/QueryBuilderEngine.php
@@ -180,7 +180,7 @@ class QueryBuilderEngine extends BaseEngine
 
                         if ($columnDef['method'] instanceof Closure) {
                             $whereQuery = $queryBuilder->newQuery();
-                            call_user_func_array($columnDef['method'], [$whereQuery, $keyword]);
+                            call_user_func_array($columnDef['method'], [$whereQuery, $this->request->keyword()]);
                             $queryBuilder->addNestedWhereQuery($whereQuery, 'or');
                         } else {
                             $this->compileColumnQuery(
@@ -188,7 +188,7 @@ class QueryBuilderEngine extends BaseEngine
                                 Helper::getOrMethod($columnDef['method']),
                                 $columnDef['parameters'],
                                 $columnName,
-                                $keyword
+                                $this->request->keyword()
                             );
                         }
                     } else {


### PR DESCRIPTION
# WIP

- Use full keyword value on filterColumn api.

## TODO
- Do not include filterColumn on multi-term searching to lessen the query length.