### PR TITLE
[8.0] Fix return type

### DIFF
--- a/src/DataTablesServiceProvider.php
+++ b/src/DataTablesServiceProvider.php
@@ -67,7 +67,7 @@ class DataTablesServiceProvider extends ServiceProvider
     /**
      * Get the services provided by the provider.
      *
-     * @return string[]
+     * @return array
      */
     public function provides()
     {


### PR DESCRIPTION
Fix return type in `provides` function at `DataTablesServiceProvider`