### PR TITLE
Query with subqueries exception fix

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -767,7 +767,9 @@ class QueryDataTable extends DataTableAbstract
     {
         $query_log = $this->connection->getQueryLog();
         array_walk_recursive($query_log, function (&$item) {
-            $item = utf8_encode($item);
+            if (is_string($item)) {
+                $item = utf8_encode($item);
+            }
         });
 
         $output['queries'] = $query_log;


### PR DESCRIPTION
vendor/yajra/laravel-datatables-oracle/src/QueryDataTable.php

```
protected function showDebugger(array $output)
{
    $query_log = $this->connection->getQueryLog();
    array_walk_recursive($query_log, function (&$item) {
            $item = utf8_encode($item);
    });
```

Some fixes:

```
protected function showDebugger(array $output)
{
    $query_log = $this->connection->getQueryLog();
    array_walk_recursive($query_log, function (&$item) {
        if (is_string($item)) {
            $item = utf8_encode($item);
        }
    });
```
