### PR TITLE
Escape row in data processor also accepts Htmlable 

### DIFF
--- a/src/Processors/DataProcessor.php
+++ b/src/Processors/DataProcessor.php
@@ -2,6 +2,7 @@
 
 namespace Yajra\DataTables\Processors;
 
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
 use Yajra\DataTables\Utilities\Helper;
 
@@ -253,7 +254,7 @@ class DataProcessor
     }
 
     /**
-     * Escape all string values of row.
+     * Escape all string or Htmlable values of row.
      *
      * @param array $row
      * @return array
@@ -263,7 +264,7 @@ class DataProcessor
         $arrayDot = array_filter(Arr::dot($row));
         foreach ($arrayDot as $key => $value) {
             if (! in_array($key, $this->rawColumns)) {
-                $arrayDot[$key] = is_string($value) ? e($value) : $value;
+                $arrayDot[$key] = (is_string($value) || $value instanceof Htmlable) ? e($value) : $value;
             }
         }
 


### PR DESCRIPTION
After the PR #2399 some of our Datatables were not working as expected.
This is because as a row attribute we sometimes pass a `Htmlable` object `HtmlString`.

Like this:
```
    public function dataTable($query): DataTableAbstract
    {
        return datatables()
            ->eloquent($query)
            ->setRowClass('cursor-pointer')
            ->addRowAttr('onclick', fn (Model $model) => new HtmlString("window.location.href = '" . route('blabla') . "';"));
    }
```
I just added an extra check to the dataprocessor function escapeRow to see if it is a Htmlable object. So it can be passed to the `e` function where it correctly handles the Htmlable
```
if ($value instanceof Htmlable) {
            return $value->toHtml();
        }
```