### PR TITLE
READEME: publish  command requires quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Register provider and facade on your `config/app.php` file.
 
 #### Configuration (Optional)
 ```bash
-$ php artisan vendor:publish --provider=Yajra\DataTables\DataTablesServiceProvider
+$ php artisan vendor:publish --provider="Yajra\DataTables\DataTablesServiceProvider"
 ```
 
 And that's it! Start building out some awesome DataTables!


### PR DESCRIPTION
The provider needs to be quoted, presumably because of the back-slashes that are needed for the namespace.