### PR TITLE
[8.0] Add withQuery api for query callback.

### DIFF
--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -355,7 +355,8 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
      * @param callable $value
      * @return $this
      */
-    public function withQuery($key, callable $value) {
+    public function withQuery($key, callable $value)
+    {
         $this->appends[$key] = $value;
 
         return $this;

--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -340,10 +340,23 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
         if (is_array($key)) {
             $this->appends = $key;
         } elseif (is_callable($value)) {
-            $this->appends[$key] = $value;
+            $this->appends[$key] = value($value);
         } else {
             $this->appends[$key] = value($value);
         }
+
+        return $this;
+    }
+
+    /**
+     * Add with query callback value on response.
+     *
+     * @param string   $key
+     * @param callable $value
+     * @return $this
+     */
+    public function withQuery($key, callable $value) {
+        $this->appends[$key] = $value;
 
         return $this;
     }


### PR DESCRIPTION
Revert #1758 with callback implementation since its BC.

```php
return datatables($query)
    ->setRowId('id')
    ->withQuery('totalWeight', function($filteredQuery) {
        return $filteredQuery->sum('weight');
    })
```