### PR TITLE
[9.0] Add the possibility to makeHidden() some attribute of a model.

### DIFF
--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -247,7 +247,7 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
     }
 
     /**
-     * Add a makeHidden() to the row object
+     * Add a makeHidden() to the row object.
      *
      * @param array          $attributes
      * @return $this

--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -55,6 +55,7 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
         'filter' => [],
         'order'  => [],
         'only'   => null,
+        'make_hidden' => [],
     ];
 
     /**

--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -254,7 +254,6 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
      */
     public function makeHidden(array $attributes = [])
     {
-
         $this->columnDef['make_hidden'] = array_merge_recursive($this->columnDef['make_hidden'] ?: [], $attributes);
 
         return $this;

--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -55,7 +55,7 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
         'filter'      => [],
         'order'       => [],
         'only'        => null,
-        'hidden' => [],
+        'hidden'      => [],
     ];
 
     /**

--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -55,7 +55,7 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
         'filter'      => [],
         'order'       => [],
         'only'        => null,
-        'make_hidden' => [],
+        'hidden' => [],
     ];
 
     /**
@@ -255,7 +255,7 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
      */
     public function makeHidden(array $attributes = [])
     {
-        $this->columnDef['make_hidden'] = array_merge_recursive(array_get($this->columnDef, 'make_hidden', []), $attributes);
+        $this->columnDef['hidden'] = array_merge_recursive(array_get($this->columnDef, 'hidden', []), $attributes);
 
         return $this;
     }

--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -254,7 +254,7 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
      */
     public function makeHidden(array $attributes = [])
     {
-        $this->columnDef['make_hidden'] = array_merge_recursive($this->columnDef['make_hidden'] ?: [], $attributes);
+        $this->columnDef['make_hidden'] = array_merge_recursive(array_get($this->columnDef, 'make_hidden', []), $attributes);
 
         return $this;
     }

--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -247,6 +247,20 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
     }
 
     /**
+     * Add a makeHidden() to the row object
+     *
+     * @param array          $attributes
+     * @return $this
+     */
+    public function makeHidden(array $attributes = [])
+    {
+
+        $this->columnDef['make_hidden'] = array_merge_recursive($this->columnDef['make_hidden'] ?: [], $attributes);
+
+        return $this;
+    }
+
+    /**
      * Set columns that should not be escaped.
      * Optionally merge the defaults from config.
      *

--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -49,12 +49,12 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
      * @var array
      */
     protected $columnDef = [
-        'index'  => false,
-        'append' => [],
-        'edit'   => [],
-        'filter' => [],
-        'order'  => [],
-        'only'   => null,
+        'index'       => false,
+        'append'      => [],
+        'edit'        => [],
+        'filter'      => [],
+        'order'       => [],
+        'only'        => null,
         'make_hidden' => [],
     ];
 

--- a/src/Processors/DataProcessor.php
+++ b/src/Processors/DataProcessor.php
@@ -82,7 +82,7 @@ class DataProcessor
         $this->escapeColumns = $columnDef['escape'];
         $this->includeIndex  = $columnDef['index'];
         $this->rawColumns    = $columnDef['raw'];
-        $this->makeHidden    = $columnDef['make_hidden'];
+        $this->makeHidden    = $columnDef['hidden'];
         $this->templates     = $templates;
         $this->start         = $start;
     }
@@ -99,7 +99,7 @@ class DataProcessor
         $indexColumn  = config('datatables.index_column', 'DT_RowIndex');
 
         foreach ($this->results as $row) {
-            $data  = Helper::convertToArray($row, ['make_hidden' => $this->makeHidden]);
+            $data  = Helper::convertToArray($row, ['hidden' => $this->makeHidden]);
             $value = $this->addColumns($data, $row);
             $value = $this->editColumns($value, $row);
             $value = $this->setupRowVariables($value, $row);

--- a/src/Processors/DataProcessor.php
+++ b/src/Processors/DataProcessor.php
@@ -180,17 +180,7 @@ class DataProcessor
         if (is_null($this->onlyColumns)) {
             return $data;
         } else {
-            $dotted_array = array_intersect_key(
-                array_dot($data),
-                array_flip(array_merge($this->onlyColumns, $this->exceptions))
-            );
-
-            $nested_array = [];
-            foreach ($dotted_array as $key => $value) {
-                array_set($nested_array, $key, $value);
-            }
-
-            return $nested_array;
+            return array_intersect_key($data, array_flip(array_merge($this->onlyColumns, $this->exceptions)));
         }
     }
 

