### PR TITLE
[6.0] Return true for true, true(string) and 1 in isColumnSearchable method

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -119,10 +119,10 @@ class Request extends IlluminateRequest
     public function isColumnSearchable($i, $column_search = true)
     {
         if ($column_search) {
-            return $this->input("columns.$i.searchable") === 'true' && $this->columnKeyword($i) != '';
+            return in_array($this->input("columns.$i.searchable"), [true, 'true', 1]) && $this->columnKeyword($i) != '';
         }
 
-        return $this->input("columns.$i.searchable") === 'true';
+        return in_array($this->input("columns.$i.searchable"), [true, 'true', 1]);
     }
 
     /**

--- a/src/Request.php
+++ b/src/Request.php
@@ -119,10 +119,10 @@ class Request extends IlluminateRequest
     public function isColumnSearchable($i, $column_search = true)
     {
         if ($column_search) {
-            return in_array($this->input("columns.$i.searchable"), [true, 'true', 1]) && $this->columnKeyword($i) != '';
+            return filter_var($this->input("columns.$i.searchable"), FILTER_VALIDATE_BOOLEAN) && $this->columnKeyword($i) != '';
         }
 
-        return in_array($this->input("columns.$i.searchable"), [true, 'true', 1]);
+        return filter_var($this->input("columns.$i.searchable"), FILTER_VALIDATE_BOOLEAN);
     }
 
     /**

--- a/tests/CollectionEngineTest.php
+++ b/tests/CollectionEngineTest.php
@@ -17,7 +17,7 @@ class TestDatatablesCollectionEngine extends PHPUnit_Framework_TestCase
         $app->shouldReceive('instance')->once()->andReturn($app);
 
         Illuminate\Support\Facades\Facade::setFacadeApplication($app);
-        Config::swap($config = m::mock('ConfigMock'));
+        Config::swap(new \Illuminate\Config\Repository);
     }
 
     public function tearDown()
@@ -59,7 +59,6 @@ class TestDatatablesCollectionEngine extends PHPUnit_Framework_TestCase
 
     protected function setupBuilder()
     {
-        Config::shouldReceive('get');
         $data = [
             ['id' => 1, 'name' => 'foo'],
             ['id' => 2, 'name' => 'bar'],

--- a/tests/QueryBuilderEngineTest.php
+++ b/tests/QueryBuilderEngineTest.php
@@ -17,7 +17,7 @@ class TestDatatablesQueryBuilderEngine extends PHPUnit_Framework_TestCase
         $app->shouldReceive('instance')->once()->andReturn($app);
 
         Illuminate\Support\Facades\Facade::setFacadeApplication($app);
-        Config::swap($config = m::mock('ConfigMock'));
+        Config::swap(new \Illuminate\Config\Repository);
     }
 
     public function tearDown()
@@ -76,8 +76,6 @@ class TestDatatablesQueryBuilderEngine extends PHPUnit_Framework_TestCase
 
     protected function setupBuilder($showAllRecords = false)
     {
-        Config::shouldReceive('get');
-
         $cache   = m::mock('stdClass');
         $driver  = m::mock('stdClass');
         $data    = [


### PR DESCRIPTION
Validate the key `searchable` in request input against all possible true values `[true, 'true', 1]`