### PR TITLE
[9.0] Fix rendering column from blade file.

### DIFF
--- a/src/Utilities/Helper.php
+++ b/src/Utilities/Helper.php
@@ -78,7 +78,7 @@ class Helper
     public static function compileBlade($str, $data = [])
     {
         if (view()->exists($str)) {
-            return view($str, $data);
+            return view($str, $data)->render();
         }
 
         ob_start() && extract($data, EXTR_SKIP);


### PR DESCRIPTION
Fix Issue #2062

Column with blade file is rendered by view() but it cannot be converted to json response. render() will return just HTML code.
Also without render if we try to debug $data inside DT source by Log or var_dump it will result with "Allowed memory size of xxx bytes exhausted".