### PR TITLE
[8.0] Allow boolean values for column[i].searchable

### DIFF
--- a/src/Utilities/Request.php
+++ b/src/Utilities/Request.php
@@ -154,10 +154,20 @@ class Request
     public function isColumnSearchable($i, $column_search = true)
     {
         if ($column_search) {
-            return $this->request->input("columns.$i.searchable", 'true') === 'true' && $this->columnKeyword($i) != '';
+            return 
+                (
+                    $this->request->input("columns.$i.searchable", 'true') === 'true' 
+                    || 
+                    $this->request->input("columns.$i.searchable", 'true') === true 
+                ) 
+                && $this->columnKeyword($i) != '';
         }
 
-        return $this->request->input("columns.$i.searchable", 'true') === 'true';
+        return ( 
+            $this->request->input("columns.$i.searchable", 'true') === 'true' 
+            || 
+            $this->request->input("columns.$i.searchable", 'true') === true
+        );
     }
 
     /**


### PR DESCRIPTION
When dt Request is sent as application/json instead of multipart/form-data
and when in ColumnDef boolean values are used the search does not work. 

Did not work
column[i].searchable = true;

Did work
column[i].searchable = 'true';

But the type of searchable is boolean according to 
https://datatables.net/reference/option/columns.searchable

might affect https://github.com/yajra/laravel-datatables/issues/1789
