### PR TITLE
[9.x] Enhance count

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -224,7 +224,7 @@ class QueryDataTable extends DataTableAbstract
      *
      * @return \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder
      */
-    protected function prepareCountQuery()
+    public function prepareCountQuery()
     {
         $builder = clone $this->query;
 

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -228,12 +228,17 @@ class QueryDataTable extends DataTableAbstract
     {
         $builder = clone $this->query;
 
-        if (! $this->isComplexQuery($builder)) {
-            $row_count = $this->wrap('row_count');
-            $builder->select($this->connection->raw("'1' as {$row_count}"));
-            if (! $this->keepSelectBindings) {
-                $builder->setBindings([], 'select');
-            }
+        if ($this->isComplexQuery($builder)) {
+            $table = $this->connection->raw('('.$builder->toSql().') count_row_table');
+
+            return $this->connection->table($table)
+                ->setBindings($builder->getBindings());
+        }
+
+        $row_count = $this->wrap('row_count');
+        $builder->select($this->connection->raw("'1' as {$row_count}"));
+        if (! $this->keepSelectBindings) {
+            $builder->setBindings([], 'select');
         }
 
         return $builder;

--- a/tests/Unit/QueryDataTableTest.php
+++ b/tests/Unit/QueryDataTableTest.php
@@ -15,8 +15,8 @@ class QueryDataTableTest extends TestCase
         $dataTable = app('datatables')->of(
             DB::table('module_telers')
                 ->selectRaw('module_telers.id, module_telers.publiceren, module_telers.archief, module_telers.uitgelicht, module_telers.image_header, module_telers.bedrijfsnaam, module_telers.titel, module_telers.plaats, group_concat(DISTINCT productenAlias.titel SEPARATOR \', \') as producten')
-                ->leftJoin('relation_producten_telers','module_telers.id', '=', 'relation_producten_telers.telers_id')
-                ->leftJoin('module_producten as productenAlias','productenAlias.id', '=', 'relation_producten_telers.producten_id')
+                ->leftJoin('relation_producten_telers', 'module_telers.id', '=', 'relation_producten_telers.telers_id')
+                ->leftJoin('module_producten as productenAlias', 'productenAlias.id', '=', 'relation_producten_telers.producten_id')
                 ->groupBy('module_telers.id')
         );
 

--- a/tests/Unit/QueryDataTableTest.php
+++ b/tests/Unit/QueryDataTableTest.php
@@ -22,7 +22,6 @@ class QueryDataTableTest extends TestCase
 
         $this->assertQueryWrapped(true, $dataTable->prepareCountQuery());
 
-
         /** @var \Yajra\DataTables\QueryDataTable $dataTable */
         $dataTable = app('datatables')->of(
             DB::table('posts')->selectRaw('title AS state')->groupBy('state')->having('state', '!=', 'deleted')

--- a/tests/Unit/QueryDataTableTest.php
+++ b/tests/Unit/QueryDataTableTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Yajra\DataTables\Tests\Unit;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Yajra\DataTables\Tests\Models\User;
+use Yajra\DataTables\Tests\TestCase;
+
+class QueryDataTableTest extends TestCase
+{
+    public function test_complex_query_are_wrapped_and_countable()
+    {
+        /** @var \Yajra\DataTables\QueryDataTable $dataTable */
+        $dataTable = app('datatables')->of(
+            DB::table('module_telers')
+                ->selectRaw('module_telers.id, module_telers.publiceren, module_telers.archief, module_telers.uitgelicht, module_telers.image_header, module_telers.bedrijfsnaam, module_telers.titel, module_telers.plaats, group_concat(DISTINCT productenAlias.titel SEPARATOR \', \') as producten')
+                ->leftJoin('relation_producten_telers','module_telers.id', '=', 'relation_producten_telers.telers_id')
+                ->leftJoin('module_producten as productenAlias','productenAlias.id', '=', 'relation_producten_telers.producten_id')
+                ->groupBy('module_telers.id')
+        );
+
+        $this->assertQueryWrapped(true, $dataTable->prepareCountQuery());
+
+
+        /** @var \Yajra\DataTables\QueryDataTable $dataTable */
+        $dataTable = app('datatables')->of(
+            DB::table('posts')->selectRaw('title AS state')->groupBy('state')->having('state', '!=', 'deleted')
+        );
+
+        $this->assertQueryWrapped(true, $dataTable->prepareCountQuery());
+        $this->assertEquals(60, $dataTable->count());
+    }
+
+    public function test_simple_queries_are_not_wrapped_and_countable()
+    {
+        /** @var \Yajra\DataTables\QueryDataTable $dataTable */
+        $dataTable = app('datatables')->of(
+            User::with('posts')->select('users.*')
+        );
+
+        $this->assertQueryWrapped(false, $dataTable->prepareCountQuery());
+        $this->assertEquals(20, $dataTable->count());
+    }
+
+    /**
+     * @param $expected bool
+     * @param $query \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder
+     * @return void
+     */
+    protected function assertQueryWrapped($expected, $query)
+    {
+        $sql = $query->toSql();
+
+        $this->assertSame($expected, Str::endsWith($sql, 'count_row_table'), "'{$sql}' is not wrapped");
+    }
+}


### PR DESCRIPTION
Hey @yajra,

This time I've added tests so we are sure we don't break anything - to make things testable I had to change the visibility of `prepareCountQuery()` which is now `public`.

This approach utilizes the existing `isComplexQuery()` to determine if we need to wrap the complex query or not.

If we have more examples they should be easy to add now.

Cheers Adrian

---
Fixes #1928 