### PR TITLE
Create eloquent datatable from relation

### DIFF
--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -20,17 +20,14 @@ class EloquentDataTable extends QueryDataTable
     /**
      * EloquentEngine constructor.
      *
-     * @param  \Illuminate\Database\Eloquent\Model|EloquentBuilder  $model
-     *
-     * @throws \Yajra\DataTables\Exceptions\Exception
+     * @param  Model|EloquentBuilder  $model
      */
-    public function __construct($model)
+    public function __construct(Model|EloquentBuilder $model)
     {
         $builder = match (true) {
             $model instanceof Model => $model->newQuery(),
             $model instanceof Relation => $model->getQuery(),
             $model instanceof EloquentBuilder => $model,
-            default => throw new Exception('Invalid model type. Must be an instance of Eloquent Model, Eloquent Relation, or Eloquent Builder.'),
         };
 
         parent::__construct($builder->getQuery());

--- a/tests/Integration/EloquentDataTableTest.php
+++ b/tests/Integration/EloquentDataTableTest.php
@@ -121,6 +121,17 @@ class EloquentDataTableTest extends TestCase
         $this->assertEquals(Carbon::parse($user->created_at)->format('Y-m-d'), $data['created_at_formatted']);
     }
 
+    /** @test */
+    public function it_accepts_a_relation()
+    {
+        $user = User::first();
+
+        $dataTable = app('datatables')->eloquent($user->posts());
+        $response = $dataTable->toJson();
+        $this->assertInstanceOf(EloquentDataTable::class, $dataTable);
+        $this->assertInstanceOf(JsonResponse::class, $response);
+    }
+
     protected function setUp(): void
     {
         parent::setUp();


### PR DESCRIPTION
The `DataTables::eloquent()` method accepts a `Illuminate\Contracts\Database\Eloquent\Builder` which can be an eloquent builder, but also an eloquent relation.

Using `DataTables::eloquent(User::query())` works fine, but `DataTables::eloquent($user->posts())` throws the following error:

```
Exception Property [columns] does not exist on the Eloquent builder instance. 
    vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php:1701 Illuminate\Database\Eloquent\Builder::__get
    vendor/yajra/laravel-datatables-oracle/src/QueryDataTable.php:59 Yajra\DataTables\QueryDataTable::__construct
    vendor/yajra/laravel-datatables-oracle/src/EloquentDataTable.php:39 Yajra\DataTables\EloquentDataTable::__construct
    vendor/yajra/laravel-datatables-oracle/src/DataTableAbstract.php:167 Yajra\DataTables\DataTableAbstract::create
    vendor/yajra/laravel-datatables-oracle/src/DataTables.php:126 Yajra\DataTables\DataTables::eloquent
```

This happens because the constructor of `EloquentDataTable` passes the eloquent builder to its parent, instead of the query builder.

This PR fixes the constructor of `EloquentDataTable` so that the correct object is passed to the `QueryDataTable` constructor.