### PR TITLE
Check SoftDeletes on HasOne or BelongsTo relations

### DIFF
--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -138,6 +138,7 @@ class EloquentDataTable extends QueryDataTable
     protected function joinEagerLoadedColumn($relation, $relationColumn)
     {
         $table     = '';
+        $deletedAt = false;
         $lastQuery = $this->query;
         foreach (explode('.', $relation) as $eachRelation) {
             $model = $lastQuery->getRelation($eachRelation);
@@ -163,22 +164,32 @@ class EloquentDataTable extends QueryDataTable
                     $table   = $model->getRelated()->getTable();
                     $foreign = $model->getQualifiedForeignKeyName();
                     $other   = $model->getQualifiedParentKeyName();
+                    $deletedAt = $this->checkSoftDeletesOnModel($model->getRelated());
                     break;
 
                 case $model instanceof BelongsTo:
                     $table   = $model->getRelated()->getTable();
                     $foreign = $model->getQualifiedForeignKey();
                     $other   = $model->getQualifiedOwnerKeyName();
+                    $deletedAt = $this->checkSoftDeletesOnModel($model->getRelated());
                     break;
 
                 default:
                     throw new Exception('Relation ' . get_class($model) . ' is not yet supported.');
             }
-            $this->performJoin($table, $foreign, $other);
+            $this->performJoin($table, $foreign, $other, $deletedAt);
             $lastQuery = $model->getQuery();
         }
 
         return $table . '.' . $relationColumn;
+    }
+
+    protected function checkSoftDeletesOnModel($model){
+        if (in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses($model))) {
+            return $model->getDeletedAtColumn();
+        }
+
+        return false;
     }
 
     /**
@@ -187,9 +198,10 @@ class EloquentDataTable extends QueryDataTable
      * @param string $table
      * @param string $foreign
      * @param string $other
+     * @param string $deletedAt
      * @param string $type
      */
-    protected function performJoin($table, $foreign, $other, $type = 'left')
+    protected function performJoin($table, $foreign, $other, $deletedAt = null, $type = 'left')
     {
         $joins = [];
         foreach ((array) $this->getBaseQueryBuilder()->joins as $key => $join) {
@@ -198,6 +210,10 @@ class EloquentDataTable extends QueryDataTable
 
         if (! in_array($table, $joins)) {
             $this->getBaseQueryBuilder()->join($table, $foreign, '=', $other, $type);
+        }
+
+        if ($deletedAt !== false) {
+            $this->getBaseQueryBuilder()->whereNull($deletedAt);
         }
     }
 }

--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -138,6 +138,7 @@ class EloquentDataTable extends QueryDataTable
     protected function joinEagerLoadedColumn($relation, $relationColumn)
     {
         $table     = '';
+        $deletedAt = false;
         $lastQuery = $this->query;
         foreach (explode('.', $relation) as $eachRelation) {
             $model = $lastQuery->getRelation($eachRelation);
@@ -163,22 +164,32 @@ class EloquentDataTable extends QueryDataTable
                     $table   = $model->getRelated()->getTable();
                     $foreign = $model->getQualifiedForeignKeyName();
                     $other   = $model->getQualifiedParentKeyName();
+                    $deletedAt = $this->checkSoftDeletesOnModel($model->getRelated());
                     break;
 
                 case $model instanceof BelongsTo:
                     $table   = $model->getRelated()->getTable();
                     $foreign = $model->getQualifiedForeignKey();
                     $other   = $model->getQualifiedOwnerKeyName();
+                    $deletedAt = $this->checkSoftDeletesOnModel($model->getRelated());
                     break;
 
                 default:
                     throw new Exception('Relation ' . get_class($model) . ' is not yet supported.');
             }
-            $this->performJoin($table, $foreign, $other);
+            $this->performJoin($table, $foreign, $other, $deletedAt);
             $lastQuery = $model->getQuery();
         }
 
         return $table . '.' . $relationColumn;
+    }
+
+    protected function checkSoftDeletesOnModel($model){
+        if (in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses($model))) {
+            return $model->getDeletedAtColumn();
+        }
+
+        return false;
     }
 
     /**
@@ -187,9 +198,10 @@ class EloquentDataTable extends QueryDataTable
      * @param string $table
      * @param string $foreign
      * @param string $other
+     * @param string $deletedAt
      * @param string $type
      */
