### PR TITLE
Support for Eloquent API Resources

### DIFF
--- a/src/ApiResourceDataTable.php
+++ b/src/ApiResourceDataTable.php
@@ -1,0 +1,314 @@
+<?php
+
+namespace Yajra\DataTables;
+
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
+use Illuminate\Contracts\Support\Arrayable;
+
+class ApiResourceDataTable extends DataTableAbstract
+{
+    /**
+     * Collection object.
+     *
+     * @var Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     */
+    public $collection;
+
+    /**
+     * Collection object.
+     *
+     * @var Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     */
+    public $original;
+
+    /**
+     * Can the DataTable engine be created with these parameters.
+     *
+     * @param mixed $source
+     * @return bool
+     */
+    public static function canCreate($source)
+    {
+        return is_array($source) || $source instanceof AnonymousResourceCollection;
+    }
+
+    /**
+     * Factory method, create and return an instance for the DataTable engine.
+     *
+     * @param array|Illuminate\Http\Resources\Json\AnonymousResourceCollection $source
+     * @return CollectionDataTable|DataTableAbstract
+     */
+    public static function create($source)
+    {
+        if (is_array($source)) {
+            $source = new AnonymousResourceCollection($source);
+        }
+
+        return parent::create($source);
+    }
+
+    /**
+     * CollectionEngine constructor.
+     *
+     * @param Illuminate\Http\Resources\Json\AnonymousResourceCollection $collection
+     */
+    public function __construct(AnonymousResourceCollection $collection)
+    {
+        $this->request    = app('datatables.request');
+        $this->config     = app('datatables.config');
+        $this->collection = $collection;
+        $this->original   = $collection;
+        $this->columns    = array_keys($this->serialize($collection->first()));
+    }
+
+    /**
+     * Serialize collection.
+     *
+     * @param  mixed $collection
+     * @return mixed|null
+     */
+    protected function serialize($collection)
+    {
+        return $collection instanceof Arrayable ? $collection->toArray() : (array) $collection;
+    }
+
+    /**
+     * Count results.
+     *
+     * @return int
+     */
+    public function count()
+    {
+        return $this->collection->count() > $this->totalRecords ? $this->totalRecords : $this->collection->count();
+    }
+
+    /**
+     * Perform column search.
+     *
+     * @return void
+     */
+    public function columnSearch()
+    {
+        $columns = $this->request->get('columns', []);
+        for ($i = 0, $c = count($columns); $i < $c; $i++) {
+            if ($this->request->isColumnSearchable($i)) {
+                $this->isFilterApplied = true;
+
+                $regex   = $this->request->isRegex($i);
+                $column  = $this->getColumnName($i);
+                $keyword = $this->request->columnKeyword($i);
+
+                $this->collection = $this->collection->filter(
+                    function ($row) use ($column, $keyword, $regex) {
+                        $data = $this->serialize($row);
+
+                        $value = Arr::get($data, $column);
+
+                        if ($this->config->isCaseInsensitive()) {
+                            if ($regex) {
+                                return preg_match('/' . $keyword . '/i', $value) == 1;
+                            }
+
+                            return strpos(Str::lower($value), Str::lower($keyword)) !== false;
+                        }
+
+                        if ($regex) {
+                            return preg_match('/' . $keyword . '/', $value) == 1;
+                        }
+
+                        return strpos($value, $keyword) !== false;
+                    }
+                );
+            }
+        }
+    }
+
+    /**
+     * Perform pagination.
+     *
+     * @return void
+     */
+    public function paging()
+    {
+        $this->collection = $this->collection->slice(
+            $this->request->input('start'),
+            (int) $this->request->input('length') > 0 ? $this->request->input('length') : 10
+        );
+    }
+
+    /**
+     * Organizes works.
+     *
+     * @param bool $mDataSupport
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function make($mDataSupport = true)
+    {
+        try {
+            $this->totalRecords = $this->totalCount();
+
+            if ($this->totalRecords) {
+                $results   = $this->results();
+                $processed = $this->processResults($results, $mDataSupport);
+                $output    = $this->transform($results, $processed);
+
+                $this->collection = collect($output);
+                $this->ordering();
+                $this->filterRecords();
+                $this->paginate();
+
+                $this->revertIndexColumn($mDataSupport);
+            }
+
+            return $this->render($this->collection->values()->all());
+        } catch (\Exception $exception) {
+            return $this->errorResponse($exception);
+        }
+    }
+
+    /**
+     * Count total items.
+     *
+     * @return int
+     */
+    public function totalCount()
+    {
+        return $this->totalRecords ? $this->totalRecords : $this->collection->count();
+    }
+
+    /**
+     * Get results.
+     *
+     * @return mixed
+     */
+    public function results()
+    {
+        return $this->collection->all();
+    }
+
+    /**
+     * Revert transformed DT_Row_Index back to it's original values.
+     *
+     * @param bool $mDataSupport
+     */
+    private function revertIndexColumn($mDataSupport)
+    {
+        if ($this->columnDef['index']) {
+            $index = $mDataSupport ? config('datatables.index_column', 'DT_Row_Index') : 0;
+            $start = (int) $this->request->input('start');
+            $this->collection->transform(function ($data) use ($index, &$start) {
+                $data[$index] = ++$start;
+
+                return $data;
+            });
+        }
+    }
+
+    /**
+     * Perform global search for the given keyword.
+     *
+     * @param string $keyword
+     */
+    protected function globalSearch($keyword)
+    {
+        $keyword = $this->config->isCaseInsensitive() ? Str::lower($keyword) : $keyword;
+
+        $this->collection = $this->collection->filter(function ($row) use ($keyword) {
+            $this->isFilterApplied = true;
+
+            $data = $this->serialize($row);
+            foreach ($this->request->searchableColumnIndex() as $index) {
+                $column = $this->getColumnName($index);
+                $value = Arr::get($data, $column);
+                if (! $value || is_array($value)) {
+                    if (! is_numeric($value)) {
+                        continue;
+                    }
+
+                    $value = (string) $value;
+                }
+
+                $value = $this->config->isCaseInsensitive() ? Str::lower($value) : $value;
+                if (Str::contains($value, $keyword)) {
+                    return true;
+                }
+            }
+
+            return false;
+        });
+    }
+
+    /**
+     * Perform default query orderBy clause.
+     */
+    protected function defaultOrdering()
+    {
+        $criteria = $this->request->orderableColumns();
+        if (! empty($criteria)) {
+            $sorter = $this->getSorter($criteria);
+
+            $this->collection = $this->collection
+                ->map(function ($data) {
+                    return array_dot($data);
+                })
+                ->sort($sorter)
+                ->map(function ($data) {
+                    foreach ($data as $key => $value) {
+                        unset($data[$key]);
+                        array_set($data, $key, $value);
+                    }
+
+                    return $data;
+                });
+        }
+    }
+
+    /**
+     * Get array sorter closure.
+     *
+     * @param array $criteria
+     * @return \Closure
+     */
+    protected function getSorter(array $criteria)
+    {
+        $sorter = function ($a, $b) use ($criteria) {
+            foreach ($criteria as $orderable) {
+                $column    = $this->getColumnName($orderable['column']);
+                $direction = $orderable['direction'];
+                if ($direction === 'desc') {
+                    $first  = $b;
+                    $second = $a;
+                } else {
+                    $first  = $a;
+                    $second = $b;
+                }
+                if ($this->config->isCaseInsensitive()) {
+                    $cmp = strnatcasecmp($first[$column], $second[$column]);
+                } else {
+                    $cmp = strnatcmp($first[$column], $second[$column]);
+                }
+                if ($cmp != 0) {
+                    return $cmp;
+                }
+            }
+
+            // all elements were equal
+            return 0;
+        };
+
+        return $sorter;
+    }
+
+    /**
+     * Resolve callback parameter instance.
+     *
+     * @return $this
+     */
+    protected function resolveCallbackParameter()
+    {
+        return $this;
+    }
+}