--- a/src/Processors/DataProcessor.php
+++ b/src/Processors/DataProcessor.php
@@ -82,6 +82,7 @@ class DataProcessor
         $this->escapeColumns = $columnDef['escape'];
         $this->includeIndex  = $columnDef['index'];
         $this->rawColumns    = $columnDef['raw'];
+        $this->makeHidden    = $columnDef['make_hidden'];
         $this->templates     = $templates;
         $this->start         = $start;
     }
@@ -98,7 +99,7 @@ class DataProcessor
         $indexColumn  = config('datatables.index_column', 'DT_RowIndex');
 
         foreach ($this->results as $row) {
-            $data  = Helper::convertToArray($row);
+            $data  = Helper::convertToArray($row, ['make_hidden' => $this->makeHidden]);
             $value = $this->addColumns($data, $row);
             $value = $this->editColumns($value, $row);
             $value = $this->setupRowVariables($value, $row);
@@ -179,7 +180,17 @@ class DataProcessor
         if (is_null($this->onlyColumns)) {
             return $data;
         } else {
-            return array_intersect_key($data, array_flip(array_merge($this->onlyColumns, $this->exceptions)));
+            $dotted_array = array_intersect_key(
+                array_dot($data),
+                array_flip(array_merge($this->onlyColumns, $this->exceptions))
+            );
+
+            $nested_array = [];
+            foreach ($dotted_array as $key => $value) {
+                array_set($nested_array, $key, $value);
+            }
+
+            return $nested_array;
         }
     }
 

--- a/src/Utilities/Helper.php
+++ b/src/Utilities/Helper.php
@@ -151,10 +151,12 @@ class Helper
      * Converts array object values to associative array.
      *
      * @param mixed $row
+     * @param array $filters
      * @return array
      */
