### PR TITLE
Code cleanup in QueryDataTable class

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -309,7 +309,7 @@ class QueryDataTable extends DataTableAbstract
             }
 
             if ($this->hasFilterColumn($column)) {
-                $keyword = $this->getColumnSearchKeyword($index, $raw = true);
+                $keyword = $this->getColumnSearchKeyword($index, true);
                 $this->applyFilterColumn($this->getBaseQueryBuilder(), $column, $keyword);
             } else {
                 $column  = $this->resolveRelationColumn($column);

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -766,7 +766,7 @@ class QueryDataTable extends DataTableAbstract
     protected function showDebugger(array $output)
     {
         $query_log = $this->connection->getQueryLog();
-        array_walk_recursive($query_log, function (&$item, $key) {
+        array_walk_recursive($query_log, function (&$item) {
             $item = utf8_encode($item);
         });
 

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -572,7 +572,7 @@ class QueryDataTable extends DataTableAbstract
      * Override default column ordering.
      *
      * @param string $column
-     * @param string $sql
+     * @param string|\Closure $sql
      * @param array  $bindings
      * @return $this
      * @internal string $1 Special variable that returns the requested order direction of the column.


### PR DESCRIPTION
I discovered a warning in the orderColumn function if you use the closure syntax with Laravel .idea and PHPStorm 2021.1 installed.
Changing the PHPDoc for the function to include \Closure as a type I had no error anymore. I double checked the documentation and here the closure syntax is mentioned:
https://yajrabox.com/docs/laravel-datatables/master/order-column

Because I was in the class anyway I checked my PHPStorm warnings for the class and find 2 other things that can be cleaned up. 

Hope the PR will help
