### PR TITLE
[9.0] Add support for startsWithSearch filter.

### DIFF
--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -440,12 +440,25 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
     /**
      * Set smart search config at runtime.
      *
-     * @param bool $bool
+     * @param bool $state
      * @return $this
      */
-    public function smart($bool = true)
+    public function smart($state = true)
     {
-        $this->config->set(['datatables.search.smart' => $bool]);
+        $this->config->set('datatables.search.smart', $state);
+
+        return $this;
+    }
+
+    /**
+     * Set starts_with search config at runtime.
+     *
+     * @param bool $state
+     * @return $this
+     */
+    public function startsWithSearch($state = true)
+    {
+        $this->config->set('datatables.search.starts_with', $state);
 
         return $this;
     }

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -493,6 +493,10 @@ class QueryDataTable extends DataTableAbstract
      */
     protected function prepareKeyword($keyword)
     {
+        if ($this->config->isStartsWithSearch()) {
+            return "$keyword%";
+        }
+
         if ($this->config->isCaseInsensitive()) {
             $keyword = Str::lower($keyword);
         }

--- a/src/Utilities/Config.php
+++ b/src/Utilities/Config.php
@@ -94,4 +94,14 @@ class Config
     {
         return $this->repository->get('datatables.search.multi_term', true);
     }
+
+    /**
+     * Check if dataTable config uses starts_with searching.
+     *
+     * @return bool
+     */
+    public function isStartsWithSearch()
+    {
+        return $this->repository->get('datatables.search.starts_with', false);
+    }
 }

--- a/src/config/datatables.php
+++ b/src/config/datatables.php
@@ -27,6 +27,12 @@ return [
          * SQL: column LIKE "%k%e%y%w%o%r%d%"
          */
         'use_wildcards' => false,
+
+        /*
+         * Perform a search which starts with the given keyword.
+         * SQL: column LIKE "keyword%"
+         */
+        'starts_with'    => false,
     ],
 
     /*


### PR DESCRIPTION
Fix #2161

## Usage

```php
        return datatables()
            ->eloquent($query)
            ->setRowId('id')
            ->startsWithSearch(); // enable starts with keyword filter.
````