### PR TITLE
[8.0] Add simple pagination api.

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -46,6 +46,13 @@ class QueryDataTable extends DataTableAbstract
     protected $limitCallback;
 
     /**
+     * Flag to use simple pagination.
+     *
+     * @var bool
+     */
+    protected $simplePagination = false;
+
+    /**
      * Can the DataTable engine be created with these parameters.
      *
      * @param mixed $source
@@ -112,13 +119,45 @@ class QueryDataTable extends DataTableAbstract
     }
 
     /**
+     * Use simple pagination to set the recordsTotal equals to recordsFiltered.
+     * This will improve the performance by skipping the count query.
+     *
+     * @return $this
+     */
+    public function simplePagination()
+    {
+        $this->simplePagination = true;
+
+        return $this;
+    }
+
+    /**
      * Count total items.
      *
      * @return int
      */
     public function totalCount()
     {
+        if ($this->simplePagination) {
+            return true;
+        }
+
         return $this->totalRecords ? $this->totalRecords : $this->count();
+    }
+
+    /**
+     * Count filtered items.
+     *
+     * @return int
+     */
+    protected function filteredCount()
+    {
+        $this->filteredRecords = $this->filteredRecords ?: $this->count();
+        if ($this->simplePagination) {
+            $this->totalRecords = $this->filteredRecords;
+        }
+
+        return $this->filteredRecords;
     }
 
     /**

--- a/tests/Integration/ApiResourceEngineTest.php
+++ b/tests/Integration/ApiResourceEngineTest.php
@@ -65,7 +65,7 @@ class ApiResourceEngineTest extends TestCase
     public function it_accepts_a_resource_using_of_factory()
     {
         $dataTable = DataTables::of(UserResource::collection(User::all()));
-        $response  = $dataTable->make(true);
+        $response  = $dataTable->toJson();
         $this->assertInstanceOf(ApiResourceDataTable::class, $dataTable);
         $this->assertInstanceOf(JsonResponse::class, $response);
     }
@@ -74,7 +74,7 @@ class ApiResourceEngineTest extends TestCase
     public function it_accepts_a_resource_using_facade()
     {
         $dataTable = DatatablesFacade::of(UserResource::collection(User::all()));
-        $response  = $dataTable->make(true);
+        $response  = $dataTable->toJson();
         $this->assertInstanceOf(ApiResourceDataTable::class, $dataTable);
         $this->assertInstanceOf(JsonResponse::class, $response);
     }
@@ -83,7 +83,7 @@ class ApiResourceEngineTest extends TestCase
     public function it_accepts_a_pagination_resource()
     {
         $dataTable = DataTables::of(UserResource::collection(User::paginate(10)));
-        $response  = $dataTable->make(true);
+        $response  = $dataTable->toJson();
         $this->assertInstanceOf(ApiResourceDataTable::class, $dataTable);
         $this->assertInstanceOf(JsonResponse::class, $response);
     }
@@ -104,11 +104,11 @@ class ApiResourceEngineTest extends TestCase
         parent::setUp();
 
         $this->app['router']->get('/resource/users', function (DataTables $datatables) {
-            return $datatables->resource(UserResource::collection(User::all()))->make('true');
+            return $datatables->resource(UserResource::collection(User::all()))->toJson();
         });
 
         $this->app['router']->get('/resource/users_p', function (DataTables $datatables) {
-            return $datatables->resource(UserResource::collection(User::paginate(10)))->make('true');
+            return $datatables->resource(UserResource::collection(User::paginate(10)))->toJson();
         });
     }
 }

--- a/tests/Integration/BelongsToManyRelationTest.php
+++ b/tests/Integration/BelongsToManyRelationTest.php
@@ -87,7 +87,7 @@ class BelongsToManyRelationTest extends TestCase
         parent::setUp();
 
         $this->app['router']->get('/relations/belongsToMany', function (DataTables $datatables) {
-            return $datatables->eloquent(User::with('roles')->select('users.*'))->make('true');
+            return $datatables->eloquent(User::with('roles')->select('users.*'))->toJson();
         });
     }
 }

--- a/tests/Integration/BelongsToRelationTest.php
+++ b/tests/Integration/BelongsToRelationTest.php
@@ -84,7 +84,7 @@ class BelongsToRelationTest extends TestCase
         parent::setUp();
 
         $this->app['router']->get('/relations/belongsTo', function (DataTables $datatables) {
-            return $datatables->eloquent(Post::with('user')->select('posts.*'))->make('true');
+            return $datatables->eloquent(Post::with('user')->select('posts.*'))->toJson();
         });
     }
 }

--- a/tests/Integration/CollectionDataTableTest.php
+++ b/tests/Integration/CollectionDataTableTest.php
@@ -47,7 +47,7 @@ class CollectionDataTableTest extends TestCase
     public function it_accepts_a_model_collection_using_of_factory()
     {
         $dataTable = DataTables::of(User::all());
-        $response  = $dataTable->make(true);
+        $response  = $dataTable->toJson();
         $this->assertInstanceOf(CollectionDataTable::class, $dataTable);
         $this->assertInstanceOf(JsonResponse::class, $response);
     }
@@ -56,7 +56,7 @@ class CollectionDataTableTest extends TestCase
     public function it_accepts_a_collection_using_of_factory()
     {
         $dataTable = DataTables::of(collect());
-        $response  = $dataTable->make(true);
+        $response  = $dataTable->toJson();
         $this->assertInstanceOf(CollectionDataTable::class, $dataTable);
         $this->assertInstanceOf(JsonResponse::class, $response);
     }
@@ -65,7 +65,7 @@ class CollectionDataTableTest extends TestCase
     public function it_accepts_a_model_collection_using_facade()
     {
         $dataTable = DatatablesFacade::of(User::all());
-        $response  = $dataTable->make(true);
+        $response  = $dataTable->toJson();
         $this->assertInstanceOf(CollectionDataTable::class, $dataTable);
         $this->assertInstanceOf(JsonResponse::class, $response);
     }
@@ -74,7 +74,7 @@ class CollectionDataTableTest extends TestCase
     public function it_accepts_a_collection_using_facade()
     {
         $dataTable = DatatablesFacade::of(collect());
-        $response  = $dataTable->make(true);
+        $response  = $dataTable->toJson();
         $this->assertInstanceOf(CollectionDataTable::class, $dataTable);
         $this->assertInstanceOf(JsonResponse::class, $response);
     }
@@ -83,7 +83,7 @@ class CollectionDataTableTest extends TestCase
     public function it_accepts_a_model_using_ioc_container()
     {
         $dataTable = app('datatables')->collection(User::all());
-        $response  = $dataTable->make(true);
+        $response  = $dataTable->toJson();
         $this->assertInstanceOf(CollectionDataTable::class, $dataTable);
         $this->assertInstanceOf(JsonResponse::class, $response);
     }
@@ -113,7 +113,7 @@ class CollectionDataTableTest extends TestCase
 
         $dataTable = app('datatables')->collection($collection);
         /** @var JsonResponse $response */
