### PR TITLE
Fix check for MorphTo relation on nested relations

### DIFF
--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -92,7 +92,9 @@ class EloquentDataTable extends QueryDataTable
             return parent::compileQuerySearch($query, $columnName, $keyword, $boolean);
         }
 
-        if ($this->query->getModel()->$relation() instanceof MorphTo) {
+        $model = $this->query->getModel();
+
+        if (method_exists($model, $relation) && $model->$relation() instanceof MorphTo) {
             $query->{$boolean . 'WhereHasMorph'}($relation, '*', function (Builder $query) use ($column, $keyword) {
                 parent::compileQuerySearch($query, $column, $keyword, '');
             });


### PR DESCRIPTION
The conditional causes errors when there are nested relations for which checking the instance of the relation method returned value causes a BadMethodCallException.

I have code that has a deep relation in the eloquent query and to test for MorphTo tries to call something like App\Models\MyModel::relation.deep.method() causing an error, since it does not exist.

I've added simple code to check the method exists before actually calling it.

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
