### PR TITLE
[9.0] Fix skipTotalRecords api not working on initial state.

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -158,7 +158,9 @@ class QueryDataTable extends DataTableAbstract
     public function totalCount()
     {
         if ($this->skipTotalRecords) {
-            return true;
+            $this->isFilterApplied = true;
+
+            return 1;
         }
 
         return $this->totalRecords ? $this->totalRecords : $this->count();


### PR DESCRIPTION
Set filterApplied to true to always trigger counting of filteredRecords.