### PR TITLE
[7.0] Fix escapeColumns bug.

### DIFF
--- a/src/Processors/DataProcessor.php
+++ b/src/Processors/DataProcessor.php
@@ -217,7 +217,7 @@ class DataProcessor
             if ($this->escapeColumns == '*') {
                 $row = $this->escapeRow($row);
             } elseif (is_array($this->escapeColumns)) {
-                $columns = array_diff_key($this->escapeColumns, $this->rawColumns);
+                $columns = array_diff($this->escapeColumns, $this->rawColumns);
                 foreach ($columns as $key) {
                     array_set($row, $key, e(array_get($row, $key)));
                 }


### PR DESCRIPTION
Hello,

i'm think this is a bug and not intended.
there is an array_diff_key inside escapeColumns in DataProcessor, but it should be an array_diff i think, because it's the value that matter.

it may be related to https://github.com/yajra/laravel-datatables/issues/1305 and https://github.com/yajra/laravel-datatables/issues/1302

tests are not passing, because they test the old behaviour, so if this gets merged we will need to change the tests.

thanks