### PR TITLE
[9.0] Sorting nested relation that refers to the same table.

### DIFF
--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -170,10 +170,11 @@ class EloquentDataTable extends QueryDataTable
                 case $model instanceof BelongsTo:
                     $table     = $model->getRelated()->getTable();
                     $alias     = "alias_{$index}_{$table}";
-                    $tableAs   = "{$table} AS $alias";
+                    $tableAs   = "{$table} AS {$alias}";
                     $foreign   = $model->getQualifiedForeignKeyName();
                     $owner     = "{$alias}.{$model->getOwnerKeyName()}";
                     $deletedAt = $this->checkSoftDeletesOnModel($model->getRelated());
+
                     break;
 
                 default:

--- a/tests/Integration/QueryDataTableTest.php
+++ b/tests/Integration/QueryDataTableTest.php
@@ -218,7 +218,7 @@ class QueryDataTableTest extends TestCase
         ]);
 
         $queries = $crawler->json()['queries'];
-        $this->assertContains('"1" = ?', $queries[1]['query']);
+        $this->assertStringContainsString('"1" = ?', $queries[1]['query']);
     }
 
     protected function setUp(): void


### PR DESCRIPTION
A fix for the issue #2045 . It only addresses the "BelongsTo". I did not touch the rest of the relations, so a more complete "fix" can be made.

I also replaced the deprecated function "assertContains" with "assertStringContainsString" in the QueryDataTableTest.

I ran the tests and nothing exploded :P