### PR TITLE
[BC] Fix the default name of index column to follow DT syntax.

### DIFF
--- a/src/CollectionDataTable.php
+++ b/src/CollectionDataTable.php
@@ -189,14 +189,14 @@ class CollectionDataTable extends DataTableAbstract
     }
 
     /**
-     * Revert transformed DT_Row_Index back to it's original values.
+     * Revert transformed DT_RowIndex back to it's original values.
      *
      * @param bool $mDataSupport
      */
     private function revertIndexColumn($mDataSupport)
     {
         if ($this->columnDef['index']) {
-            $index = $mDataSupport ? config('datatables.index_column', 'DT_Row_Index') : 0;
+            $index = $mDataSupport ? config('datatables.index_column', 'DT_RowIndex') : 0;
             $start = (int) $this->request->input('start');
             $this->collection->transform(function ($data) use ($index, &$start) {
                 $data[$index] = ++$start;

--- a/src/Processors/DataProcessor.php
+++ b/src/Processors/DataProcessor.php
@@ -89,7 +89,7 @@ class DataProcessor
     public function process($object = false)
     {
         $this->output = [];
-        $indexColumn  = config('datatables.index_column', 'DT_Row_Index');
+        $indexColumn  = config('datatables.index_column', 'DT_RowIndex');
 
         foreach ($this->results as $row) {
             $data  = Helper::convertToArray($row);

--- a/src/config/datatables.php
+++ b/src/config/datatables.php
@@ -32,7 +32,7 @@ return [
     /*
      * DataTables internal index id response column name.
      */
-    'index_column' => 'DT_Row_Index',
+    'index_column' => 'DT_RowIndex',
 
     /*
      * List of available builders for DataTables.

--- a/tests/Integration/QueryEngineTest.php
+++ b/tests/Integration/QueryEngineTest.php
@@ -140,7 +140,7 @@ class QueryEngineTest extends TestCase
     {
         $crawler = $this->call('GET', '/query/indexColumn', [
             'columns' => [
-                ['data' => 'DT_Row_index', 'name' => 'index', 'searchable' => 'false', 'orderable' => 'false'],
+                ['data' => 'DT_RowIndex', 'name' => 'index', 'searchable' => 'false', 'orderable' => 'false'],
                 ['data' => 'name', 'name' => 'name', 'searchable' => 'true', 'orderable' => 'true'],
                 ['data' => 'email', 'name' => 'email', 'searchable' => 'true', 'orderable' => 'true'],
             ],
@@ -153,7 +153,7 @@ class QueryEngineTest extends TestCase
             'recordsFiltered' => 1,
         ]);
 
-        $this->assertArrayHasKey('DT_Row_Index', $crawler->json()['data'][0]);
+        $this->assertArrayHasKey('DT_RowIndex', $crawler->json()['data'][0]);
     }
 
     /** @test */


### PR DESCRIPTION
This is a small PR that changes the name of the index column to follow DT syntax.
DT syntax for special columns is like: `DT_NameName`
But the name of the index column was `DT_Name_Name`
I don't know this is a breaking change or no cause I only changed the default value.