### PR TITLE
[7.0] Use static class to resolve datatables instance.

### DIFF
--- a/src/Datatables.php
+++ b/src/Datatables.php
@@ -45,7 +45,7 @@ class Datatables
      */
     public static function of($source)
     {
-        $datatables = app('datatables');
+        $datatables = app(static::class);
         $config     = app('config');
         $engines    = $config->get('datatables.engines');
         $builders   = $config->get('datatables.builders');


### PR DESCRIPTION
Re-apply fix for #464, #465.
