### PR TITLE
[7.0] Use an empty array as the default value when no columns are found

### DIFF
--- a/src/Engines/CollectionEngine.php
+++ b/src/Engines/CollectionEngine.php
@@ -207,7 +207,7 @@ class CollectionEngine extends BaseEngine
      */
     public function columnSearch()
     {
-        $columns = $this->request->get('columns');
+        $columns = $this->request->get('columns', []);
         for ($i = 0, $c = count($columns); $i < $c; $i++) {
             if ($this->request->isColumnSearchable($i)) {
                 $this->isFilterApplied = true;


### PR DESCRIPTION
At my place of work we are still using Laravel 5.4 and Laravel Datatables 7. This small change is necessary to prevent us requiring a fork of Laravel Datatables.

Here are the later commits where this problem is fixed in Laravel Datatables 8/9.

- https://github.com/yajra/laravel-datatables/commit/4136d7b
- https://github.com/yajra/laravel-datatables/commit/784fdeb