### PR TITLE
Cast database engines to array.

### DIFF
--- a/src/DataTablesServiceProvider.php
+++ b/src/DataTablesServiceProvider.php
@@ -41,7 +41,7 @@ class DataTablesServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $engines = config('datatables.engines');
+        $engines = (array) config('datatables.engines');
         foreach ($engines as $engine => $class) {
             $engine = Str::camel($engine);
 

--- a/src/DataTablesServiceProvider.php
+++ b/src/DataTablesServiceProvider.php
@@ -2,9 +2,9 @@
 
 namespace Yajra\DataTables;
 
+use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Yajra\DataTables\Utilities\Config;
-use Illuminate\Support\ServiceProvider;
 use Yajra\DataTables\Utilities\Request;
 
 class DataTablesServiceProvider extends ServiceProvider


### PR DESCRIPTION
Prevents passing `null` to the `foreach` loop in case no database engines defined.

Fix #2202 
<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