-        $response = $dataTable->make('true');
+        $response = $dataTable->toJson();
 
         $this->assertEquals([
             'draw'            => 1,
@@ -134,7 +134,7 @@ class CollectionDataTableTest extends TestCase
     public function it_accepts_a_model_using_ioc_container_factory()
     {
         $dataTable = app('datatables')->of(User::all());
-        $response  = $dataTable->make(true);
+        $response  = $dataTable->toJson();
         $this->assertInstanceOf(CollectionDataTable::class, $dataTable);
         $this->assertInstanceOf(JsonResponse::class, $response);
     }
@@ -168,7 +168,7 @@ class CollectionDataTableTest extends TestCase
 
         $dataTable = app('datatables')->collection($collection);
         /** @var JsonResponse $response */
-        $response = $dataTable->addColumn('foo', 'bar {{$name}}')->make('true');
+        $response = $dataTable->addColumn('foo', 'bar {{$name}}')->toJson();
 
         $this->assertEquals([
             'draw'            => 1,
@@ -188,7 +188,7 @@ class CollectionDataTableTest extends TestCase
             ['id' => 2, 'name' => 'bar'],
         ];
         $dataTable = app('datatables')->of($source);
-        $response  = $dataTable->make(true);
+        $response  = $dataTable->toJson();
         $this->assertInstanceOf(CollectionDataTable::class, $dataTable);
         $this->assertInstanceOf(JsonResponse::class, $response);
     }
@@ -198,7 +198,7 @@ class CollectionDataTableTest extends TestCase
         parent::setUp();
 
         $this->app['router']->get('/collection/users', function (DataTables $datatables) {
-            return $datatables->collection(User::all())->make('true');
+            return $datatables->collection(User::all())->toJson();
         });
     }
 }

