### PR TITLE
[7.0] Whitelisting src directory in phpunit.xml

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,7 +16,7 @@
         </testsuite>
     </testsuites>
     <filter>
-	<whitelist processUncoveredFilesFromWhitelist="yes">
+	    <whitelist processUncoveredFilesFromWhitelist="yes">
     		<directory suffix=".php">./src</directory>
         </whitelist>
         <blacklist>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,6 +16,9 @@
         </testsuite>
     </testsuites>
     <filter>
+	<whitelist processUncoveredFilesFromWhitelist="yes">
+    		<directory suffix=".php">./src</directory>
+        </whitelist>
         <blacklist>
             <directory suffix=".php">./vendor</directory>
         </blacklist>


### PR DESCRIPTION
Hello,

i'm whitelisting src directory in phpunit.xml, because phpunit fails to execute code coverage without it.
i think we should do this on master has well.

thanks.