### PR TITLE
[9.0] Add support for search panes.

### DIFF
--- a/src/CollectionDataTable.php
+++ b/src/CollectionDataTable.php
@@ -251,14 +251,6 @@ class CollectionDataTable extends DataTableAbstract
     }
 
     /**
-     * Perform search using search pane values.
-     */
-    protected function searchPanesSearch()
-    {
-        // TODO: Add support for search pane.
-    }
-
-    /**
      * Perform default query orderBy clause.
      */
     protected function defaultOrdering()

--- a/src/CollectionDataTable.php
+++ b/src/CollectionDataTable.php
@@ -251,6 +251,14 @@ class CollectionDataTable extends DataTableAbstract
     }
 
     /**
+     * Perform search using search pane values.
+     */
+    protected function searchPanesSearch()
+    {
+        throw new \Exception('Search panes is not yet supported on collection');
+    }
+
+    /**
      * Perform default query orderBy clause.
      */
     protected function defaultOrdering()

--- a/src/CollectionDataTable.php
+++ b/src/CollectionDataTable.php
@@ -255,7 +255,7 @@ class CollectionDataTable extends DataTableAbstract
      */
     protected function searchPanesSearch()
     {
-        throw new \Exception('Search panes is not yet supported on collection');
+        // TODO: Add support for search pane.
     }
 
     /**

--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -672,7 +672,7 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
      */
     protected function searchPanesSearch()
     {
-        $columns = $this->request->get('searchPanes');
+        $columns = $this->request->get('searchPanes', []);
 
         foreach ($columns as $column => $values) {
             if ($this->isBlacklisted($column) && ! $this->hasFilterColumn($column)) {

--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -668,22 +668,9 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
     }
 
     /**
-     * Perform search on submitted search panes.
+     * Perform search using search pane values.
      */
-    protected function searchPanesSearch()
-    {
-        $columns = $this->request->get('searchPanes', []);
-
-        foreach ($columns as $column => $values) {
-            if ($this->isBlacklisted($column) && ! $this->hasFilterColumn($column)) {
-                continue;
-            }
-
-            $this->getBaseQueryBuilder()->whereIn($column, $values);
-
-            $this->isFilterApplied = true;
-        }
-    }
+    abstract protected function searchPanesSearch();
 
     /**
      * Perform global search.
@@ -797,8 +784,8 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
             $output = $this->showDebugger($output);
         }
 
-        foreach ($this->searchPanes as $column => $options) {
-            $output['searchPanes']['options'][$column] = $options;
+        foreach ($this->searchPanes as $column => $searchPane) {
+            $output['searchPanes']['options'][$column] = $searchPane['options'];
         }
 
         return new JsonResponse(
@@ -957,9 +944,10 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
     /**
      * @param string $column
      * @param mixed $options
+     * @param \Closure|null $builder
      * @return $this
      */
-    public function searchPanes($column, $options)
+    public function searchPanes($column, $options, callable $builder = null)
     {
         if ($options instanceof Arrayable) {
             $options = $options->toArray();
@@ -967,7 +955,8 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
             $options = value($options);
         }
 
-        $this->searchPanes[$column] = $options;
+        $this->searchPanes[$column]['options'] = $options;
+        $this->searchPanes[$column]['builder'] = $builder;
 
         return $this;
     }

--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -669,7 +669,10 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
     /**
      * Perform search using search pane values.
      */
-    abstract protected function searchPanesSearch();
+    protected function searchPanesSearch()
+    {
+        // Add support for search pane.
+    }
 
     /**
      * Perform global search.

--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -663,7 +663,26 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
         }
 
         $this->columnSearch();
+        $this->searchPanesSearch();
         $this->filteredRecords = $this->isFilterApplied ? $this->filteredCount() : $this->totalRecords;
+    }
+
+    /**
+     * Perform search on submitted search panes.
+     */
+    protected function searchPanesSearch()
+    {
+        $columns = $this->request->get('searchPanes');
+
+        foreach ($columns as $column => $values) {
+            if ($this->isBlacklisted($column) && ! $this->hasFilterColumn($column)) {
+                continue;
+            }
+
+            $this->getBaseQueryBuilder()->whereIn($column, $values);
+
+            $this->isFilterApplied = true;
+        }
     }
 
     /**

--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -942,17 +942,19 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
     }
 
     /**
+     * Add a search pane options on response.
+     *
      * @param string $column
      * @param mixed $options
-     * @param \Closure|null $builder
+     * @param callable|null $builder
      * @return $this
      */
-    public function searchPanes($column, $options, callable $builder = null)
+    public function searchPane($column, $options, callable $builder = null)
     {
+        $options = value($options);
+
         if ($options instanceof Arrayable) {
             $options = $options->toArray();
-        } else {
-            $options = value($options);
         }
 
         $this->searchPanes[$column]['options'] = $options;

--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Traits\Macroable;
 use Psr\Log\LoggerInterface;
 use Yajra\DataTables\Contracts\DataTable;
 use Yajra\DataTables\Exceptions\Exception;
+use Yajra\DataTables\Extensions\SearchPanes;
 use Yajra\DataTables\Processors\DataProcessor;
 use Yajra\DataTables\Utilities\Helper;
 
@@ -144,6 +145,11 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
      * @var mixed
      */
     protected $serializer;
+
+    /**
+     * @var array
+     */
+    protected $searchPanes = [];
 
     /**
      * Can the DataTable engine be created with these parameters.
@@ -772,6 +778,10 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
             $output = $this->showDebugger($output);
         }
 
+        foreach ($this->searchPanes as $column => $options) {
+            $output['searchPanes']['options'][$column] = $options;
+        }
+
         return new JsonResponse(
             $output,
             200,
@@ -923,5 +933,23 @@ abstract class DataTableAbstract implements DataTable, Arrayable, Jsonable
     protected function getPrimaryKeyName()
     {
         return 'id';
+    }
+
+    /**
+     * @param string $column
+     * @param mixed $options
+     * @return $this
+     */
+    public function searchPanes($column, $options)
+    {
+        if ($options instanceof Arrayable) {
+            $options = $options->toArray();
+        } else {
+            $options = value($options);
+        }
+
+        $this->searchPanes[$column] = $options;
+
+        return $this;
     }
 }

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -108,6 +108,28 @@ class QueryDataTable extends DataTableAbstract
     }
 
     /**
+     * Perform search using search pane values.
+     */
+    protected function searchPanesSearch()
+    {
+        $columns = $this->request->get('searchPanes', []);
+
+        foreach ($columns as $column => $values) {
+            if ($this->isBlacklisted($column)) {
+                continue;
+            }
+
+            if ($callback = data_get($this->searchPanes, $column . '.builder')) {
+                $callback($this->getBaseQueryBuilder(), $values);
+            } else {
+                $this->getBaseQueryBuilder()->whereIn($column, $values);
+            }
+
+            $this->isFilterApplied = true;
+        }
+    }
+
+    /**
      * Prepare query by executing count, filter, order and paginate.
      */
     protected function prepareQuery()

--- a/tests/Integration/QueryDataTableTest.php
+++ b/tests/Integration/QueryDataTableTest.php
@@ -371,7 +371,7 @@ class QueryDataTableTest extends TestCase
             $options = User::select('id as value', 'name as label')->get();
 
             return $dataTable->query(DB::table('users'))
-                        ->searchPanes('name', $options)
+                        ->searchPane('name', $options)
                         ->toJson();
         });
     }

