### PR TITLE
[9.0] Fix issue with non-existing variables/attributes .

### DIFF
--- a/src/CollectionDataTable.php
+++ b/src/CollectionDataTable.php
@@ -295,9 +295,9 @@ class CollectionDataTable extends DataTableAbstract
                     $second = $b;
                 }
                 if ($this->config->isCaseInsensitive()) {
-                    $cmp = strnatcasecmp($first[$column], $second[$column]);
+                    $cmp = strnatcasecmp($first[$column] ?? null, $second[$column] ?? null);
                 } else {
-                    $cmp = strnatcmp($first[$column], $second[$column]);
+                    $cmp = strnatcmp($first[$column] ?? null, $second[$column] ?? null);
                 }
                 if ($cmp != 0) {
                     return $cmp;


### PR DESCRIPTION
This change fix problem with non-existing variables/attributes during sorting by Collection engine.

There is no problem with displaying undefined values thanks this:

`->columnDefs([['defaultContent' => '-', 'targets' => '_all']])`

But when we try sort column we will get an error:

`Undefined index: resourcename.non_existing_attribute in C:\laragon\www\app\vendor\yajra\laravel-datatables-oracle\src\CollectionDataTable.php:298`

![Screenshot_1](https://user-images.githubusercontent.com/17027876/81661404-5d26e480-943c-11ea-93fb-e05d51cfc538.png)
