### PR TITLE
[8.0] Make wildcard string a function parameter.

### DIFF
--- a/src/Utilities/Helper.php
+++ b/src/Utilities/Helper.php
@@ -280,12 +280,25 @@ class Helper
      */
     public static function wildcardLikeString($str, $lowercase = true)
     {
-        $wild  = '%';
+        return static::wildcardString($str, '%', $lowercase);
+    }
+
+    /**
+     * Adds wildcards to the given string.
+     *
+     * @param string $str
+     * @param string $wildcard
+     * @param bool   $lowercase
+     * @return string
+     */
+    public static function wildcardString($str, $wildcard, $lowercase = true)
+    {
+        $wild = $wildcard;
         $chars = preg_split('//u', $str, -1, PREG_SPLIT_NO_EMPTY);
 
         if (count($chars) > 0) {
             foreach ($chars as $char) {
-                $wild .= $char . '%';
+                $wild .= $char . $wildcard;
             }
         }
 

--- a/tests/Unit/HelperTest.php
+++ b/tests/Unit/HelperTest.php
@@ -247,4 +247,22 @@ class HelperTest extends TestCase
         $result  = Helper::replacePatternWithKeyword($subject, $keyword, '$1');
         $this->assertEquals(['foo in ?', ['bar']], $result);
     }
+
+    public function test_wildcard_like_string()
+    {
+        $str = 'keyword';
+
+        $keyword = Helper::wildcardLikeString($str);
+
+        $this->assertEquals('%k%e%y%w%o%r%d%', $keyword);
+    }
+
+    public function test_wildcard_string()
+    {
+        $str = 'Keyword';
+
+        $keyword = Helper::wildcardString($str, '.*', true);
+
+        $this->assertEquals('.*k.*e.*y.*w.*o.*r.*d.*', $keyword);
+    }
 }


### PR DESCRIPTION
This PR adds a `wildcardString` method so you can configure the wildcard string. The `wildcardLikeString` method can be used for SQL type queries, but for other plugins a different wildcard then `%` is required.