### PR TITLE
[8.0] Add addColumns() to EloquentDataTable.

### DIFF
--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -29,6 +29,28 @@ class EloquentDataTable extends QueryDataTable
     }
 
     /**
+     * Add columns in collection.
+     *
+     * @param  array  $names
+     * @param  bool|int  $order
+     * @return $this
+     */
+    public function addColumns(array $names, $order = false)
+    {
+        foreach ($names as $name => $attribute) {
+            if (is_int($name)) {
+                $name = $attribute;
+            }
+
+            $this->addColumn($name, function ($model) use ($attribute) {
+                return $model->getAttribute($attribute);
+            }, is_int($order) ? $order++ : $order);
+        }
+
+        return $this;
+    }
+
+    /**
      * If column name could not be resolved then use primary key.
      *
      * @return string


### PR DESCRIPTION
It is useful when you want to add many invisible attributes.

```php
$dataTable->addColumns(['foo', 'a' => 'b'], 3);
```

equals:

```php
$dataTable->addColumn('foo', function ($model) {
    return $model->foo;
}, 3);

$dataTable->addColumn('a', function ($model) {
    return $model->b;
}, 4);
```