### PR TITLE
[8.0] Remove unused provides() from service provider.

### DIFF
--- a/src/DataTablesServiceProvider.php
+++ b/src/DataTablesServiceProvider.php
@@ -9,13 +9,6 @@ use Yajra\DataTables\Utilities\Request;
 class DataTablesServiceProvider extends ServiceProvider
 {
     /**
-     * Indicates if loading of the provider is deferred.
-     *
-     * @var bool
-     */
-    protected $defer = false;
-
-    /**
      * Bootstrap the application events.
      *
      * @return void
@@ -60,19 +53,5 @@ class DataTablesServiceProvider extends ServiceProvider
     protected function isLumen()
     {
         return str_contains($this->app->version(), 'Lumen');
-    }
-
-    /**
-     * Get the services provided by the provider.
-     *
-     * @return string[]
-     */
-    public function provides()
-    {
-        return [
-            'datatables',
-            'datatables.config',
-            'datatables.request',
-        ];
     }
 }


### PR DESCRIPTION
The default value of `$defer` is `false`, and this behavior will not be changed ever, so we don't need to override it.

And the `provides()` method is useless for a service provider which is not deferred.
