### PR TITLE
[9.0] Enable the dotted notation in the ->only() function

### DIFF
--- a/src/Processors/DataProcessor.php
+++ b/src/Processors/DataProcessor.php
@@ -179,7 +179,17 @@ class DataProcessor
         if (is_null($this->onlyColumns)) {
             return $data;
         } else {
-            return array_intersect_key($data, array_flip(array_merge($this->onlyColumns, $this->exceptions)));
+            $dotted_array = array_intersect_key(
+                array_dot($data),
+                array_flip(array_merge($this->onlyColumns, $this->exceptions))
+            );
+
+            $nested_array = [];
+            foreach ($dotted_array as $key => $value) {
+                array_set($nested_array, $key, $value);
+            }
+
+            return $nested_array;
         }
     }
 

--- a/src/Processors/DataProcessor.php
+++ b/src/Processors/DataProcessor.php
@@ -180,8 +180,13 @@ class DataProcessor
             return $data;
         } else {
             $results = [];
-            foreach (array_merge($this->onlyColumns, $this->exceptions) as $column) {
-                Arr::set($results, $column, Arr::get($data, $column));
+            foreach ($this->onlyColumns as $onlyColumn) {
+                Arr::set($results, $onlyColumn, Arr::get($data, $onlyColumn));
+            }
+            foreach ($this->exceptions as $exception) {
+                if ($column = Arr::get($data, $exception)) {
+                    Arr::set($results, $exception, $column);
+                }
             }
 
             return $results;
@@ -255,7 +260,7 @@ class DataProcessor
     {
         $arrayDot = array_filter(array_dot($row));
         foreach ($arrayDot as $key => $value) {
-            if (! in_array($key, $this->rawColumns)) {
+            if (!in_array($key, $this->rawColumns)) {
                 $arrayDot[$key] = e($value);
             }
         }

--- a/src/Processors/DataProcessor.php
+++ b/src/Processors/DataProcessor.php
@@ -179,17 +179,12 @@ class DataProcessor
         if (is_null($this->onlyColumns)) {
             return $data;
         } else {
-            $dotted_array = array_intersect_key(
-                array_dot($data),
-                array_flip(array_merge($this->onlyColumns, $this->exceptions))
-            );
-
-            $nested_array = [];
-            foreach ($dotted_array as $key => $value) {
-                array_set($nested_array, $key, $value);
+            $results = [];
+            foreach (array_merge($this->onlyColumns, $this->exceptions) as $column) {
+                Arr::set($results, $column, Arr::get($data, $column));
             }
 
-            return $nested_array;
+            return $results;
         }
     }
 

--- a/src/Processors/DataProcessor.php
+++ b/src/Processors/DataProcessor.php
@@ -261,7 +261,7 @@ class DataProcessor
     {
         $arrayDot = array_filter(array_dot($row));
         foreach ($arrayDot as $key => $value) {
-            if (!in_array($key, $this->rawColumns)) {
+            if (! in_array($key, $this->rawColumns)) {
                 $arrayDot[$key] = e($value);
             }
         }


### PR DESCRIPTION
The `->only()` function is currently not removing nested Column when using it like this : 

```
$dataTable->only(‘user.posts’);
```

using the `Arr::dot()` helper and then the `Arr::set()` helper enable the use of the dotted notation in this function