### PR TITLE
Fix morph relation support with multi level relations

### DIFF
--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -131,8 +131,7 @@ class EloquentDataTable extends QueryDataTable
     protected function isMorphRelation($relation)
     {
         $isMorph = false;
-        if ($relation !== null && $relation !== '')
-        {
+        if ($relation !== null && $relation !== '') {
             $relationParts = explode('.', $relation);
             $firstRelation = array_shift($relationParts);
             $isMorph       = $this->query->getModel()->$firstRelation() instanceof MorphTo;

--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -92,7 +92,7 @@ class EloquentDataTable extends QueryDataTable
             return parent::compileQuerySearch($query, $columnName, $keyword, $boolean);
         }
 
-        if ($this->query->getModel()->$relation() instanceof MorphTo) {
+        if ($this->isMorphRelation($relation)) {
             $query->{$boolean . 'WhereHasMorph'}($relation, '*', function (Builder $query) use ($column, $keyword) {
                 parent::compileQuerySearch($query, $column, $keyword, '');
             });
@@ -120,6 +120,25 @@ class EloquentDataTable extends QueryDataTable
         }
 
         return $this->joinEagerLoadedColumn($relation, $columnName);
+    }
+
+    /**
+     * Check if a relation is a morphed one or not.
+     *
+     * @param  string $relation
+     * @return bool
+     */
+    protected function isMorphRelation($relation)
+    {
+        $isMorph = false;
+        if ($relation !== null && $relation !== '')
+        {
+            $relationParts = explode('.', $relation);
+            $firstRelation = array_shift($relationParts);
+            $isMorph       = $this->query->getModel()->$firstRelation() instanceof MorphTo;
+        }
+
+        return $isMorph;
     }
 
     /**


### PR DESCRIPTION
Recent PR https://github.com/yajra/laravel-datatables/pull/2580 fails when a multiple level relationship is used ($relation string has several dot separated relations). I've created this fix in order to check only the first relation (I don't really know how Laravel behaves with multi level relationships when all or any are morphed).