### PR TITLE
Return empty string for null request keyword

### DIFF
--- a/src/Utilities/Request.php
+++ b/src/Utilities/Request.php
@@ -170,7 +170,7 @@ class Request
      */
     public function columnKeyword($index)
     {
-        $keyword = $this->request->input("columns.$index.search.value");
+        $keyword = $this->request->input("columns.$index.search.value") ?? '';
 
         return $this->prepareKeyword($keyword);
     }
@@ -197,7 +197,7 @@ class Request
      */
     public function keyword()
     {
-        $keyword = $this->request->input('search.value');
+        $keyword = $this->request->input('search.value') ?? '';
 
         return $this->prepareKeyword($keyword);
     }


### PR DESCRIPTION
When the keyword from the request input is null, the `keyword` method returns `null` instead of a `string` as the phpdoc suggests.
This causes a `TypeError` when implementing custom filtering logic which expects a string for the keyword.