### PR TITLE
[6.0] Fix issue 932

### DIFF
--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -159,7 +159,15 @@ class CollectionEngine extends BaseEngine
                     }
 
                     if ($this->isCaseInsensitive()) {
-                        $found[] = Str::contains(Str::lower($value), Str::lower($keyword));
+
+                        if(is_array($value)){
+                            foreach ($value as $v) {
+                                $found[] = Str::contains(Str::lower($v), Str::lower($keyword));
+                            };
+                        } else{
+                            $found[] = Str::contains(Str::lower($value), Str::lower($keyword));
+                        }
+
                     } else {
                         $found[] = Str::contains($value, $keyword);
                     }


### PR DESCRIPTION

I added a fix to take care `mb_strtolower() expects parameter 1 to be string, array given `  error.