### PR TITLE
[9.0] Add the possibility to makeVisible() some attribute of a model.

### DIFF
--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -57,6 +57,7 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
         'order'       => [],
         'only'        => null,
         'hidden'      => [],
+        'visible'     => [],
     ];
 
     /**
@@ -257,6 +258,19 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
     public function makeHidden(array $attributes = [])
     {
         $this->columnDef['hidden'] = array_merge_recursive(Arr::get($this->columnDef, 'hidden', []), $attributes);
+
+        return $this;
+    }
+
+    /**
+     * Add a makeVisible() to the row object.
+     *
+     * @param array          $attributes
+     * @return $this
+     */
+    public function makeVisible(array $attributes = [])
+    {
+        $this->columnDef['visible'] = array_merge_recursive(Arr::get($this->columnDef, 'visible', []), $attributes);
 
         return $this;
     }

--- a/src/Processors/DataProcessor.php
+++ b/src/Processors/DataProcessor.php
@@ -83,6 +83,7 @@ class DataProcessor
         $this->includeIndex  = $columnDef['index'];
         $this->rawColumns    = $columnDef['raw'];
         $this->makeHidden    = $columnDef['hidden'];
+        $this->makeVisible   = $columnDef['visible'];
         $this->templates     = $templates;
         $this->start         = $start;
     }
@@ -99,7 +100,7 @@ class DataProcessor
         $indexColumn  = config('datatables.index_column', 'DT_RowIndex');
 
         foreach ($this->results as $row) {
-            $data  = Helper::convertToArray($row, ['hidden' => $this->makeHidden]);
+            $data  = Helper::convertToArray($row, ['hidden' => $this->makeHidden, 'visible' => $this->makeVisible]);
             $value = $this->addColumns($data, $row);
             $value = $this->editColumns($value, $row);
             $value = $this->setupRowVariables($value, $row);

--- a/src/Utilities/Helper.php
+++ b/src/Utilities/Helper.php
@@ -158,6 +158,7 @@ class Helper
     public static function convertToArray($row, $filters = [])
     {
         $row  = method_exists($row, 'makeHidden') ? $row->makeHidden(Arr::get($filters, 'hidden', [])) : $row;
+        $row  = method_exists($row, 'makeVisible') ? $row->makeVisible(Arr::get($filters, 'visible', [])) : $row;
         $data = $row instanceof Arrayable ? $row->toArray() : (array) $row;
 
         foreach ($data as &$value) {


### PR DESCRIPTION
The opposite of PR #2085 
Add a makeVisible() to the row object.

Use case: 
My eloquent model have `$visible` attribute that limit serialization to JSON.
e.g. `protected $visible = ['uuid', 'name'];`
Need a method to temporarily modifying attribute visibility on datatables (on opposite of makeHidden()).