### PR TITLE
[7.0] Fix transformer implementation when parameter requires an object.

### DIFF
--- a/src/Engines/BaseEngine.php
+++ b/src/Engines/BaseEngine.php
@@ -577,7 +577,7 @@ abstract class BaseEngine implements DataTableEngineContract
         //If parameter is class assuming it requires object
         //Else just pass array by default
         if ($parameter->getClass()) {
-            $resource = new Collection($output, $this->createTransformer());
+            $resource = new Collection($this->results(), $this->createTransformer());
         } else {
             $resource = new Collection(
                 $output,


### PR DESCRIPTION
Type error: Argument 1 passed to App\Transformers\UserTransformer::transform() must be an instance of App\User, array given