### PR TITLE
Throw the original exception

### DIFF
--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -817,7 +817,7 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
         $debug = $this->config->get('app.debug');
 
         if ($error === 'throw' || (! $error && ! $debug)) {
-            throw new Exception($exception->getMessage(), $code = 0, $exception);
+            throw $exception;
         }
 
         $this->getLogger()->error($exception);

--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -10,7 +10,6 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Psr\Log\LoggerInterface;
 use Yajra\DataTables\Contracts\DataTable;
-use Yajra\DataTables\Exceptions\Exception;
 use Yajra\DataTables\Processors\DataProcessor;
 use Yajra\DataTables\Utilities\Helper;
 


### PR DESCRIPTION
Throw the original exception so you can find out where it originated.   Currently, it's a pain to track down and fix the source of exceptions even if 'throw' is set, because they only include the message.
