### PR TITLE
Don't add BelongsToMany relation column to select

### DIFF
--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -182,9 +182,6 @@ class EloquentDataTable extends QueryDataTable
                     $foreign = $pivot . '.' . $tablePK;
                     $other   = $related->getQualifiedKeyName();
 
-                    $lastQuery->addSelect($table . '.' . $relationColumn);
-                    $this->performJoin($table, $foreign, $other);
-
                     break;
 
                 case $model instanceof HasOneThrough:


### PR DESCRIPTION
It seems like a part of "duplicate column" problems with sorting/filtering by BelongsToMany relation column are coming from this. 

When you have same column names in your main and relation tables adding a `->select()` is not helping because the relation column is still added in joinEagerLoadedColumn(). And depending on the situation either your main model column will be populated with same name relation column or you're getting an error in your aggregate queries. Example:
```
Exception Message:

SQLSTATE[42S21]: Column already exists: 1060 Duplicate column name 'name' (SQL: select count(*) as aggregate from (select `crm_companies`.`id`, `crm_companies`.`name`, `dic_company_types`.`name` from `crm_companies` left join `crm_company_types` on `crm_company_types`.`company_id` = `crm_companies`.`id` left join `dic_company_types` on `crm_company_types`.`type_id` = `dic_company_types`.`id` where LOWER(`dic_company_types`.`name`) LIKE %clearing agent% group by `crm_companies`.`name`) count_row_table)
```
(`crm_companies`.`name` is the main model column, `dic_company_types`.`name`  - automatically added relation column and hence the conflict)

So I look into the code and found this place. `$this->performJoin($table, $foreign, $other);` looks unnecessary since it's performed anyway after the switch block and `addSelect` is adding a relation column that doesn't seem to be required and causes duplicates. Please correct me if I'm wrong.

Thanks