### PR TITLE
Refactor DataTables factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Styling phpdoc for facade. [#1489], credits to [@ElfSundae](https://github.com/ElfSundae).
 - Apply StyleCI fixes. [#1485], [#1483].
 - Patch docs. [#1492]
+- Add StyleCI integration. [#1484]
 
 ### [v8.3.1] - 2017-10-27
 - Fix filtered records total when using filterColumn. [#1473], credits to [@wuwx](https://github.com/wuwx).
@@ -145,6 +146,7 @@ return (new CollectionDataTable(User::all())->toJson();
 [#1489]: https://github.com/yajra/laravel-datatables/pull/1489
 [#1487]: https://github.com/yajra/laravel-datatables/pull/1487
 [#1485]: https://github.com/yajra/laravel-datatables/pull/1485
+[#1484]: https://github.com/yajra/laravel-datatables/pull/1484
 [#1483]: https://github.com/yajra/laravel-datatables/pull/1483
 [#1473]: https://github.com/yajra/laravel-datatables/pull/1473
 [#1476]: https://github.com/yajra/laravel-datatables/pull/1476

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ### [Unreleased]
 
+### [v8.3.2] - 2017-11-02
+- Fix datatables() helper and use singleton instance. [#1487], credits to [@ElfSundae](https://github.com/ElfSundae).
+- Styling phpdoc for facade. [#1489], credits to [@ElfSundae](https://github.com/ElfSundae).
+- Apply StyleCI fixes. [#1485], [#1483].
+- Patch docs. [#1492]
+
 ### [v8.3.1] - 2017-10-27
 - Fix filtered records total when using filterColumn. [#1473], credits to [@wuwx](https://github.com/wuwx).
 - Added Patreon Link. [#1476], credits to [@ChaosPower](https://github.com/ChaosPower).
@@ -123,7 +129,8 @@ return (new CollectionDataTable(User::all())->toJson();
 - Fix orderColumn api where related tables are not joined. 
 - Fix nested with relation search and sort function.
 
-[Unreleased]: https://github.com/yajra/laravel-datatables/compare/v8.3.1...8.0
+[Unreleased]: https://github.com/yajra/laravel-datatables/compare/v8.3.2...8.0
+[v8.3.2]: https://github.com/yajra/laravel-datatables/compare/v8.3.1...v8.3.2
 [v8.3.1]: https://github.com/yajra/laravel-datatables/compare/v8.3.0...v8.3.1
 [v8.3.0]: https://github.com/yajra/laravel-datatables/compare/v8.2.0...v8.3.0
 [v8.2.0]: https://github.com/yajra/laravel-datatables/compare/v8.1.1...v8.2.0
@@ -134,6 +141,11 @@ return (new CollectionDataTable(User::all())->toJson();
 [v8.0.1]: https://github.com/yajra/laravel-datatables/compare/v8.0.0...v8.0.1
 [v8.0.0]: https://github.com/yajra/laravel-datatables/compare/v7.10.1...v8.0.0
 
+[#1492]: https://github.com/yajra/laravel-datatables/pull/1492
+[#1489]: https://github.com/yajra/laravel-datatables/pull/1489
+[#1487]: https://github.com/yajra/laravel-datatables/pull/1487
+[#1485]: https://github.com/yajra/laravel-datatables/pull/1485
+[#1483]: https://github.com/yajra/laravel-datatables/pull/1483
 [#1473]: https://github.com/yajra/laravel-datatables/pull/1473
 [#1476]: https://github.com/yajra/laravel-datatables/pull/1476
 [#1478]: https://github.com/yajra/laravel-datatables/pull/1478

--- a/src/CollectionDataTable.php
+++ b/src/CollectionDataTable.php
@@ -17,50 +17,24 @@ class CollectionDataTable extends DataTableAbstract
     public $collection;
 
     /**
-     * Collection object.
+     * The original source.
      *
-     * @var \Illuminate\Support\Collection
+     * @var mixed
      */
     public $original;
 
     /**
-     * Can the DataTable engine be created with these parameters.
+     * CollectionDataTable constructor.
      *
      * @param mixed $source
-     * @return bool
      */
-    public static function canCreate($source)
-    {
-        return is_array($source) || $source instanceof Collection;
-    }
-
-    /**
-     * Factory method, create and return an instance for the DataTable engine.
-     *
-     * @param array|\Illuminate\Support\Collection $source
-     * @return CollectionDataTable|DataTableAbstract
-     */
-    public static function create($source)
-    {
-        if (is_array($source)) {
-            $source = new Collection($source);
-        }
-
-        return parent::create($source);
-    }
-
-    /**
-     * CollectionEngine constructor.
-     *
-     * @param \Illuminate\Support\Collection $collection
-     */
-    public function __construct(Collection $collection)
+    public function __construct($source)
     {
         $this->request    = app('datatables.request');
         $this->config     = app('datatables.config');
-        $this->collection = $collection;
-        $this->original   = $collection;
-        $this->columns    = array_keys($this->serialize($collection->first()));
+        $this->original   = $source;
+        $this->collection = $source instanceof Collection ? $source : new Collection($source);
+        $this->columns    = array_keys($this->serialize($this->collection->first()));
     }
 
     /**

--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -137,28 +137,6 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
     protected $config;
 
     /**
-     * Can the DataTable engine be created with these parameters.
-     *
-     * @param mixed $source
-     * @return bool
-     */
-    public static function canCreate($source)
-    {
-        return false;
-    }
-
-    /**
-     * Factory method, create and return an instance for the DataTable engine.
-     *
-     * @param mixed $source
-     * @return DataTableAbstract
-     */
-    public static function create($source)
-    {
-        return new static($source);
-    }
-
-    /**
      * Add column in collection.
      *
      * @param string          $name

--- a/src/DataTables.php
+++ b/src/DataTables.php
@@ -70,7 +70,7 @@ class DataTables
             if ($source instanceof $type) {
                 if (! isset($tmpType) || is_subclass_of($type, $tmpType)) {
                     $tmpType = $type;
-                    $result = $engine;
+                    $result  = $engine;
                 }
             }
         }

--- a/src/DataTables.php
+++ b/src/DataTables.php
@@ -3,6 +3,7 @@
 namespace Yajra\DataTables;
 
 use Exception;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 class DataTables
@@ -84,7 +85,7 @@ class DataTables
      */
     protected function createDataTable($engine, $source)
     {
-        $class = class_exists($engine) ? $engine : config("datatables.engines.$engine");
+        $class = class_exists($engine) ? $engine : Arr::get(config('datatables.engines'), $engine);
 
         if (! $class) {
             throw new Exception("Unsupported DataTable engine [$engine]");

--- a/src/DataTablesServiceProvider.php
+++ b/src/DataTablesServiceProvider.php
@@ -34,29 +34,6 @@ class DataTablesServiceProvider extends ServiceProvider
     }
 
     /**
-     * Boot the instance, add macros for datatable engines.
-     *
-     * @return void
-     */
-    public function boot()
-    {
-        $engines = config('datatables.engines');
-        foreach ($engines as $engine => $class) {
-            $engine = camel_case($engine);
-
-            if (! method_exists(DataTables::class, $engine) && ! DataTables::hasMacro($engine)) {
-                DataTables::macro($engine, function () use ($class) {
-                    if (! call_user_func_array([$class, 'canCreate'], func_get_args())) {
-                        throw new \InvalidArgumentException();
-                    }
-
-                    return call_user_func_array([$class, 'create'], func_get_args());
-                });
-            }
-        }
-    }
-
-    /**
      * Setup package assets.
      *
      * @return void

--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -4,7 +4,6 @@ namespace Yajra\DataTables;
 
 use Illuminate\Database\Eloquent\Builder;
 use Yajra\DataTables\Exceptions\Exception;
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -17,18 +16,7 @@ class EloquentDataTable extends QueryDataTable
     protected $query;
 
     /**
-     * Can the DataTable engine be created with these parameters.
-     *
-     * @param mixed $source
-     * @return bool
-     */
-    public static function canCreate($source)
-    {
-        return $source instanceof Builder || $source instanceof Relation;
-    }
-
-    /**
-     * EloquentEngine constructor.
+     * EloquentDataTable constructor.
      *
      * @param mixed $model
      */

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -46,17 +46,6 @@ class QueryDataTable extends DataTableAbstract
     protected $limitCallback;
 
     /**
-     * Can the DataTable engine be created with these parameters.
-     *
-     * @param mixed $source
-     * @return bool
-     */
-    public static function canCreate($source)
-    {
-        return $source instanceof Builder;
-    }
-
-    /**
      * @param \Illuminate\Database\Query\Builder $builder
      */
     public function __construct(Builder $builder)

--- a/src/config/datatables.php
+++ b/src/config/datatables.php
@@ -39,21 +39,25 @@ return [
      * This is where you can register your custom dataTables builder.
      */
     'engines' => [
-        'eloquent'   => \Yajra\DataTables\EloquentDataTable::class,
-        'query'      => \Yajra\DataTables\QueryDataTable::class,
-        'collection' => \Yajra\DataTables\CollectionDataTable::class,
+        'eloquent'   => Yajra\DataTables\EloquentDataTable::class,
+        'query'      => Yajra\DataTables\QueryDataTable::class,
+        'collection' => Yajra\DataTables\CollectionDataTable::class,
     ],
 
     /*
      * DataTables accepted builder to engine mapping.
-     * This is where you can override which engine a builder should use
-     * Note, only change this if you know what you are doing!
+     * This is where you can override which engine a builder should use.
      */
     'builders' => [
-        //Illuminate\Database\Eloquent\Relations\Relation::class => 'eloquent',
-        //Illuminate\Database\Eloquent\Builder::class            => 'eloquent',
-        //Illuminate\Database\Query\Builder::class               => 'query',
-        //Illuminate\Support\Collection::class                   => 'collection',
+        'eloquent' => [
+            Illuminate\Database\Eloquent\Builder::class,
+            Illuminate\Database\Eloquent\Relations\Relation::class,
+        ],
+        'query'      => Illuminate\Database\Query\Builder::class,
+        'collection' => [
+            'array',
+            Illuminate\Support\Collection::class,
+        ],
     ],
 
     /*

--- a/src/config/datatables.php
+++ b/src/config/datatables.php
@@ -53,7 +53,7 @@ return [
             Illuminate\Database\Eloquent\Builder::class,
             Illuminate\Database\Eloquent\Relations\Relation::class,
         ],
-        'query'      => Illuminate\Database\Query\Builder::class,
+        'query' => Illuminate\Database\Query\Builder::class,
         'collection' => [
             'array',
             Illuminate\Support\Collection::class,

--- a/src/config/datatables.php
+++ b/src/config/datatables.php
@@ -46,18 +46,12 @@ return [
 
     /*
      * DataTables accepted builder to engine mapping.
-     * This is where you can override which engine a builder should use.
      */
     'builders' => [
-        'eloquent' => [
-            Illuminate\Database\Eloquent\Builder::class,
-            Illuminate\Database\Eloquent\Relations\Relation::class,
-        ],
-        'query'      => Illuminate\Database\Query\Builder::class,
-        'collection' => [
-            'array',
-            Illuminate\Support\Collection::class,
-        ],
+        Illuminate\Database\Eloquent\Builder::class            => 'eloquent',
+        Illuminate\Database\Eloquent\Relations\Relation::class => 'eloquent',
+        Illuminate\Database\Query\Builder::class               => 'query',
+        Illuminate\Support\Collection::class                   => 'collection',
     ],
 
     /*

--- a/src/config/datatables.php
+++ b/src/config/datatables.php
@@ -53,7 +53,7 @@ return [
             Illuminate\Database\Eloquent\Builder::class,
             Illuminate\Database\Eloquent\Relations\Relation::class,
         ],
-        'query' => Illuminate\Database\Query\Builder::class,
+        'query'      => Illuminate\Database\Query\Builder::class,
         'collection' => [
             'array',
             Illuminate\Support\Collection::class,

--- a/tests/Integration/CollectionEngineTest.php
+++ b/tests/Integration/CollectionEngineTest.php
@@ -46,7 +46,7 @@ class CollectionEngineTest extends TestCase
     /** @test */
     public function it_accepts_a_model_collection_using_of_factory()
     {
-        $dataTable = DataTables::of(User::all());
+        $dataTable = DatatablesFacade::of(User::all());
         $response  = $dataTable->make(true);
         $this->assertInstanceOf(CollectionDataTable::class, $dataTable);
         $this->assertInstanceOf(JsonResponse::class, $response);
@@ -55,7 +55,7 @@ class CollectionEngineTest extends TestCase
     /** @test */
     public function it_accepts_a_collection_using_of_factory()
     {
-        $dataTable = DataTables::of(collect());
+        $dataTable = DatatablesFacade::of(collect());
         $response  = $dataTable->make(true);
         $this->assertInstanceOf(CollectionDataTable::class, $dataTable);
         $this->assertInstanceOf(JsonResponse::class, $response);

--- a/tests/Integration/EloquentEngineTest.php
+++ b/tests/Integration/EloquentEngineTest.php
@@ -46,7 +46,7 @@ class EloquentEngineTest extends TestCase
     /** @test */
     public function it_accepts_a_model_using_of_factory()
     {
-        $dataTable = DataTables::of(User::query());
+        $dataTable = DatatablesFacade::of(User::query());
         $response  = $dataTable->make(true);
         $this->assertInstanceOf(EloquentDataTable::class, $dataTable);
         $this->assertInstanceOf(JsonResponse::class, $response);

--- a/tests/Integration/QueryEngineTest.php
+++ b/tests/Integration/QueryEngineTest.php
@@ -65,7 +65,7 @@ class QueryEngineTest extends TestCase
     /** @test */
     public function it_accepts_a_query_using_of_factory()
     {
-        $dataTable = DataTables::of(DB::table('users'));
+        $dataTable = DatatablesFacade::of(DB::table('users'));
         $response  = $dataTable->make(true);
         $this->assertInstanceOf(QueryDataTable::class, $dataTable);
         $this->assertInstanceOf(JsonResponse::class, $response);


### PR DESCRIPTION
In this PR, I would like to refactor a clean API for the `DataTables` factory.

ref: https://github.com/yajra/laravel-datatables/pull/1462#issuecomment-340034303

- ~~[BC] Exchange key and value for the `builders` config.~~
  ~~Builders should be mapped from engines to types because the engines are unique. This change will allow configuring different engines for the same type.~~

- ~~Keys in the `builders` config can be an engine alias which defined in the `engines` config, or an engine class name.~~
  Engines in the `builders` config can be a class name now.
  ```php
  'builders' => [
      Illuminate\Database\Eloquent\Builder::class => 'eloquent',
      App\BillData => App\DataTables\BillDataTable::class,
  ],
  ```

- ~~Add support to specify any types in the `builders` config.~~
  ```php
  'builders' => [
      'image' => [
          'resource',
          'array',
          Illuminate\Support\Collection::class,
      ],
  ],
  ```

- [BC] Change static methods `of()` and `make()` in `DataTables` to instance methods. Remove `Yajra\DataTables\DataTables::of` and `Yajra\DataTables\DataTables::make` usage.
  Since the DataTables has been registered as a singleton in the container, using the ugly (original DataTables) class directly is a bad design in this situation. Think about if the user or an extended package override `make()` method, the user must replace all `DataTables::make` to `CustomDataTables::make`.
  If someone prefers to access DataTables methods using static way, the facade is the best choice.
  ```php
  \DataTables::make(...)
  \Yajra\DataTables\Facades\DataTables::instanceMethod()
  ```

- Add support to make DataTable instances using configured engines alias as `DataTables` methods.
  ```php
  'engines' => [
      'eloquent' => ...,
      'foo_bar' => ...,
  ],

  \DataTables::eloquent($data);
  datatables()->fooBar($data);
  ```

- Remove unnecessary `canCreate`, `create` interfaces for DataTable engines.
  To implement a new DataTable, just start with `__construct`.

- Remove unnecessary `Macroable` trait for the `DataTables`.
  For now, the `DataTables` is just a factory to create DataTable instances, we do not want user to add macros to make it messy. If you want to register a custom engine, just add alias to the `engines` configuration.

- Remove support of variable length parameters for `make()`.
  See https://github.com/yajra/laravel-datatables/pull/1487#issuecomment-340184553

- [TODO] Remove needless backward compatibility. @yajra
  ```php
  $request
  $html

  getRequest()
  getConfig()
  queryBuilder()
  getHtmlBuilder()
  ```

**~~Extending~~ Notes**

- The `DataTables` factory depends upon the configuration of `engines` and `builders`.
- `engines` config just acts as class aliases, like `app()->bind('eloquent', 'Yajra\DataTables\EloquentDataTable')`. Adding an engine alias is only needed if you want to use this alias as a method of `DataTables` to resolve the DataTable instances, like `datatables()->eloquent(...)`.
- `make()` automatically decides an engine class by comparing the type of given data with types defined in the `builders` config.
  ~~There may be different engines for the same type, in this case we can not autoselect in anyway, so let the user (application) decide. `make()` will use the first match.~~
  ~~If you are developing a public package that contains some DataTable engines, it is not recommended to change/set/merge user's `datatables.builders` configuration. Just document what you provide, and let user be free to use them.~~
