### PR TITLE
[8.0] Fix merging config

### DIFF
--- a/src/DataTablesServiceProvider.php
+++ b/src/DataTablesServiceProvider.php
@@ -16,20 +16,6 @@ class DataTablesServiceProvider extends ServiceProvider
     protected $defer = false;
 
     /**
-     * Bootstrap the application events.
-     *
-     * @return void
-     */
-    public function boot()
-    {
-        $this->mergeConfigFrom(__DIR__ . '/config/datatables.php', 'datatables');
-
-        $this->publishes([
-            __DIR__ . '/config/datatables.php' => config_path('datatables.php'),
-        ], 'datatables');
-    }
-
-    /**
      * Register the service provider.
      *
      * @return void
@@ -39,6 +25,8 @@ class DataTablesServiceProvider extends ServiceProvider
         if ($this->isLumen()) {
             require_once 'lumen.php';
         }
+
+        $this->setupAssets();
 
         $this->app->alias('datatables', DataTables::class);
         $this->app->singleton('datatables', function () {
@@ -50,6 +38,20 @@ class DataTablesServiceProvider extends ServiceProvider
         });
 
         $this->app->singleton('datatables.config', Config::class);
+    }
+
+    /**
+     * Setup package assets.
+     *
+     * @return void
+     */
+    protected function setupAssets()
+    {
+        $this->mergeConfigFrom($config = __DIR__ . '/config/datatables.php', 'datatables');
+
+        if ($this->app->runningInConsole()) {
+            $this->publishes([$config => config_path('datatables.php')], 'datatables');
+        }
     }
 
     /**


### PR DESCRIPTION
`mergeConfigFrom` should be called in the `register` method, it means once the package being registered, its config are ready to use. Then other services can access them safely without caring about the order of application services bootstrap.

This is also mentioned in the [official documentation](https://laravel.com/docs/5.5/packages#configuration):
> To merge the configurations, use the mergeConfigFrom method within your service provider's register method.

`publishes` is useful only in the console application, and in the console application all services will be booted, so it does not matter putting `publishes` whether in `register` or `boot` method. Some core services also put it in `register` to make code organized, such as `MailServiceProvider::registerMarkdownRenderer`.