### PR TITLE
[9.0] Add column formatter.

### DIFF
--- a/src/Contracts/Formatter.php
+++ b/src/Contracts/Formatter.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Yajra\DataTables\Contracts;
+
+interface Formatter
+{
+    /**
+     * @param string $value
+     * @param mixed $row
+     * @return string
+     */
+    public function format($value, $row);
+}

--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -194,6 +194,7 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
      * @param string|array $columns
      * @param mixed|\Yajra\DataTables\Contracts\Formatter $formatter
      * @return $this
+     * @throws \Exception
      */
     public function formatColumn($columns, $formatter)
     {
@@ -202,7 +203,7 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
         }
 
         if (! $formatter instanceof Formatter) {
-            throw new \Exception('Formatter must be an instance of '. Formatter::class);
+            throw new \Exception('$formatter must be an instance of '. Formatter::class);
         }
 
         foreach ((array) $columns as $column) {

--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -775,7 +775,7 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
      * Get processed data.
      *
      * @param mixed $results
-     * @param bool $object
+     * @param bool  $object
      * @return array
      */
     protected function processResults($results, $object = false)

--- a/src/Processors/DataProcessor.php
+++ b/src/Processors/DataProcessor.php
@@ -5,6 +5,7 @@ namespace Yajra\DataTables\Processors;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
 use Yajra\DataTables\Utilities\Helper;
+use Yajra\DataTables\Contracts\Formatter;
 
 class DataProcessor
 {
@@ -127,9 +128,16 @@ class DataProcessor
      */
     protected function addColumns($data, $row)
     {
-        foreach ($this->appendColumns as $key => $value) {
-            $value['content'] = Helper::compileContent($value['content'], $data, $row);
-            $data             = Helper::includeInArray($value, $data);
+        foreach ($this->appendColumns as $value) {
+            if ($value['content'] instanceof Formatter) {
+                $column = str_replace('_formatted', '', $value['name']);
+
+                $value['content'] = $value['content']->format($data[$column], $row);
+            } else {
+                $value['content'] = Helper::compileContent($value['content'], $data, $row);
+            }
+
+            $data = Helper::includeInArray($value, $data);
         }
 
         return $data;

--- a/tests/Integration/QueryDataTableTest.php
+++ b/tests/Integration/QueryDataTableTest.php
@@ -11,6 +11,8 @@ use Yajra\DataTables\Facades\DataTables as DatatablesFacade;
 use Yajra\DataTables\QueryDataTable;
 use Yajra\DataTables\Tests\Models\User;
 use Yajra\DataTables\Tests\TestCase;
+use Carbon\Carbon;
+use Yajra\DataTables\Contracts\Formatter;
 
 class QueryDataTableTest extends TestCase
 {
@@ -286,6 +288,27 @@ class QueryDataTableTest extends TestCase
         ]);
     }
 
+    /** @test */
+    public function it_can_return_formatted_columns()
+    {
+        $crawler = $this->call('GET', '/query/formatColumn');
+
+        $crawler->assertJson([
+            'draw'            => 0,
+            'recordsTotal'    => 20,
+            'recordsFiltered' => 20,
+        ]);
+
+        $user = DB::table('users')->find(1);
+        $data = $crawler->json('data')[0];
+
+        $this->assertTrue(isset($data['created_at']));
+        $this->assertTrue(isset($data['created_at_formatted']));
+
+        $this->assertEquals($user->created_at, $data['created_at']);
+        $this->assertEquals(Carbon::parse($user->created_at)->format('Y-m-d'), $data['created_at_formatted']);
+    }
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -294,6 +317,12 @@ class QueryDataTableTest extends TestCase
 
         $route->get('/query/users', function (DataTables $dataTable) {
             return $dataTable->query(DB::table('users'))->toJson();
+        });
+
+        $route->get('/query/formatColumn', function (DataTables $dataTable) {
+            return $dataTable->query(DB::table('users'))
+                        ->formatColumn('created_at', new DateFormatter('Y-m-d'))
+                        ->toJson();
         });
 
         $route->get('/query/simple', function (DataTables $dataTable) {
@@ -376,3 +405,23 @@ class QueryDataTableTest extends TestCase
         });
     }
 }
+
+class DateFormatter implements Formatter
+{
+    protected $format;
+
+    public function __construct($format = null)
+    {
+        $this->format = $format;
+    }
+
+    public function format($value, $row)
+    {
+        if ($this->format) {
+            return Carbon::parse($value)->format($this->format);
+        }
+
+        return Carbon::parse($value)->diffForHumans();
+    }
+}
+


### PR DESCRIPTION
- Proposed implementation of field/column [formatters](https://editor.datatables.net/manual/php/formatters).
- Fix https://github.com/yajra/laravel-datatables-editor/issues/33

## Example

### Date Formatter

```php
use Carbon\Carbon;
use Yajra\DataTables\Contracts\Formatter;

class DateFormatter implements Formatter
{
    protected $format;

    public function __construct($format = null)
    {
        $this->format = $format;
    }

    public function format($value, $row)
    {
        if ($this->format) {
            return Carbon::parse($value)->format($this->format);
        }

        return Carbon::parse($value)->diffForHumans();
    }
}
```

### Server-side script
```php
    public function dataTable($query)
    {
        $formatter = new DateFormatter($format = 'Y-m-d');

        return datatables()
            ->eloquent($query)
            ->formatColumn('updated_at', new DateFormatter) // using new formatter instance
            ->formatColumn('created_at', DateFormatter::class) // using formatter class
            ->formatColumn('published_at', $formatter) // using instance
            ->formatColumn(['published_at', 'created_at'], $formatter) // format multiple columns
            ->setRowId('id');
    }

 ...

// columns
return [
  Column::make('status')->data('status_formatted'),
  ...
]
```

### Json Response

```js
{
  data: [
    {
      id: 1, 
      created_at: "2020-11-03T02:27:20.000000Z", 
      created_at_formatted: "2020-11-03"
    }
  ],
  ...
}
```