-    public static function convertToArray($row)
+    public static function convertToArray($row, $filters = [])
     {
+        $row = method_exists($row, 'makeHidden') ? $row->makeHidden($filters['make_hidden']) : $row;
         $data = $row instanceof Arrayable ? $row->toArray() : (array) $row;
 
         foreach ($data as &$value) {

--- a/src/Utilities/Helper.php
+++ b/src/Utilities/Helper.php
@@ -120,7 +120,7 @@ class Helper
     public static function castToArray($param)
     {
         if ($param instanceof \stdClass) {
-            $param = (array)$param;
+            $param = (array) $param;
 
             return $param;
         }
@@ -140,7 +140,7 @@ class Helper
      */
     public static function getOrMethod($method)
     {
-        if (!Str::contains(Str::lower($method), 'or')) {
+        if (! Str::contains(Str::lower($method), 'or')) {
             return 'or' . ucfirst($method);
         }
 
@@ -157,7 +157,7 @@ class Helper
     public static function convertToArray($row, $filters = [])
     {
         $row  = method_exists($row, 'makeHidden') ? $row->makeHidden($filters['make_hidden']) : $row;
-        $data = $row instanceof Arrayable ? $row->toArray() : (array)$row;
+        $data = $row instanceof Arrayable ? $row->toArray() : (array) $row;
 
         foreach ($data as &$value) {
             if (is_object($value) || is_array($value)) {
@@ -194,7 +194,7 @@ class Helper
                 $row[$key] = $value->format('Y-m-d H:i:s');
             } else {
                 if (is_object($value)) {
-                    $row[$key] = (string)$value;
+                    $row[$key] = (string) $value;
                 } else {
                     $row[$key] = $value;
                 }
@@ -261,7 +261,7 @@ class Helper
     {
         $matches = explode(' as ', Str::lower($str));
 
-        if (!empty($matches)) {
+        if (! empty($matches)) {
             if ($wantsAlias) {
                 return array_pop($matches);
             }

--- a/src/Utilities/Helper.php
+++ b/src/Utilities/Helper.php
@@ -156,7 +156,7 @@ class Helper
      */
     public static function convertToArray($row, $filters = [])
     {
-        $row  = method_exists($row, 'makeHidden') ? $row->makeHidden($filters['make_hidden']) : $row;
+        $row  = method_exists($row, 'makeHidden') ? $row->makeHidden(array_get($filters, 'make_hidden', [])) : $row;
         $data = $row instanceof Arrayable ? $row->toArray() : (array) $row;
 
         foreach ($data as &$value) {

--- a/src/Utilities/Helper.php
+++ b/src/Utilities/Helper.php
@@ -120,7 +120,7 @@ class Helper
     public static function castToArray($param)
     {
         if ($param instanceof \stdClass) {
-            $param = (array) $param;
+            $param = (array)$param;
 
             return $param;
         }
@@ -140,7 +140,7 @@ class Helper
      */
     public static function getOrMethod($method)
     {
-        if (! Str::contains(Str::lower($method), 'or')) {
+        if (!Str::contains(Str::lower($method), 'or')) {
             return 'or' . ucfirst($method);
         }
 
@@ -156,8 +156,8 @@ class Helper
      */
     public static function convertToArray($row, $filters = [])
     {
-        $row = method_exists($row, 'makeHidden') ? $row->makeHidden($filters['make_hidden']) : $row;
-        $data = $row instanceof Arrayable ? $row->toArray() : (array) $row;
+        $row  = method_exists($row, 'makeHidden') ? $row->makeHidden($filters['make_hidden']) : $row;
+        $data = $row instanceof Arrayable ? $row->toArray() : (array)$row;
 
         foreach ($data as &$value) {
             if (is_object($value) || is_array($value)) {
@@ -194,7 +194,7 @@ class Helper
                 $row[$key] = $value->format('Y-m-d H:i:s');
             } else {
                 if (is_object($value)) {
-                    $row[$key] = (string) $value;
+                    $row[$key] = (string)$value;
                 } else {
                     $row[$key] = $value;
                 }
@@ -261,7 +261,7 @@ class Helper
     {
         $matches = explode(' as ', Str::lower($str));
 
-        if (! empty($matches)) {
+        if (!empty($matches)) {
             if ($wantsAlias) {
                 return array_pop($matches);
             }

--- a/src/Utilities/Helper.php
+++ b/src/Utilities/Helper.php
@@ -156,7 +156,7 @@ class Helper
      */
     public static function convertToArray($row, $filters = [])
     {
-        $row  = method_exists($row, 'makeHidden') ? $row->makeHidden(array_get($filters, 'make_hidden', [])) : $row;
+        $row  = method_exists($row, 'makeHidden') ? $row->makeHidden(array_get($filters, 'hidden', [])) : $row;
         $data = $row instanceof Arrayable ? $row->toArray() : (array) $row;
 
         foreach ($data as &$value) {


### PR DESCRIPTION
When converting the data into an array processable by the library, if the row object is an instance of Arrayable, the method `toArray()` is called on it.

The `toArray()` method compute all getters on the object’s attributes which can take some processing time.

Within this PR, I added the possiblity to use a makeHidden() before this convertion using the following synthax : 

```
$datatable->makeHidden([’posts`]);
```

It can grealty reduce the processing time if you don’t need a huge relationship in the resulting array

As for now, the `makeHidden()` of an eloquent Object does not allow the use of a dot notation (like this `->makeHidden([’posts.comments`]);`) but I hope it will eventually. In the meantime, it might be usefull to implement it inside the laravel-datatables library.