### PR TITLE
Added optional merge of config raw columns to rawColumns method

### DIFF
--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -249,15 +249,25 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
     /**
      * Set columns that should not be escaped.
      *
+     * Optionally merge the defaults from config
+     *
      * @param array $columns
+     * @param bool $merge
      * @return $this
      */
-    public function rawColumns(array $columns)
+    public function rawColumns(array $columns, $merge = false)
     {
-        $this->columnDef['raw'] = $columns;
+        if ($merge) {
+            $config = $this->config->get('datatables.columns');
+
+            $this->columnDef['raw'] = array_merge($config['raw'], $columns);
+        } else {
+            $this->columnDef['raw'] = $columns;
+        }
 
         return $this;
     }
+
 
     /**
      * Sets DT_RowClass template.


### PR DESCRIPTION
This pull request allows the optional merging of the raw columns defined in the config, and any new ones that you may want to add.

From my point of view, it seems odd that rawColumns was removing the ones defined in config, we use the ones defined on config as default across all tables, e.g. actions, so setting rawColumn(['state']) caused actions to disappear.

The pull request is written for backwards compatiblity, it won't merge unless true is passed.

Example:

**In config**

```php
    /*
     * Default columns definition of dataTable utility functions.
     */
    'columns' => [
        
        /*
         * List of columns that are allowed to display html content.
         * Note: Adding columns to list will make us available to XSS attacks.
         */
        'raw' => ['action'],
```

**Existing functionality**

```php
    return DataTables::eloquent($model)
                ->addColumn('link', '<a href="#">Html Column</a>')
                ->addColumn('action', 'path.to.view')
                ->rawColumns(['state'])
                ->toJson();
```

Results in raw columns as just state, the action column is no longer a raw column.

**New merge functionality**

```php
    return DataTables::eloquent($model)
                ->addColumn('link', '<a href="#">Html Column</a>')
                ->addColumn('action', 'path.to.view')
                ->rawColumns(['state'], true)
                ->toJson();
```

Results in raw columns as state and action.

A variation in this idea could be a new method rawColumnsMerge, so existing method is left alone, and a new that just does merge could be used.
