### PR TITLE
[7.0] Patch configuration override issue.

### DIFF
--- a/src/Engines/BaseEngine.php
+++ b/src/Engines/BaseEngine.php
@@ -247,7 +247,7 @@ abstract class BaseEngine implements DataTableEngineContract
     public function removeColumn()
     {
         $names                     = func_get_args();
-        $this->columnDef['excess'] = array_merge($this->columnDef['excess'], $names);
+        $this->columnDef['excess'] = array_merge($this->getColumnsDefinition()['excess'], $names);
 
         return $this;
     }
@@ -925,7 +925,7 @@ abstract class BaseEngine implements DataTableEngineContract
     public function pushToBlacklist($column)
     {
         if (! $this->isBlacklisted($column)) {
-            array_push($this->columnDef['blacklist'], $column);
+            $this->columnDef['blacklist'][] = $column;
         }
 
         return $this;
@@ -939,11 +939,13 @@ abstract class BaseEngine implements DataTableEngineContract
      */
     protected function isBlacklisted($column)
     {
-        if (in_array($column, $this->columnDef['blacklist'])) {
+        $colDef = $this->getColumnsDefinition();
+
+        if (in_array($column, $colDef['blacklist'])) {
             return true;
         }
 
-        if ($this->columnDef['whitelist'] === '*' || in_array($column, $this->columnDef['whitelist'])) {
+        if ($colDef['whitelist'] === '*' || in_array($column, $colDef['whitelist'])) {
             return false;
         }
 

--- a/src/Engines/BaseEngine.php
+++ b/src/Engines/BaseEngine.php
@@ -68,13 +68,8 @@ abstract class BaseEngine implements DataTableEngineContract
         'index'     => false,
         'append'    => [],
         'edit'      => [],
-        'excess'    => ['rn', 'row_num'],
         'filter'    => [],
         'order'     => [],
-        'escape'    => '*',
-        'raw'       => ['action'],
-        'blacklist' => ['password', 'remember_token'],
-        'whitelist' => '*',
     ];
 
     /**


### PR DESCRIPTION
This PR will:

1. Remove default settings that were extracted to config.
2. Fix merging of default config.
3. Fix config override issue #1293.

NOTE:
Users using the old config file may have to force publish the asset.
`php artisan vendor:publish --tag=datatables --force`