### PR TITLE
[9.0] Pass global search to filter callback.

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -286,7 +286,7 @@ class QueryDataTable extends DataTableAbstract
 
             if ($this->hasFilterColumn($column)) {
                 $keyword = $this->getColumnSearchKeyword($index, $raw = true);
-                $this->applyFilterColumn($this->getBaseQueryBuilder(), $column, $keyword);
+                $this->applyFilterColumn($this->getBaseQueryBuilder(), $column, $keyword, false);
             } else {
                 $column  = $this->resolveRelationColumn($column);
                 $keyword = $this->getColumnSearchKeyword($index);
@@ -333,7 +333,7 @@ class QueryDataTable extends DataTableAbstract
      * @param string $keyword
      * @param string $boolean
      */
-    protected function applyFilterColumn($query, $columnName, $keyword, $boolean = 'and')
+    protected function applyFilterColumn($query, $columnName, $keyword, $boolean = 'and', $isGlobalSearch = false)
     {
         $query    = $this->getBaseQueryBuilder($query);
         $callback = $this->columnDef['filter'][$columnName]['method'];
@@ -344,7 +344,7 @@ class QueryDataTable extends DataTableAbstract
             $builder = $this->query->newQuery();
         }
 
-        $callback($builder, $keyword);
+        $callback($builder, $keyword, $isGlobalSearch);
 
         $query->addNestedWhereQuery($this->getBaseQueryBuilder($builder), $boolean);
     }
@@ -706,7 +706,7 @@ class QueryDataTable extends DataTableAbstract
                 })
                 ->each(function ($column) use ($keyword, $query) {
                     if ($this->hasFilterColumn($column)) {
-                        $this->applyFilterColumn($query, $column, $keyword, 'or');
+                        $this->applyFilterColumn($query, $column, $keyword, 'or', true);
                     } else {
                         $this->compileQuerySearch($query, $column, $keyword);
                     }


### PR DESCRIPTION
I've columns that shouldn't be filtered on global search. E.g. I've a checkbox filter that toggles deleted entries. I tried to filter them like so:

```php
            ->filterColumn('deleted_at', function ($query, $input) {
                if ($input !== '1') {
                    $query->whereNull('users.deleted_at');
                }
            })
```

But this would kill the global search, because this query is also applied in a `or` group.

With this change I would be able to check, if the filter method is global or not like so:

```php
            ->filterColumn('deleted_at', function ($query, $input, $isGlobalSearch) {
                if ($input !== '1' && !$isGlobalSearch) {
                    $query->whereNull('users.deleted_at');
                }
            });
```

What do you say about this solution? Is there a different approach possible?