### PR TITLE
Adds Option to Enable/Disable Searching & Filtering (In case user already has searched/filtered dataset)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "dylancoots-mwi/laravel-datatables",
+  "name": "yajra/laravel-datatables-oracle",
   "description": "jQuery DataTables API for Laravel 4|5",
   "keywords": [
     "laravel",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "dylancoots-mwi/laravel-datatables-oracle",
+  "name": "yajra/laravel-datatables-oracle",
   "description": "jQuery DataTables API for Laravel 4|5",
   "keywords": [
     "laravel",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "yajra/laravel-datatables-oracle",
+  "name": "dylancoots-mwi/laravel-datatables",
   "description": "jQuery DataTables API for Laravel 4|5",
   "keywords": [
     "laravel",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "dylancoots-mwi/laravel-datatables",
+  "name": "yajra/laravel-datatables-oracle",
   "description": "jQuery DataTables API for Laravel 4|5",
   "keywords": [
     "laravel",
@@ -15,11 +15,11 @@
   ],
   "require": {
     "php": "^7.1.3",
-    "illuminate/database": "5.7.*|^6.0",
-    "illuminate/filesystem": "5.7.*|^6.0",
-    "illuminate/http": "5.7.*|^6.0",
-    "illuminate/support": "5.7.*|^6.0",
-    "illuminate/view": "5.7.*|^6.0"
+    "illuminate/database": "5.8.*|^6.0",
+    "illuminate/filesystem": "5.8.*|^6.0",
+    "illuminate/http": "5.8.*|^6.0",
+    "illuminate/support": "5.8.*|^6.0",
+    "illuminate/view": "5.8.*|^6.0"
   },
   "require-dev": {
     "orchestra/testbench": "^3.8"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "yajra/laravel-datatables-oracle",
+  "name": "dylancoots-mwi/laravel-datatables-oracle",
   "description": "jQuery DataTables API for Laravel 4|5",
   "keywords": [
     "laravel",

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
   ],
   "require": {
     "php": "^7.1.3",
-    "illuminate/database": "5.8.*|^6.0",
-    "illuminate/filesystem": "5.8.*|^6.0",
-    "illuminate/http": "5.8.*|^6.0",
-    "illuminate/support": "5.8.*|^6.0",
-    "illuminate/view": "5.8.*|^6.0"
+    "illuminate/database": "5.7.*|^6.0",
+    "illuminate/filesystem": "5.7.*|^6.0",
+    "illuminate/http": "5.7.*|^6.0",
+    "illuminate/support": "5.7.*|^6.0",
+    "illuminate/view": "5.7.*|^6.0"
   },
   "require-dev": {
     "orchestra/testbench": "^3.8"

--- a/src/CollectionDataTable.php
+++ b/src/CollectionDataTable.php
@@ -152,6 +152,8 @@ class CollectionDataTable extends DataTableAbstract
      * Organizes works.
      *
      * @param bool $mDataSupport
+     * @param bool $useFiltering Choose whether to use built in filter functions
+     * @param bool $useOrdering Choose whether to use built in order functions
      * @return \Illuminate\Http\JsonResponse
      */
     public function make($mDataSupport = true, $useFiltering = true, $useOrdering = true)

--- a/src/CollectionDataTable.php
+++ b/src/CollectionDataTable.php
@@ -154,7 +154,7 @@ class CollectionDataTable extends DataTableAbstract
      * @param bool $mDataSupport
      * @return \Illuminate\Http\JsonResponse
      */
-    public function make($mDataSupport = true)
+    public function make($mDataSupport = true, $useFiltering = true, $useOrdering = true)
     {
         try {
             $this->totalRecords = $this->totalCount();
@@ -165,8 +165,12 @@ class CollectionDataTable extends DataTableAbstract
                 $output    = $this->transform($results, $processed);
 
                 $this->collection = collect($output);
-                $this->ordering();
-                $this->filterRecords();
+                if ($useOrdering) {
+                    $this->ordering();
+                }
+                if ($useFiltering) {
+                    $this->filterRecords();
+                }
                 $this->paginate();
 
                 $this->revertIndexColumn($mDataSupport);

--- a/src/Contracts/DataTable.php
+++ b/src/Contracts/DataTable.php
@@ -69,5 +69,5 @@ interface DataTable
      * @param bool $mDataSupport
      * @return \Illuminate\Http\JsonResponse
      */
-    public function make($mDataSupport = true);
+    public function make($mDataSupport = true, $useFiltering = true, $useOrdering = true);
 }

--- a/src/Contracts/DataTable.php
+++ b/src/Contracts/DataTable.php
@@ -67,6 +67,8 @@ interface DataTable
      * Organizes works.
      *
      * @param bool $mDataSupport
+     * @param bool $useFiltering Choose whether to use built in filter functions
+     * @param bool $useOrdering Choose whether to use built in order functions
      * @return \Illuminate\Http\JsonResponse
      */
     public function make($mDataSupport = true, $useFiltering = true, $useOrdering = true);

--- a/src/DataTables.php
+++ b/src/DataTables.php
@@ -42,7 +42,7 @@ class DataTables
      * @return mixed
      * @throws \Exception
      */
-    public static function make($source)
+    public static function make($source, $useFiltering = true, $useOrdering = true)
     {
         $engines  = config('datatables.engines');
         $builders = config('datatables.builders');

--- a/src/DataTables.php
+++ b/src/DataTables.php
@@ -39,6 +39,8 @@ class DataTables
      * Make a DataTable instance from source.
      *
      * @param mixed $source
+     * @param bool $useFiltering Choose whether to use built in filter functions
+     * @param bool $useOrdering Choose whether to use built in order functions
      * @return mixed
      * @throws \Exception
      */

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -92,7 +92,7 @@ class QueryDataTable extends DataTableAbstract
      * @return \Illuminate\Http\JsonResponse
      * @throws \Exception
      */
-    public function make($mDataSupport = true)
+    public function make($mDataSupport = true, $useFiltering = true, $useOrdering = true)
     {
         try {
             $this->prepareQuery();
@@ -110,14 +110,18 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Prepare query by executing count, filter, order and paginate.
      */
-    protected function prepareQuery()
+    protected function prepareQuery($useFiltering = true, $useOrdering = true)
     {
         if (! $this->prepared) {
             $this->totalRecords = $this->totalCount();
 
             if ($this->totalRecords) {
-                $this->filterRecords();
-                $this->ordering();
+                if ($useOrdering) {
+                    $this->ordering();
+                }
+                if ($useFiltering) {
+                    $this->filterRecords();
+                }
                 $this->paginate();
             }
         }

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -89,6 +89,8 @@ class QueryDataTable extends DataTableAbstract
      * Organizes works.
      *
      * @param bool $mDataSupport
+     * @param bool $useFiltering Choose whether to use built in filter functions
+     * @param bool $useOrdering Choose whether to use built in order functions
      * @return \Illuminate\Http\JsonResponse
      * @throws \Exception
      */


### PR DESCRIPTION
<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
This pull request contains changes that would allow the developer to choose if they would like to use the DataTables built in Search and Filtering. Over time using this package, I found that it's best to handle the searching and filtering before passing the data into DataTables. All default to current default activity (search = true, sort = true)