### PR TITLE
[8.0] Remove useless else statements.

### DIFF
--- a/src/CollectionDataTable.php
+++ b/src/CollectionDataTable.php
@@ -109,16 +109,16 @@ class CollectionDataTable extends DataTableAbstract
                         if ($this->config->isCaseInsensitive()) {
                             if ($regex) {
                                 return preg_match('/' . $keyword . '/i', $value) == 1;
-                            } else {
-                                return strpos(Str::lower($value), Str::lower($keyword)) !== false;
                             }
-                        } else {
-                            if ($regex) {
-                                return preg_match('/' . $keyword . '/', $value) == 1;
-                            } else {
-                                return strpos($value, $keyword) !== false;
-                            }
+
+                            return strpos(Str::lower($value), Str::lower($keyword)) !== false;
                         }
+
+                        if ($regex) {
+                            return preg_match('/' . $keyword . '/', $value) == 1;
+                        }
+
+                        return strpos($value, $keyword) !== false;
                     }
                 );
             }
@@ -226,9 +226,9 @@ class CollectionDataTable extends DataTableAbstract
                 if (! $value || is_array($value)) {
                     if (! is_numeric($value)) {
                         continue;
-                    } else {
-                        $value = (string) $value;
                     }
+
+                    $value = (string) $value;
                 }
 
                 $value = $this->config->isCaseInsensitive() ? Str::lower($value) : $value;

--- a/src/Utilities/Helper.php
+++ b/src/Utilities/Helper.php
@@ -19,20 +19,20 @@ class Helper
     {
         if (self::isItemOrderInvalid($item, $array)) {
             return array_merge($array, [$item['name'] => $item['content']]);
-        } else {
-            $count = 0;
-            $last  = $array;
-            $first = [];
-            foreach ($array as $key => $value) {
-                if ($count == $item['order']) {
-                    return array_merge($first, [$item['name'] => $item['content']], $last);
-                }
+        }
 
-                unset($last[$key]);
-                $first[$key] = $value;
-
-                $count++;
+        $count = 0;
+        $last  = $array;
+        $first = [];
+        foreach ($array as $key => $value) {
+            if ($count == $item['order']) {
+                return array_merge($first, [$item['name'] => $item['content']], $last);
             }
+
+            unset($last[$key]);
+            $first[$key] = $value;
+
+            $count++;
         }
     }
 
@@ -259,9 +259,9 @@ class Helper
         if (! empty($matches)) {
             if ($wantsAlias) {
                 return array_pop($matches);
-            } else {
-                return array_shift($matches);
             }
+
+            return array_shift($matches);
         } elseif (strpos($str, '.')) {
             $array = explode('.', $str);
 


### PR DESCRIPTION
I've removed the `else`s when we have already returned something :put_litter_in_its_place:

We can also enable `no_useless_else` in `StyleCI`. Should we?