### PR TITLE
[8.0] Fix exception/warning for PHP 7.2.

### DIFF
--- a/src/CollectionDataTable.php
+++ b/src/CollectionDataTable.php
@@ -65,7 +65,7 @@ class CollectionDataTable extends DataTableAbstract
      */
     public function columnSearch()
     {
-        $columns = $this->request->get('columns') ?: [];
+        $columns = $this->request->get('columns', []);
         for ($i = 0, $c = count($columns); $i < $c; $i++) {
             if ($this->request->isColumnSearchable($i)) {
                 $this->isFilterApplied = true;

--- a/src/CollectionDataTable.php
+++ b/src/CollectionDataTable.php
@@ -65,7 +65,7 @@ class CollectionDataTable extends DataTableAbstract
      */
     public function columnSearch()
     {
-        $columns = $this->request->get('columns');
+        $columns = $this->request->get('columns') ?: [];
         for ($i = 0, $c = count($columns); $i < $c; $i++) {
             if ($this->request->isColumnSearchable($i)) {
                 $this->isFilterApplied = true;


### PR DESCRIPTION
When you use:

`Datatables::of(User::all())->toJson()`

In PHP 7.2 you will get:

`PHP Warning:  count(): Parameter must be an array or an object that implements Countable in yajra/laravel-datatables-oracle/src/CollectionDataTable.php on line 69`

This creates an empty array if get request it's not defined so count() doesn't fail.

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