--- a/src/ApiResourceDataTable.php
+++ b/src/ApiResourceDataTable.php
@@ -39,7 +39,7 @@ class ApiResourceDataTable extends DataTableAbstract
      * Factory method, create and return an instance for the DataTable engine.
      *
      * @param array|Illuminate\Http\Resources\Json\AnonymousResourceCollection $source
-     * @return CollectionDataTable|DataTableAbstract
+     * @return ApiResourceDataTable|DataTableAbstract
      */
     public static function create($source)
     {
@@ -59,9 +59,9 @@ class ApiResourceDataTable extends DataTableAbstract
     {
         $this->request    = app('datatables.request');
         $this->config     = app('datatables.config');
-        $this->collection = $collection;
-        $this->original   = $collection;
-        $this->columns    = array_keys($this->serialize($collection->first()));
+        $this->collection = collect($collection->toArray($this->request));
+        $this->original   = collect($collection->toArray($this->request));
+        $this->columns    = array_keys($this->serialize(collect($collection->toArray($this->request))->first()));
     }
 
     /**

--- a/src/DataTables.php
+++ b/src/DataTables.php
@@ -127,6 +127,17 @@ class DataTables
     }
 
     /**
+     * DataTables using Collection.
+     *
+     * @param \Illuminate\Http\Resources\Json\AnonymousResourceCollection|array $collection
+     * @return DataTableAbstract|ApiResourceDataTable
+     */
+    public function resource($resource)
+    {
+        return ApiResourceDataTable::create($resource);
+    }
+
+    /**
      * Get html builder instance.
      *
      * @return \Yajra\DataTables\Html\Builder

--- a/src/config/datatables.php
+++ b/src/config/datatables.php
@@ -42,6 +42,7 @@ return [
         'eloquent'   => \Yajra\DataTables\EloquentDataTable::class,
         'query'      => \Yajra\DataTables\QueryDataTable::class,
         'collection' => \Yajra\DataTables\CollectionDataTable::class,
+        'anonymousresourcecollection' => \Yajra\DataTables\ApiResourceDataTable::class,
     ],
 
     /*

--- a/tests/Http/Resources/UserCollection.php
+++ b/tests/Http/Resources/UserCollection.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Yajra\DataTables\Tests\Http\Resources;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class UserCollection extends ResourceCollection
+{
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        // return parent::toArray($request);
+        return $this->collection;
+    }
+}

--- a/tests/Http/Resources/UserResource.php
+++ b/tests/Http/Resources/UserResource.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Yajra\DataTables\Tests\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class UserResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        // return parent::toArray($request);
+        return [
+            // 'id' => $this->id,
+            'email' => $this->email,
+            'name' => $this->name
+        ];
+    }
+}

--- a/tests/Integration/ApiResourceEngineTest.php
+++ b/tests/Integration/ApiResourceEngineTest.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace Yajra\DataTables\Tests\Integration;
+
+use Yajra\DataTables\DataTables;
+use Illuminate\Http\JsonResponse;
+use Yajra\DataTables\Tests\TestCase;
+use Yajra\DataTables\Tests\Models\User;
+use Yajra\DataTables\CollectionDataTable;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Yajra\DataTables\Facades\DataTables as DatatablesFacade;
+
+class ApiResourceEngineTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function it_returns_all_records_when_no_parameters_is_passed()
+    {
+        $crawler = $this->call('GET', '/resource/users');
+        $crawler->assertJson([
+            'draw'            => 0,
+            'recordsTotal'    => 20,
+            'recordsFiltered' => 20,
+        ]);
+    }
+
+    /** @test */
+    public function it_can_perform_global_search()
+    {
+        $crawler = $this->call('GET', '/resource/users', [
+            'columns' => [
+                ['data' => 'name', 'name' => 'name', 'searchable' => 'true', 'orderable' => 'true'],
+                ['data' => 'email', 'name' => 'email', 'searchable' => 'true', 'orderable' => 'true'],
+            ],
+            'search' => ['value' => 'Record 19'],
+        ]);
+
+        $crawler->assertJson([
+            'draw'            => 0,
+            'recordsTotal'    => 20,
+            'recordsFiltered' => 1,
+        ]);
+    }
+
+    /** @test */
+    public function it_accepts_a_model_collection_using_of_factory()
+    {
+        $dataTable = DataTables::of(User::all());
+        $response  = $dataTable->make(true);
+        $this->assertInstanceOf(CollectionDataTable::class, $dataTable);
+        $this->assertInstanceOf(JsonResponse::class, $response);
+    }
+
+    /** @test */
+    public function it_accepts_a_collection_using_of_factory()
+    {
+        $dataTable = DataTables::of(collect());
+        $response  = $dataTable->make(true);
+        $this->assertInstanceOf(CollectionDataTable::class, $dataTable);
+        $this->assertInstanceOf(JsonResponse::class, $response);
+    }
+
+    /** @test */
+    public function it_accepts_a_model_collection_using_facade()
+    {
+        $dataTable = DatatablesFacade::of(User::all());
+        $response  = $dataTable->make(true);
+        $this->assertInstanceOf(CollectionDataTable::class, $dataTable);
+        $this->assertInstanceOf(JsonResponse::class, $response);
+    }
+
+    /** @test */
+    public function it_accepts_a_collection_using_facade()
+    {
+        $dataTable = DatatablesFacade::of(collect());
+        $response  = $dataTable->make(true);
+        $this->assertInstanceOf(CollectionDataTable::class, $dataTable);
+        $this->assertInstanceOf(JsonResponse::class, $response);
+    }
+
+    /** @test */
+    public function it_accepts_a_model_using_ioc_container()
+    {
+        $dataTable = app('datatables')->collection(User::all());
+        $response  = $dataTable->make(true);
+        $this->assertInstanceOf(CollectionDataTable::class, $dataTable);
+        $this->assertInstanceOf(JsonResponse::class, $response);
+    }
+
+    /** @test */
+    public function it_can_sort_case_insensitive_strings()
+    {
+        config()->set('app.debug', false);
+        request()->merge([
+            'columns' => [
+                ['data' => 'name', 'name' => 'name', 'searchable' => 'true', 'orderable' => 'true'],
+            ],
+            'order'  => [['column' => 0, 'dir' => 'asc']],
+            'start'  => 0,
+            'length' => 10,
+            'draw'   => 1,
+        ]);
+
+        $collection = collect([
+            ['name' => 'ABC'],
+            ['name' => 'BCD'],
+            ['name' => 'ZXY'],
+            ['name' => 'aaa'],
+            ['name' => 'bbb'],
+            ['name' => 'zzz'],
+        ]);
+
+        $dataTable = app('datatables')->collection($collection);
+        /** @var JsonResponse $response */
+        $response = $dataTable->make('true');
+
+        $this->assertEquals([
+            'draw'            => 1,
+            'recordsTotal'    => 6,
+            'recordsFiltered' => 6,
+            'data'            => [
+                ['name' => 'aaa'],
+                ['name' => 'ABC'],
+                ['name' => 'bbb'],
+                ['name' => 'BCD'],
+                ['name' => 'ZXY'],
+                ['name' => 'zzz'],
+            ],
+        ], $response->getData(true));
+    }
+
+    /** @test */
+    public function it_accepts_a_model_using_ioc_container_factory()
+    {
+        $dataTable = app('datatables')->of(User::all());
+        $response  = $dataTable->make(true);
+        $this->assertInstanceOf(CollectionDataTable::class, $dataTable);
+        $this->assertInstanceOf(JsonResponse::class, $response);
+    }
+
+    /** @test */
+    public function it_can_search_on_added_columns()
+    {
+        config()->set('app.debug', false);
+        request()->merge([
+            'columns' => [
+                ['data' => 'name', 'name' => 'name', 'searchable' => 'true', 'orderable' => 'true'],
+                ['data' => 'foo',  'name' => 'foo', 'searchable' => 'true', 'orderable' => 'true'],
+            ],
+            'order'  => [['column' => 0, 'dir' => 'asc']],
+            'start'  => 0,
+            'search' => [
+                'value' => 'bar aaa',
+            ],
+            'length' => 10,
+            'draw'   => 1,
+        ]);
+
+        $collection = collect([
+            ['name' => 'ABC'],
+            ['name' => 'BCD'],
+            ['name' => 'ZXY'],
+            ['name' => 'aaa'],
+            ['name' => 'bbb'],
+            ['name' => 'zzz'],
+        ]);
+
+        $dataTable = app('datatables')->collection($collection);
+        /** @var JsonResponse $response */
+        $response = $dataTable->addColumn('foo', 'bar {{$name}}')->make('true');
+
+        $this->assertEquals([
+            'draw'            => 1,
+            'recordsTotal'    => 6,
+            'recordsFiltered' => 1,
+            'data'            => [
+                ['name' => 'aaa', 'foo' => 'bar aaa'],
+            ],
+        ], $response->getData(true));
+    }
+
+    /** @test */
+    public function it_accepts_array_data_source()
+    {
+        $source = [
+            ['id' => 1, 'name' => 'foo'],
+            ['id' => 2, 'name' => 'bar'],
+        ];
+        $dataTable = app('datatables')->of($source);
+        $response  = $dataTable->make(true);
+        $this->assertInstanceOf(CollectionDataTable::class, $dataTable);
+        $this->assertInstanceOf(JsonResponse::class, $response);
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->app['router']->get('/resource/users', function (DataTables $datatables) {
+            return $datatables->collection(User::all())->make('true');
+        });
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -22,34 +22,44 @@ abstract class TestCase extends BaseTestCase
     {
         /** @var \Illuminate\Database\Schema\Builder $schemaBuilder */
         $schemaBuilder = $this->app['db']->connection()->getSchemaBuilder();
-        $schemaBuilder->create('users', function (Blueprint $table) {
-            $table->increments('id');
-            $table->string('name');
-            $table->string('email');
-            $table->timestamps();
-        });
-        $schemaBuilder->create('posts', function (Blueprint $table) {
-            $table->increments('id');
-            $table->string('title');
-            $table->unsignedInteger('user_id');
-            $table->timestamps();
-        });
-        $schemaBuilder->create('hearts', function (Blueprint $table) {
-            $table->increments('id');
-            $table->unsignedInteger('user_id');
-            $table->string('size');
-            $table->timestamps();
-        });
-        $schemaBuilder->create('roles', function (Blueprint $table) {
-            $table->increments('id');
-            $table->string('role');
-            $table->timestamps();
-        });
-        $schemaBuilder->create('role_user', function (Blueprint $table) {
-            $table->unsignedInteger('role_id');
-            $table->unsignedInteger('user_id');
-            $table->timestamps();
-        });
+        if(!$schemaBuilder->hasTable('users')) {
+            $schemaBuilder->create('users', function (Blueprint $table) {
+                $table->increments('id');
+                $table->string('name');
+                $table->string('email');
+                $table->timestamps();
+            });
+        }
+        if(!$schemaBuilder->hasTable('posts')) {
+            $schemaBuilder->create('posts', function (Blueprint $table) {
+                $table->increments('id');
+                $table->string('title');
+                $table->unsignedInteger('user_id');
+                $table->timestamps();
+            });
+        }
+        if(!$schemaBuilder->hasTable('hearts')) {
+            $schemaBuilder->create('hearts', function (Blueprint $table) {
+                $table->increments('id');
+                $table->unsignedInteger('user_id');
+                $table->string('size');
+                $table->timestamps();
+            });
+        }
+        if(!$schemaBuilder->hasTable('roles')) {
+            $schemaBuilder->create('roles', function (Blueprint $table) {
+                $table->increments('id');
+                $table->string('role');
+                $table->timestamps();
+            });
+        }
+        if(!$schemaBuilder->hasTable('role_user')) {
+            $schemaBuilder->create('role_user', function (Blueprint $table) {
+                $table->unsignedInteger('role_id');
+                $table->unsignedInteger('user_id');
+                $table->timestamps();
+            });
+        }
     }
 
     protected function seedDatabase()


### PR DESCRIPTION
Hello,

This PR aims to address the following issues:

https://github.com/yajra/laravel-datatables/issues/1515
https://github.com/yajra/laravel-datatables/issues/1659

Laravel 5.5 introduced to us Eloquent API resources where we could easily describe the format that we wanted for our API responses. This package currently does not support the new API resources. Through this PR, I have added a new engine to handle API Resources, updated the configuration and added a new test case to test the new functionality.

We can use the package as below now:

`DataTables::of(App\Http\Resources\UserResource::collection(App\User::all()))->toJson();`

or

`datatables()->of(App\Http\Resources\UserResource::collection(App\User::all()))->toJson();`

or

`DataTables::resource(App\Http\Resources\UserResource::collection(App\User::all()))->toJson();`

or 

`datatables->resource(App\Http\Resources\UserResource::collection(App\User::all()))->toJson();`


Please review and let me know if there are any corrections and/or enhancements that can be done here if this PR is considered to be merged.

Thanks!