### PR TITLE
fix: check polymorphic on nested relationship

### DIFF
--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -92,7 +92,7 @@ class EloquentDataTable extends QueryDataTable
             return parent::compileQuerySearch($query, $columnName, $keyword, $boolean);
         }
 
-        if ($this->query->getModel()->$relation() instanceof MorphTo) {
+        if ($this->isMorphedRelation($this->query->getModel(), $relation)) {
             $query->{$boolean . 'WhereHasMorph'}($relation, '*', function (Builder $query) use ($column, $keyword) {
                 parent::compileQuerySearch($query, $column, $keyword, '');
             });
@@ -101,6 +101,23 @@ class EloquentDataTable extends QueryDataTable
                 parent::compileQuerySearch($query, $column, $keyword, '');
             });
         }
+    }
+
+    /**
+     * @param $model
+     * @param string $relations
+     * @return bool
+     */
+    protected function isMorphedRelation($model, string $relations)
+    {
+        $relations     = explode('.', $relations);
+        $relation_name = array_shift($relations);
+
+        if (count($relations) > 0) {
+            return $this->isMorphedRelation($model->$relation_name()->getRelated(), implode('.', $relations));
+        }
+
+        return $model->$relation_name() instanceof MorphTo;
     }
 
     /**


### PR DESCRIPTION
@yajra it appears I introduced a small bug for nested relationship :(

Assuming my query source model is CharacterInfo - and has a relationship called `affiliation` to the class `CharacterAffiliation`
The current change is doing `CharacterInfo::affiliation()` to retrieve relationship and determine its nature => pass

However, add a new relation to `CharacterAffiliation` called `corporation` which will target `UniverseName`.
Now, the current change will do `CharacterInfo::affiliation.corporation()` which is wrong.

I don't know how to handle that - but since the package is largely consumed, I think the best would be to rollback change until it's addressed :/

sorry about the issue :(

related to #2580, eveseat/seat#791