--- a/tests/Integration/CollectionDataTableTest.php
+++ b/tests/Integration/CollectionDataTableTest.php
@@ -10,7 +10,7 @@ use Yajra\DataTables\CollectionDataTable;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Yajra\DataTables\Facades\DataTables as DatatablesFacade;
 
-class CollectionEngineTest extends TestCase
+class CollectionDataTableTest extends TestCase
 {
     use DatabaseTransactions;
 

--- a/tests/Integration/EloquentDataTableTest.php
+++ b/tests/Integration/EloquentDataTableTest.php
@@ -47,7 +47,7 @@ class EloquentDataTableTest extends TestCase
     public function it_accepts_a_model_using_of_factory()
     {
         $dataTable = DataTables::of(User::query());
-        $response  = $dataTable->make(true);
+        $response  = $dataTable->toJson();
         $this->assertInstanceOf(EloquentDataTable::class, $dataTable);
         $this->assertInstanceOf(JsonResponse::class, $response);
     }
@@ -56,7 +56,7 @@ class EloquentDataTableTest extends TestCase
     public function it_accepts_a_model_using_facade()
     {
         $dataTable = DatatablesFacade::of(User::query());
-        $response  = $dataTable->make(true);
+        $response  = $dataTable->toJson();
         $this->assertInstanceOf(EloquentDataTable::class, $dataTable);
         $this->assertInstanceOf(JsonResponse::class, $response);
     }
@@ -65,7 +65,7 @@ class EloquentDataTableTest extends TestCase
     public function it_accepts_a_model_using_facade_eloquent_method()
     {
         $dataTable = DatatablesFacade::eloquent(User::query());
-        $response  = $dataTable->make(true);
+        $response  = $dataTable->toJson();
         $this->assertInstanceOf(EloquentDataTable::class, $dataTable);
         $this->assertInstanceOf(JsonResponse::class, $response);
     }
@@ -74,7 +74,7 @@ class EloquentDataTableTest extends TestCase
     public function it_accepts_a_model_using_ioc_container()
     {
         $dataTable = app('datatables')->eloquent(User::query());
-        $response  = $dataTable->make(true);
+        $response  = $dataTable->toJson();
         $this->assertInstanceOf(EloquentDataTable::class, $dataTable);
         $this->assertInstanceOf(JsonResponse::class, $response);
     }
@@ -83,7 +83,7 @@ class EloquentDataTableTest extends TestCase
     public function it_accepts_a_model_using_ioc_container_factory()
     {
         $dataTable = app('datatables')->of(User::query());
-        $response  = $dataTable->make(true);
+        $response  = $dataTable->toJson();
         $this->assertInstanceOf(EloquentDataTable::class, $dataTable);
         $this->assertInstanceOf(JsonResponse::class, $response);
     }
@@ -93,7 +93,7 @@ class EloquentDataTableTest extends TestCase
         parent::setUp();
 
         $this->app['router']->get('/eloquent/users', function (DataTables $datatables) {
-            return $datatables->eloquent(User::query())->make('true');
+            return $datatables->eloquent(User::query())->toJson();
         });
     }
 }

