### PR TITLE
Change Log contract to LoggerInterface

### DIFF
--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -4,7 +4,7 @@ namespace Yajra\DataTables;
 
 use Illuminate\Support\Str;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Contracts\Logging\Log;
+use Psr\Log\LoggerInterface;
 use Yajra\DataTables\Utilities\Helper;
 use Illuminate\Support\Traits\Macroable;
 use Yajra\DataTables\Contracts\DataTable;
@@ -720,11 +720,11 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
     /**
      * Get monolog/logger instance.
      *
-     * @return \Illuminate\Contracts\Logging\Log
+     * @return \Psr\Log\LoggerInterface
      */
     public function getLogger()
     {
-        $this->logger = $this->logger ?: app(Log::class);
+        $this->logger = $this->logger ?: app(LoggerInterface::class);
 
         return $this->logger;
     }
@@ -732,10 +732,10 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
     /**
      * Set monolog/logger instance.
      *
-     * @param \Illuminate\Contracts\Logging\Log $logger
+     * @param \Psr\Log\LoggerInterface $logger
      * @return $this
      */
-    public function setLogger(Log $logger)
+    public function setLogger(LoggerInterface $logger)
     {
         $this->logger = $logger;
 

--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -3,8 +3,8 @@
 namespace Yajra\DataTables;
 
 use Illuminate\Support\Str;
-use Illuminate\Http\JsonResponse;
 use Psr\Log\LoggerInterface;
+use Illuminate\Http\JsonResponse;
 use Yajra\DataTables\Utilities\Helper;
 use Illuminate\Support\Traits\Macroable;
 use Yajra\DataTables\Contracts\DataTable;


### PR DESCRIPTION
Hello,

the Illuminate\Contracts\Logging\Log does not exist in 5.6,
we need to use the Psr\Log\LoggerInterface instead.

thanks.