-    protected function performJoin($table, $foreign, $other, $type = 'left')
+    protected function performJoin($table, $foreign, $other, $deletedAt = false, $type = 'left')
     {
         $joins = [];
         foreach ((array) $this->getBaseQueryBuilder()->joins as $key => $join) {
@@ -198,6 +210,10 @@ class EloquentDataTable extends QueryDataTable
 
         if (! in_array($table, $joins)) {
             $this->getBaseQueryBuilder()->join($table, $foreign, '=', $other, $type);
+        }
+
+        if ($deletedAt !== false) {
+            $this->getBaseQueryBuilder()->whereNull($deletedAt);
         }
     }
 }

--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -138,7 +138,6 @@ class EloquentDataTable extends QueryDataTable
     protected function joinEagerLoadedColumn($relation, $relationColumn)
     {
         $table     = '';
-        $deletedAt = false;
         $lastQuery = $this->query;
         foreach (explode('.', $relation) as $eachRelation) {
             $model = $lastQuery->getRelation($eachRelation);
@@ -164,32 +163,22 @@ class EloquentDataTable extends QueryDataTable
                     $table   = $model->getRelated()->getTable();
                     $foreign = $model->getQualifiedForeignKeyName();
                     $other   = $model->getQualifiedParentKeyName();
-                    $deletedAt = $this->checkSoftDeletesOnModel($model->getRelated());
                     break;
 
                 case $model instanceof BelongsTo:
                     $table   = $model->getRelated()->getTable();
                     $foreign = $model->getQualifiedForeignKey();
                     $other   = $model->getQualifiedOwnerKeyName();
-                    $deletedAt = $this->checkSoftDeletesOnModel($model->getRelated());
                     break;
 
                 default:
                     throw new Exception('Relation ' . get_class($model) . ' is not yet supported.');
             }
-            $this->performJoin($table, $foreign, $other, $deletedAt);
+            $this->performJoin($table, $foreign, $other);
             $lastQuery = $model->getQuery();
         }
 
         return $table . '.' . $relationColumn;
-    }
-
-    protected function checkSoftDeletesOnModel($model){
-        if (in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses($model))) {
-            return $model->getDeletedAtColumn();
-        }
-
-        return false;
     }
 
     /**
@@ -198,10 +187,9 @@ class EloquentDataTable extends QueryDataTable
      * @param string $table
      * @param string $foreign
      * @param string $other
-     * @param string $deletedAt
      * @param string $type
      */
-    protected function performJoin($table, $foreign, $other, $deletedAt = null, $type = 'left')
+    protected function performJoin($table, $foreign, $other, $type = 'left')
     {
         $joins = [];
         foreach ((array) $this->getBaseQueryBuilder()->joins as $key => $join) {
@@ -210,10 +198,6 @@ class EloquentDataTable extends QueryDataTable
 
         if (! in_array($table, $joins)) {
             $this->getBaseQueryBuilder()->join($table, $foreign, '=', $other, $type);
-        }
-
-        if ($deletedAt !== false) {
-            $this->getBaseQueryBuilder()->whereNull($deletedAt);
         }
     }
 }

--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -161,16 +161,16 @@ class EloquentDataTable extends QueryDataTable
                     break;
 
                 case $model instanceof HasOneOrMany:
-                    $table   = $model->getRelated()->getTable();
-                    $foreign = $model->getQualifiedForeignKeyName();
-                    $other   = $model->getQualifiedParentKeyName();
+                    $table     = $model->getRelated()->getTable();
+                    $foreign   = $model->getQualifiedForeignKeyName();
+                    $other     = $model->getQualifiedParentKeyName();
                     $deletedAt = $this->checkSoftDeletesOnModel($model->getRelated());
                     break;
 
                 case $model instanceof BelongsTo:
-                    $table   = $model->getRelated()->getTable();
-                    $foreign = $model->getQualifiedForeignKey();
-                    $other   = $model->getQualifiedOwnerKeyName();
+                    $table     = $model->getRelated()->getTable();
+                    $foreign   = $model->getQualifiedForeignKey();
+                    $other     = $model->getQualifiedOwnerKeyName();
                     $deletedAt = $this->checkSoftDeletesOnModel($model->getRelated());
                     break;
 
@@ -184,7 +184,8 @@ class EloquentDataTable extends QueryDataTable
         return $table . '.' . $relationColumn;
     }
 
-    protected function checkSoftDeletesOnModel($model){
+    protected function checkSoftDeletesOnModel($model)
+    {
         if (in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses($model))) {
             return $model->getDeletedAtColumn();
         }


### PR DESCRIPTION
Right now, if the related table uses SoftDeletes, it is not handled via the `performJoin` method.