### PR TITLE
[9.0] Enable the dotted notation in the ->removeColumn() function

### DIFF
--- a/src/Processors/DataProcessor.php
+++ b/src/Processors/DataProcessor.php
@@ -192,7 +192,7 @@ class DataProcessor
     protected function removeExcessColumns(array $data)
     {
         foreach ($this->excessColumns as $value) {
-            unset($data[$value]);
+            Arr::forget($data, $value);
         }
 
         return $data;


### PR DESCRIPTION
The `->removeColumn()` function is currently not removing nested Column when using it like this : 

```
$dataTable->removeColumn(‘user.posts’);
```

using the `Arr::forget()` helper enable the use of the dotted notation in this function