--- a/tests/Integration/EloquentDataTableTest.php
+++ b/tests/Integration/EloquentDataTableTest.php
@@ -10,7 +10,7 @@ use Yajra\DataTables\Tests\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Yajra\DataTables\Facades\DataTables as DatatablesFacade;
 
-class EloquentEngineTest extends TestCase
+class EloquentDataTableTest extends TestCase
 {
     use DatabaseTransactions;
 

--- a/tests/Integration/HasManyRelationTest.php
+++ b/tests/Integration/HasManyRelationTest.php
@@ -58,7 +58,7 @@ class HasManyRelationTest extends TestCase
         parent::setUp();
 
         $this->app['router']->get('/relations/hasMany', function (DataTables $datatables) {
-            return $datatables->eloquent(User::with('posts')->select('users.*'))->make('true');
+            return $datatables->eloquent(User::with('posts')->select('users.*'))->toJson();
         });
     }
 }

--- a/tests/Integration/HasOneRelationTest.php
+++ b/tests/Integration/HasOneRelationTest.php
@@ -84,7 +84,7 @@ class HasOneRelationTest extends TestCase
         parent::setUp();
 
         $this->app['router']->get('/relations/hasOne', function (DataTables $datatables) {
-            return $datatables->eloquent(User::with('heart')->select('users.*'))->make('true');
+            return $datatables->eloquent(User::with('heart')->select('users.*'))->toJson();
         });
     }
 }

--- a/tests/Integration/QueryDataTableTest.php
+++ b/tests/Integration/QueryDataTableTest.php
@@ -84,7 +84,7 @@ class QueryDataTableTest extends TestCase
     public function it_accepts_a_query_using_of_factory()
     {
         $dataTable = DataTables::of(DB::table('users'));
-        $response  = $dataTable->make(true);
+        $response  = $dataTable->toJson();
         $this->assertInstanceOf(QueryDataTable::class, $dataTable);
         $this->assertInstanceOf(JsonResponse::class, $response);
     }
@@ -93,7 +93,7 @@ class QueryDataTableTest extends TestCase
     public function it_accepts_a_query_using_facade()
     {
         $dataTable = DatatablesFacade::of(DB::table('users'));
-        $response  = $dataTable->make(true);
+        $response  = $dataTable->toJson();
         $this->assertInstanceOf(QueryDataTable::class, $dataTable);
         $this->assertInstanceOf(JsonResponse::class, $response);
     }
@@ -102,7 +102,7 @@ class QueryDataTableTest extends TestCase
     public function it_accepts_a_query_using_facade_query_method()
     {
         $dataTable = DatatablesFacade::query(DB::table('users'));
-        $response  = $dataTable->make(true);
+        $response  = $dataTable->toJson();
         $this->assertInstanceOf(QueryDataTable::class, $dataTable);
         $this->assertInstanceOf(JsonResponse::class, $response);
     }
@@ -111,7 +111,7 @@ class QueryDataTableTest extends TestCase
     public function it_accepts_a_query_using_deprecated_facade_query_builder_method()
     {
         $dataTable = DatatablesFacade::queryBuilder(DB::table('users'));
-        $response  = $dataTable->make(true);
+        $response  = $dataTable->toJson();
         $this->assertInstanceOf(QueryDataTable::class, $dataTable);
         $this->assertInstanceOf(JsonResponse::class, $response);
     }
@@ -120,7 +120,7 @@ class QueryDataTableTest extends TestCase
     public function it_accepts_a_query_using_ioc_container()
     {
         $dataTable = app('datatables')->query(DB::table('users'));
-        $response  = $dataTable->make(true);
+        $response  = $dataTable->toJson();
         $this->assertInstanceOf(QueryDataTable::class, $dataTable);
         $this->assertInstanceOf(JsonResponse::class, $response);
     }
