### PR TITLE
Use simple numeric sorting when dealing with numeric values

### DIFF
--- a/src/CollectionDataTable.php
+++ b/src/CollectionDataTable.php
@@ -294,7 +294,15 @@ class CollectionDataTable extends DataTableAbstract
                     $first  = $a;
                     $second = $b;
                 }
-                if ($this->config->isCaseInsensitive()) {
+                if (is_numeric($first[$column] ?? null) && is_numeric($second[$column] ?? null)) {
+                    if ($first[$column] < $second[$column]) {
+                        $cmp = -1;
+                    } elseif ($first[$column] > $second[$column]) {
+                        $cmp = 1;
+                    } else {
+                        $cmp = 0;
+                    }
+                } elseif ($this->config->isCaseInsensitive()) {
                     $cmp = strnatcasecmp($first[$column] ?? null, $second[$column] ?? null);
                 } else {
                     $cmp = strnatcmp($first[$column] ?? null, $second[$column] ?? null);

--- a/tests/Integration/CollectionDataTableTest.php
+++ b/tests/Integration/CollectionDataTableTest.php
@@ -131,6 +131,48 @@ class CollectionDataTableTest extends TestCase
     }
 
     /** @test */
+    public function it_can_sort_numeric_strings()
+     {
+         config()->set('app.debug', false);
+         request()->merge([
+             'columns' => [
+                 ['data' => 'amount', 'name' => 'amount', 'searchable' => 'true', 'orderable' => 'true'],
+             ],
+             'order'  => [['column' => 0, 'dir' => 'asc']],
+             'start'  => 0,
+             'length' => 10,
+             'draw'   => 1,
+         ]);
+
+         $collection = collect([
+             ['amount' => '12'],
+             ['amount' => '7'],
+             ['amount' => '-8'],
+             ['amount' => '0'],
+             ['amount' => '-3'],
+             ['amount' => '8'],
+         ]);
+
+         $dataTable = app('datatables')->collection($collection);
+         /** @var JsonResponse $response */
+         $response = $dataTable->toJson();
+
+         $this->assertEquals([
+             'draw'            => 1,
+             'recordsTotal'    => 6,
+             'recordsFiltered' => 6,
+             'data'            => [
+                 ['amount' => '-8'],
+                 ['amount' => '-3'],
+                 ['amount' => '0'],
+                 ['amount' => '7'],
+                 ['amount' => '8'],
+                 ['amount' => '12'],
+             ],
+         ], $response->getData(true));
+     }
+
+    /** @test */
     public function it_accepts_a_model_using_ioc_container_factory()
     {
         $dataTable = app('datatables')->of(User::all());

--- a/tests/Integration/CollectionDataTableTest.php
+++ b/tests/Integration/CollectionDataTableTest.php
@@ -132,45 +132,45 @@ class CollectionDataTableTest extends TestCase
 
     /** @test */
     public function it_can_sort_numeric_strings()
-     {
-         config()->set('app.debug', false);
-         request()->merge([
-             'columns' => [
-                 ['data' => 'amount', 'name' => 'amount', 'searchable' => 'true', 'orderable' => 'true'],
-             ],
-             'order'  => [['column' => 0, 'dir' => 'asc']],
-             'start'  => 0,
-             'length' => 10,
-             'draw'   => 1,
-         ]);
+    {
+        config()->set('app.debug', false);
+        request()->merge([
+            'columns' => [
+                ['data' => 'amount', 'name' => 'amount', 'searchable' => 'true', 'orderable' => 'true'],
+            ],
+            'order'  => [['column' => 0, 'dir' => 'asc']],
+            'start'  => 0,
+            'length' => 10,
+            'draw'   => 1,
+        ]);
 
-         $collection = collect([
-             ['amount' => '12'],
-             ['amount' => '7'],
-             ['amount' => '-8'],
-             ['amount' => '0'],
-             ['amount' => '-3'],
-             ['amount' => '8'],
-         ]);
+        $collection = collect([
+            ['amount' => '12'],
+            ['amount' => '7'],
+            ['amount' => '-8'],
+            ['amount' => '0'],
+            ['amount' => '-3'],
+            ['amount' => '8'],
+        ]);
 
-         $dataTable = app('datatables')->collection($collection);
-         /** @var JsonResponse $response */
-         $response = $dataTable->toJson();
+        $dataTable = app('datatables')->collection($collection);
+        /** @var JsonResponse $response */
+        $response = $dataTable->toJson();
 
-         $this->assertEquals([
-             'draw'            => 1,
-             'recordsTotal'    => 6,
-             'recordsFiltered' => 6,
-             'data'            => [
-                 ['amount' => '-8'],
-                 ['amount' => '-3'],
-                 ['amount' => '0'],
-                 ['amount' => '7'],
-                 ['amount' => '8'],
-                 ['amount' => '12'],
-             ],
-         ], $response->getData(true));
-     }
+        $this->assertEquals([
+            'draw'            => 1,
+            'recordsTotal'    => 6,
+            'recordsFiltered' => 6,
+            'data'            => [
+                ['amount' => '-8'],
+                ['amount' => '-3'],
+                ['amount' => '0'],
+                ['amount' => '7'],
+                ['amount' => '8'],
+                ['amount' => '12'],
+            ],
+        ], $response->getData(true));
+    }
 
     /** @test */
     public function it_accepts_a_model_using_ioc_container_factory()


### PR DESCRIPTION
For a `CollectionDataTable`, don't use string comparison functions when sorting two numeric values. A test case is included. Resolves #1934 