### PR TITLE
[8.0] Removal of redundant SoftDelete check.

### DIFF
--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -138,7 +138,6 @@ class EloquentDataTable extends QueryDataTable
     protected function joinEagerLoadedColumn($relation, $relationColumn)
     {
         $table     = '';
-        $deletedAt = false;
         $lastQuery = $this->query;
         foreach (explode('.', $relation) as $eachRelation) {
             $model = $lastQuery->getRelation($eachRelation);
@@ -164,33 +163,22 @@ class EloquentDataTable extends QueryDataTable
                     $table     = $model->getRelated()->getTable();
                     $foreign   = $model->getQualifiedForeignKeyName();
                     $other     = $model->getQualifiedParentKeyName();
-                    $deletedAt = $this->checkSoftDeletesOnModel($model->getRelated());
                     break;
 
                 case $model instanceof BelongsTo:
                     $table     = $model->getRelated()->getTable();
                     $foreign   = $model->getQualifiedForeignKey();
                     $other     = $model->getQualifiedOwnerKeyName();
-                    $deletedAt = $this->checkSoftDeletesOnModel($model->getRelated());
                     break;
 
                 default:
                     throw new Exception('Relation ' . get_class($model) . ' is not yet supported.');
             }
-            $this->performJoin($table, $foreign, $other, $deletedAt);
+            $this->performJoin($table, $foreign, $other);
             $lastQuery = $model->getQuery();
         }
 
         return $table . '.' . $relationColumn;
-    }
-
-    protected function checkSoftDeletesOnModel($model)
-    {
-        if (in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses($model))) {
-            return $model->getQualifiedDeletedAtColumn();
-        }
-
-        return false;
     }
 
     /**
@@ -199,10 +187,9 @@ class EloquentDataTable extends QueryDataTable
      * @param string $table
      * @param string $foreign
      * @param string $other
-     * @param string $deletedAt
      * @param string $type
      */
-    protected function performJoin($table, $foreign, $other, $deletedAt = false, $type = 'left')
+    protected function performJoin($table, $foreign, $other, $type = 'left')
     {
         $joins = [];
         foreach ((array) $this->getBaseQueryBuilder()->joins as $key => $join) {
@@ -211,10 +198,6 @@ class EloquentDataTable extends QueryDataTable
 
         if (! in_array($table, $joins)) {
             $this->getBaseQueryBuilder()->join($table, $foreign, '=', $other, $type);
-        }
-
-        if ($deletedAt !== false) {
-            $this->getBaseQueryBuilder()->whereNull($deletedAt);
         }
     }
 }