@@ -129,7 +129,7 @@ class QueryDataTableTest extends TestCase
     public function it_accepts_a_query_using_ioc_container_factory()
     {
         $dataTable = app('datatables')->of(DB::table('users'));
-        $response  = $dataTable->make(true);
+        $response  = $dataTable->toJson();
         $this->assertInstanceOf(QueryDataTable::class, $dataTable);
         $this->assertInstanceOf(JsonResponse::class, $response);
     }

--- a/tests/Integration/QueryDataTableTest.php
+++ b/tests/Integration/QueryDataTableTest.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Query\Builder;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Yajra\DataTables\Facades\DataTables as DatatablesFacade;
 
-class QueryEngineTest extends TestCase
+class QueryDataTableTest extends TestCase
 {
     use DatabaseTransactions;
 
@@ -40,6 +40,24 @@ class QueryEngineTest extends TestCase
         $crawler->assertJson([
             'draw'            => 0,
             'recordsTotal'    => 20,
+            'recordsFiltered' => 1,
+        ]);
+    }
+
+    /** @test */
+    public function it_can_use_simple_pagination()
+    {
+        $crawler = $this->call('GET', '/query/simple', [
+            'columns' => [
+                ['data' => 'name', 'name' => 'name', 'searchable' => 'true', 'orderable' => 'true'],
+                ['data' => 'email', 'name' => 'email', 'searchable' => 'true', 'orderable' => 'true'],
+            ],
+            'search' => ['value' => 'Record-19'],
+        ]);
+
+        $crawler->assertJson([
+            'draw'            => 0,
+            'recordsTotal'    => 1,
             'recordsFiltered' => 1,
         ]);
     }
@@ -182,29 +200,35 @@ class QueryEngineTest extends TestCase
     {
         parent::setUp();
 
-        $this->app['router']->get('/query/users', function (DataTables $dataTable) {
-            return $dataTable->query(DB::table('users'))->make('true');
+        $route = $this->app['router'];
+
+        $route->get('/query/users', function (DataTables $dataTable) {
+            return $dataTable->query(DB::table('users'))->toJson();
         });
 
-        $this->app['router']->get('/query/addColumn', function (DataTables $dataTable) {
+        $route->get('/query/simple', function (DataTables $dataTable) {
+            return $dataTable->query(DB::table('users'))->simplePagination()->toJson();
+        });
+
+        $route->get('/query/addColumn', function (DataTables $dataTable) {
             return $dataTable->query(DB::table('users'))
                              ->addColumn('foo', 'bar')
-                             ->make('true');
+                             ->toJson();
         });
 
-        $this->app['router']->get('/query/indexColumn', function (DataTables $dataTable) {
+        $route->get('/query/indexColumn', function (DataTables $dataTable) {
             return $dataTable->query(DB::table('users'))
                              ->addIndexColumn()
-                             ->make('true');
+                             ->toJson();
         });
 
-        $this->app['router']->get('/query/filterColumn', function (DataTables $dataTable) {
+        $route->get('/query/filterColumn', function (DataTables $dataTable) {
             return $dataTable->query(DB::table('users'))
                              ->addColumn('foo', 'bar')
                              ->filterColumn('foo', function (Builder $builder, $keyword) {
                                  $builder->where('1', $keyword);
                              })
-                             ->make('true');
+                             ->toJson();
         });
     }
 }


### PR DESCRIPTION
Add `simplePagination()` api for better performance when using large datasets. Simple pagination will skip the `recordsTotal` count query and will set the value always equal to `recordsFiltered`. 

May address the following performance issues as listed on https://github.com/yajra/laravel-datatables/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3Aperformance+.

To use, simply add `->simplePagination()` to your dataTables chain method.
