### PR TITLE
[7.0] The global search keywords should not be an array

### DIFF
--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -193,9 +193,9 @@ class CollectionEngine extends BaseEngine
                         continue;
                     }
                     
-                    if (!is_string($value)) {
-						continue;
-					}
+                    if (is_array($value)) {
+                        continue;
+                    }
                     
                     if ($this->isCaseInsensitive()) {
                         $value = Str::lower($value);

--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -192,7 +192,11 @@ class CollectionEngine extends BaseEngine
                     if (! $value = Arr::get($data, $column)) {
                         continue;
                     }
-
+                    
+                    if (!is_string($value)) {
+						continue;
+					}
+                    
                     if ($this->isCaseInsensitive()) {
                         $value = Str::lower($value);
                     }


### PR DESCRIPTION
The Str::lower($value) can not accept array, but sometimes we get array from the client, then exception occurs like:

"error":"Exception Message:\n\nmb_strtolower() expects parameter 1 to be string, array given"