### PR TITLE
Fix builder instance when using eloquent.

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -120,9 +120,9 @@ class QueryDataTable extends DataTableAbstract
             }
 
             if ($this->searchPanes[$column] && $callback = $this->searchPanes[$column]['builder']) {
-                $callback($this->getBaseQueryBuilder(), $values);
+                $callback($this->query, $values);
             } else {
-                $this->getBaseQueryBuilder()->whereIn($column, $values);
+                $this->query->whereIn($column, $values);
             }
 
             $this->isFilterApplied = true;


### PR DESCRIPTION
This PR fixes - will use the builder instance when using eloquent instead of using the base query builder.

Fixes codes like:

```php
->searchPane('tags', $tags, function ($q, $ids) {
  return $q->whereHas('tags', function ($q) use ($ids) {
    return $q->whereIn('taggables.tag_id', $ids);
  });
})
```