### PR TITLE
[9.0] Using predefined offsets for API-driven server-side(ish) DataTables.

### DIFF
--- a/src/CollectionDataTable.php
+++ b/src/CollectionDataTable.php
@@ -318,10 +318,18 @@ class CollectionDataTable extends DataTableAbstract
         return $this;
     }
 
-    public function setOffset(int $offset)
+    /**
+     * Define the offset of the first item of the collection with respect to
+     * the FULL dataset the collection was sliced from. It effectively allows the
+     * collection to be "pre-sliced".
+     *
+     * @param int $offset
+     * @return $this
+     */
+    public function setOffset($offset)
     {
         $this->offset = $offset;
-        
+
         return $this;
     }
 }

--- a/src/CollectionDataTable.php
+++ b/src/CollectionDataTable.php
@@ -24,6 +24,13 @@ class CollectionDataTable extends DataTableAbstract
     public $original;
 
     /**
+     * The offset of the first record in the full dataset.
+     *
+     * @var int
+     */
+    private $offset = 0;
+
+    /**
      * Can the DataTable engine be created with these parameters.
      *
      * @param mixed $source
@@ -133,7 +140,7 @@ class CollectionDataTable extends DataTableAbstract
     public function paging()
     {
         $this->collection = $this->collection->slice(
-            $this->request->input('start'),
+            $this->request->input('start') - $this->offset,
             (int) $this->request->input('length') > 0 ? $this->request->input('length') : 10
         );
     }
@@ -308,6 +315,13 @@ class CollectionDataTable extends DataTableAbstract
      */
     protected function resolveCallbackParameter()
     {
+        return $this;
+    }
+
+    public function setOffset(int $offset)
+    {
+        $this->offset = $offset;
+        
         return $this;
     }
 }

--- a/src/CollectionDataTable.php
+++ b/src/CollectionDataTable.php
@@ -326,7 +326,7 @@ class CollectionDataTable extends DataTableAbstract
      * @param int $offset
      * @return $this
      */
-    public function setOffset($offset)
+    public function setOffset(int $offset)
     {
         $this->offset = $offset;
 


### PR DESCRIPTION
We had an issue today using DataTables, with server-side processing, using an API to drive the data into the table.

eg...
You have an API that returns 50 records max per request (So we can't simply get it all at once), but provides a "total records" value.
We feed that "total records" into DataTables with `->setTotalRecords($totalRecordsFromApi)`.
This helps us get the correct amount of page numbers for the data.
But whenever we should try to navigate to page 2, telling the API to give us 25 records, starting at offset 25, datatables would just show "No Data".

I initially fixed this by creating `x` dummy rows (x = offset) and merging the collections together before passing the data out to the table, but there must have been a better solution.

We came to the conclusion that an offset parameter should be sent to the method in DataTables that handles the collection splicing for pagination, then minus the offset from the splice's starting index.

This gives us proper pagination when dealing with API data.


Example:
```php
public function datatablesAjax()
{
    $params = [
        'limit' => request()->input('length'),
        'offset' => request()->input('start'),
        'query' => request()->input('search')['value']
    ];

    $data = $this->api->something()->get($params);

    $total = $data->meta->total;

    $someStuff = collect($data->something);

    $datatable = Datatables::of($someStuff)
        ->setOffset(request()->input('start'))
        ->setTotalRecords($total);

    return $datatable->make(true);
}
```