### PR TITLE
Disable ordering via orderColumn.

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -671,11 +671,15 @@ class QueryDataTable extends DataTableAbstract
      * Apply orderColumn custom query.
      *
      * @param string $column
-     * @param array  $orderable
+     * @param array $orderable
      */
     protected function applyOrderColumn($column, $orderable)
     {
         $sql = $this->columnDef['order'][$column]['sql'];
+        if ($sql === false) {
+            return;
+        }
+
         if (is_callable($sql)) {
             call_user_func($sql, $this->query, $orderable['direction']);
         } else {


### PR DESCRIPTION
Fix https://github.com/yajra/laravel-datatables/issues/1953

Sample Code:
```php
->orderColumn('name', false)
```