### PR TITLE
[9.0] Allow orderColumn using closure.

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -673,10 +673,14 @@ class QueryDataTable extends DataTableAbstract
      */
     protected function applyOrderColumn($column, $orderable)
     {
-        $sql      = $this->columnDef['order'][$column]['sql'];
-        $sql      = str_replace('$1', $orderable['direction'], $sql);
-        $bindings = $this->columnDef['order'][$column]['bindings'];
-        $this->query->orderByRaw($sql, $bindings);
+        $sql = $this->columnDef['order'][$column]['sql'];
+        if (is_callable($sql)) {
+            call_user_func($sql, $this->query, $orderable['direction']);
+        } else {
+            $sql      = str_replace('$1', $orderable['direction'], $sql);
+            $bindings = $this->columnDef['order'][$column]['bindings'];
+            $this->query->orderByRaw($sql, $bindings);
+        }
     }
 
     /**


### PR DESCRIPTION
Fix #2159, #2194.

```php
return datatables()
    ->eloquent($query)
    ->setRowId('id')
    ->orderColumn('status', function($query, $order) {
        $query->orderBy('status', $order);
    });
```