--- a/tests/Integration/HasManyRelationTest.php
+++ b/tests/Integration/HasManyRelationTest.php
@@ -94,13 +94,13 @@ class HasManyRelationTest extends TestCase
         });
 
         $this->app['router']->get('/relations/hasManyWithTrashed', function (DataTables $datatables) {
-            return $datatables->eloquent(User::with(['posts' => function($query) {
+            return $datatables->eloquent(User::with(['posts' => function ($query) {
                 $query->withTrashed();
             }])->select('users.*'))->toJson();
         });
 
         $this->app['router']->get('/relations/hasManyOnlyTrashed', function (DataTables $datatables) {
-            return $datatables->eloquent(User::with(['posts' => function($query) {
+            return $datatables->eloquent(User::with(['posts' => function ($query) {
                 $query->onlyTrashed();
             }])->select('users.*'))->toJson();
         });

--- a/tests/Integration/HasManyRelationTest.php
+++ b/tests/Integration/HasManyRelationTest.php
@@ -3,8 +3,8 @@
 namespace Yajra\DataTables\Tests\Integration;
 
 use Yajra\DataTables\DataTables;
-use Yajra\DataTables\Tests\Models\Post;
 use Yajra\DataTables\Tests\TestCase;
+use Yajra\DataTables\Tests\Models\Post;
 use Yajra\DataTables\Tests\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
@@ -94,13 +94,13 @@ class HasManyRelationTest extends TestCase
         });
 
         $this->app['router']->get('/relations/hasManyWithTrashed', function (DataTables $datatables) {
-            return $datatables->eloquent(User::with(['posts' => function($query){
+            return $datatables->eloquent(User::with(['posts' => function($query) {
                 $query->withTrashed();
             }])->select('users.*'))->toJson();
         });
 
         $this->app['router']->get('/relations/hasManyOnlyTrashed', function (DataTables $datatables) {
-            return $datatables->eloquent(User::with(['posts' => function($query){
+            return $datatables->eloquent(User::with(['posts' => function($query) {
                 $query->onlyTrashed();
             }])->select('users.*'))->toJson();
         });

--- a/tests/Integration/HasOneRelationTest.php
+++ b/tests/Integration/HasOneRelationTest.php
@@ -3,6 +3,7 @@
 namespace Yajra\DataTables\Tests\Integration;
 
 use Yajra\DataTables\DataTables;
+use Yajra\DataTables\Tests\Models\Heart;
 use Yajra\DataTables\Tests\TestCase;
 use Yajra\DataTables\Tests\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -23,6 +24,42 @@ class HasOneRelationTest extends TestCase
 
         $this->assertArrayHasKey('heart', $response->json()['data'][0]);
         $this->assertCount(20, $response->json()['data']);
+    }
+
+    /** @test */
+    public function it_returns_all_records_with_the_deleted_relation_when_called_with_withtrashed_parameter()
+    {
+        Heart::find(1)->delete();
+
+        $response = $this->call('GET', '/relations/hasOneWithTrashed');
+        $response->assertJson([
+            'draw'            => 0,
+            'recordsTotal'    => 20,
+            'recordsFiltered' => 20,
+        ]);
+
+        $this->assertArrayHasKey('heart', $response->json()['data'][0]);
+        $this->assertArrayHasKey('heart', $response->json()['data'][1]);
+        $this->assertNotEmpty($response->json()['data'][0]['heart']);
+        $this->assertNotEmpty($response->json()['data'][1]['heart']);
+    }
+
+    /** @test */
+    public function it_returns_all_records_with_the_only_deleted_relation_when_called_with_onlytrashed_parameter()
+    {
+        Heart::find(1)->delete();
+
+        $response = $this->call('GET', '/relations/hasOneOnlyTrashed');
+        $response->assertJson([
+            'draw'            => 0,
+            'recordsTotal'    => 20,
+            'recordsFiltered' => 20,
+        ]);
+
+        $this->assertArrayHasKey('heart', $response->json()['data'][0]);
+        $this->assertArrayHasKey('heart', $response->json()['data'][1]);
+        $this->assertNotEmpty($response->json()['data'][0]['heart']);
+        $this->assertEmpty($response->json()['data'][1]['heart']);
     }
 
     /** @test */
@@ -85,6 +122,18 @@ class HasOneRelationTest extends TestCase
 
         $this->app['router']->get('/relations/hasOne', function (DataTables $datatables) {
             return $datatables->eloquent(User::with('heart')->select('users.*'))->toJson();
+        });
+
+        $this->app['router']->get('/relations/hasOneWithTrashed', function (DataTables $datatables) {
+            return $datatables->eloquent(User::with(['heart' => function($query){
+                $query->withTrashed();
+            }])->select('users.*'))->toJson();
+        });
+
+        $this->app['router']->get('/relations/hasOneOnlyTrashed', function (DataTables $datatables) {
+            return $datatables->eloquent(User::with(['heart' => function($query){
+                $query->onlyTrashed();
+            }])->select('users.*'))->toJson();
         });
     }
 }

--- a/tests/Integration/HasOneRelationTest.php
+++ b/tests/Integration/HasOneRelationTest.php
@@ -125,13 +125,13 @@ class HasOneRelationTest extends TestCase
         });
 
         $this->app['router']->get('/relations/hasOneWithTrashed', function (DataTables $datatables) {
-            return $datatables->eloquent(User::with(['heart' => function($query) {
+            return $datatables->eloquent(User::with(['heart' => function ($query) {
                 $query->withTrashed();
             }])->select('users.*'))->toJson();
         });
 
         $this->app['router']->get('/relations/hasOneOnlyTrashed', function (DataTables $datatables) {
-            return $datatables->eloquent(User::with(['heart' => function($query) {
+            return $datatables->eloquent(User::with(['heart' => function ($query) {
                 $query->onlyTrashed();
             }])->select('users.*'))->toJson();
         });

--- a/tests/Integration/HasOneRelationTest.php
+++ b/tests/Integration/HasOneRelationTest.php
@@ -3,9 +3,9 @@
 namespace Yajra\DataTables\Tests\Integration;
 
 use Yajra\DataTables\DataTables;
-use Yajra\DataTables\Tests\Models\Heart;
 use Yajra\DataTables\Tests\TestCase;
 use Yajra\DataTables\Tests\Models\User;
+use Yajra\DataTables\Tests\Models\Heart;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class HasOneRelationTest extends TestCase
@@ -125,13 +125,13 @@ class HasOneRelationTest extends TestCase
         });
 
         $this->app['router']->get('/relations/hasOneWithTrashed', function (DataTables $datatables) {
-            return $datatables->eloquent(User::with(['heart' => function($query){
+            return $datatables->eloquent(User::with(['heart' => function($query) {
                 $query->withTrashed();
             }])->select('users.*'))->toJson();
         });
 
         $this->app['router']->get('/relations/hasOneOnlyTrashed', function (DataTables $datatables) {
-            return $datatables->eloquent(User::with(['heart' => function($query){
+            return $datatables->eloquent(User::with(['heart' => function($query) {
                 $query->onlyTrashed();
             }])->select('users.*'))->toJson();
         });

--- a/tests/Models/Heart.php
+++ b/tests/Models/Heart.php
@@ -3,10 +3,15 @@
 namespace Yajra\DataTables\Tests\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Heart extends Model
 {
-    protected $guarded = [];
+	use SoftDeletes;
+
+	protected $guarded = [];
+
+	protected $dates = ['deleted_at'];
 
     public function user()
     {

--- a/tests/Models/Heart.php
+++ b/tests/Models/Heart.php
@@ -7,11 +7,11 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Heart extends Model
 {
-	use SoftDeletes;
+    use SoftDeletes;
 
-	protected $guarded = [];
+    protected $guarded = [];
 
-	protected $dates = ['deleted_at'];
+    protected $dates = ['deleted_at'];
 
     public function user()
     {

--- a/tests/Models/Post.php
+++ b/tests/Models/Post.php
@@ -7,11 +7,11 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Post extends Model
 {
-	use SoftDeletes;
+    use SoftDeletes;
 
-	protected $guarded = [];
+    protected $guarded = [];
 
-	protected $dates = ['deleted_at'];
+    protected $dates = ['deleted_at'];
 
     public function user()
     {

--- a/tests/Models/Post.php
+++ b/tests/Models/Post.php
@@ -3,10 +3,15 @@
 namespace Yajra\DataTables\Tests\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Post extends Model
 {
-    protected $guarded = [];
+	use SoftDeletes;
+
+	protected $guarded = [];
+
+	protected $dates = ['deleted_at'];
 
     public function user()
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -36,6 +36,7 @@ abstract class TestCase extends BaseTestCase
                 $table->string('title');
                 $table->unsignedInteger('user_id');
                 $table->timestamps();
+                $table->softDeletes();
             });
         }
         if (! $schemaBuilder->hasTable('hearts')) {
@@ -44,6 +45,7 @@ abstract class TestCase extends BaseTestCase
                 $table->unsignedInteger('user_id');
                 $table->string('size');
                 $table->timestamps();
+                $table->softDeletes();
             });
         }
         if (! $schemaBuilder->hasTable('roles')) {


### PR DESCRIPTION
Existing method of SoftDelete check brakes relations that looks like:
```
class Thread extends Model {
   public function threads() {
      return $this->belongsTo(Thread::class)->withTrashed();
   }
}
```

or

```
class Thread extends Model {
   public function threads() {
      return $this->belongsTo(Thread::class)->onlyTrashed();
   }
}
```
Both of them got filtered by `whereNull($deletedAt)` while joining. 
Instead of this, no filtering should be applied at all on first model. 
`whereNotNull($deletedAt)` should be called at second model. 
This works well out of a box. 
