### PR TITLE
[7.0] Add config for setting the default JsonResponse header and options.

### DIFF
--- a/src/Engines/BaseEngine.php
+++ b/src/Engines/BaseEngine.php
@@ -624,7 +624,7 @@ abstract class BaseEngine implements DataTableEngineContract
             $output = $this->showDebugger($output);
         }
 
-        return new JsonResponse($output);
+        return new JsonResponse($output, 200, config('datatables.json.header', []), config('datatables.json.options', 0));
     }
 
     /**

--- a/src/config/datatables.php
+++ b/src/config/datatables.php
@@ -79,4 +79,12 @@ return [
      */
     'error'          => env('DATATABLES_ERROR', null),
 
+    /**
+     * JsonResponse header and options config.
+     */
+    'json'           => [
+        'header'  => [],
+        'options' => 0,
+    ],
+
 ];


### PR DESCRIPTION
- Add support for unescaped unicode in response
- Fix #1034
