### PR TITLE
DATATABLES_ERROR shouldn't be by default null #1805

### DIFF
--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -750,7 +750,9 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
     protected function errorResponse(\Exception $exception)
     {
         $error = $this->config->get('datatables.error');
-        if ($error === 'throw') {
+        $debug = $this->config->get('app.debug');
+
+        if ($error === 'throw' || (!$error && !$debug)) {
             throw new Exception($exception->getMessage(), $code = 0, $exception);
         }
 

--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -752,7 +752,7 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
         $error = $this->config->get('datatables.error');
         $debug = $this->config->get('app.debug');
 
-        if ($error === 'throw' || (!$error && !$debug)) {
+        if ($error === 'throw' || (! $error && ! $debug)) {
             throw new Exception($exception->getMessage(), $code = 0, $exception);
         }
 


### PR DESCRIPTION
<!--

To avoid showing any unwanted errors in production if debug is false, we throw an exception and let laravel handle it if error is null and debug is false.

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