--- a/tests/Integration/QueryDataTableTest.php
+++ b/tests/Integration/QueryDataTableTest.php
@@ -10,6 +10,7 @@ use Yajra\DataTables\DataTables;
 use Yajra\DataTables\Facades\DataTables as DatatablesFacade;
 use Yajra\DataTables\QueryDataTable;
 use Yajra\DataTables\Tests\TestCase;
+use Yajra\DataTables\Tests\Models\User;
 
 class QueryDataTableTest extends TestCase
 {
@@ -230,6 +231,27 @@ class QueryDataTableTest extends TestCase
     }
 
     /** @test */
+    public function it_returns_search_panes_options()
+    {
+        $crawler = $this->call('GET', '/query/search-panes');
+
+        $crawler->assertJson([
+            'draw'            => 0,
+            'recordsTotal'    => 20,
+            'recordsFiltered' => 20,
+            'searchPanes' => [
+                'options' => [
+                    'name' => []
+                ],
+            ]
+        ]);
+
+        $options = $crawler->json()['searchPanes']['options'];
+
+        $this->assertEquals(count($options['name']), 20);
+    }
+
+    /** @test */
     public function it_allows_column_search_added_column_with_custom_filter_handler()
     {
         $crawler = $this->call('GET', '/query/blacklisted-filter', [
@@ -327,6 +349,14 @@ class QueryDataTableTest extends TestCase
                              })
                              ->rawColumns(['name', 'email'])
                              ->toJson();
+        });
+
+        $route->get('/query/search-panes', function (DataTables $dataTable) {
+            $options = User::select('id as value', 'name as label')->get();
+
+            return $dataTable->query(DB::table('users'))
+                        ->searchPanes('name', $options)
+                        ->toJson();
         });
     }
 }

--- a/tests/Integration/QueryDataTableTest.php
+++ b/tests/Integration/QueryDataTableTest.php
@@ -252,6 +252,22 @@ class QueryDataTableTest extends TestCase
     }
 
     /** @test */
+    public function it_performs_search_using_search_panes()
+    {
+        $crawler = $this->call('GET', '/query/search-panes', [
+            'searchPanes' => [
+                'id' => [1, 2],
+            ],
+        ]);
+
+        $crawler->assertJson([
+            'draw'            => 0,
+            'recordsTotal'    => 20,
+            'recordsFiltered' => 2,
+        ]);
+    }
+
+    /** @test */
     public function it_allows_column_search_added_column_with_custom_filter_handler()
     {
         $crawler = $this->call('GET', '/query/blacklisted-filter', [


### PR DESCRIPTION
Fix #2463, #2471

JS Demo ref: https://editor.datatables.net/examples/extensions/searchPanes.html

## USAGE

```php
$users = User::query()->select('id as value', 'name as label')->get();
$categories = Category::query()->select('id as value', 'name as label')->get();

return datatables()
    ->eloquent(Post::query())
    ->setRowId('id')
    ->searchPane('user_id', $users)
    ->searchPane('category_id', $categories);
```