### PR TITLE
Change Log contract to LoggerInterface.

### DIFF
--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -3,8 +3,8 @@
 namespace Yajra\DataTables;
 
 use Illuminate\Support\Str;
+use Psr\Log\LoggerInterface;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Contracts\Logging\Log;
 use Yajra\DataTables\Utilities\Helper;
 use Illuminate\Support\Traits\Macroable;
 use Yajra\DataTables\Contracts\DataTable;
@@ -32,7 +32,7 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
     public $request;
 
     /**
-     * @var \Illuminate\Contracts\Logging\Log
+     * @var \Psr\Log\LoggerInterface
      */
     protected $logger;
 
@@ -720,11 +720,11 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
     /**
      * Get monolog/logger instance.
      *
-     * @return \Illuminate\Contracts\Logging\Log
+     * @return \Psr\Log\LoggerInterface
      */
     public function getLogger()
     {
-        $this->logger = $this->logger ?: app(Log::class);
+        $this->logger = $this->logger ?: app(LoggerInterface::class);
 
         return $this->logger;
     }
@@ -732,10 +732,10 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
     /**
      * Set monolog/logger instance.
      *
-     * @param \Illuminate\Contracts\Logging\Log $logger
+     * @param \Psr\Log\LoggerInterface $logger
      * @return $this
      */
-    public function setLogger(Log $logger)
+    public function setLogger(LoggerInterface $logger)
     {
         $this->logger = $logger;
 


### PR DESCRIPTION
After updating to Laravel 5.6, this message is displayed on error (e.g. wrong column name):

    Class Illuminate\Contracts\Logging\Log does not exist

As described in the [upgrade guide](https://laravel.com/docs/5.6/upgrade#Logging), `Illuminate\Contracts\Logging\Log` should be changed to `Psr\Log\LoggerInterface`.