### PR TITLE
[10.x] Changed PHPDocs to have the most specific class as their super type

### DIFF
--- a/src/DataTables.php
+++ b/src/DataTables.php
@@ -100,7 +100,7 @@ class DataTables
      * DataTables using Query.
      *
      * @param  \Illuminate\Database\Query\Builder|mixed  $builder
-     * @return DataTableAbstract|QueryDataTable
+     * @return QueryDataTable|DataTableAbstract
      */
     public function query($builder)
     {
@@ -111,7 +111,7 @@ class DataTables
      * DataTables using Eloquent Builder.
      *
      * @param  \Illuminate\Database\Eloquent\Builder|mixed  $builder
-     * @return DataTableAbstract|EloquentDataTable
+     * @return EloquentDataTable|DataTableAbstract
      */
     public function eloquent($builder)
     {
@@ -122,7 +122,7 @@ class DataTables
      * DataTables using Collection.
      *
      * @param  \Illuminate\Support\Collection|array  $collection
-     * @return DataTableAbstract|CollectionDataTable
+     * @return CollectionDataTable|DataTableAbstract
      */
     public function collection($collection)
     {
@@ -133,7 +133,7 @@ class DataTables
      * DataTables using Collection.
      *
      * @param  \Illuminate\Http\Resources\Json\AnonymousResourceCollection|array  $collection
-     * @return DataTableAbstract|ApiResourceDataTable
+     * @return ApiResourceDataTable|DataTableAbstract
      */
     public function resource($resource)
     {


### PR DESCRIPTION
This allows PHPStan to understand that when you call eloquent it is now dealing with an EloquentDataTable.

Before this change it keeps assuming that it is the DataTableAbstract class and you have to fix it with a useless variable and an @var tag.

This is basically a copy of #2771 but for version 10.