### PR TITLE
[8.0] Fix globalSearch not working for 0.

### DIFF
--- a/src/CollectionDataTable.php
+++ b/src/CollectionDataTable.php
@@ -198,7 +198,12 @@ class CollectionDataTable extends DataTableAbstract
                 $column = $this->getColumnName($index);
                 $value  = Arr::get($data, $column);
                 if (!$value || is_array($value)) {
-                    continue;
+                    if (!is_numeric($value)) {
+                        continue;
+                    } 
+                    else {
+                        $value = (string) $value;
+                    }
                 }
 
                 $value = $this->config->isCaseInsensitive() ? Str::lower($value) : $value;


### PR DESCRIPTION
#1466 
Fixed a bug in globalSearch that prevented search results for the value 0.

