### PR TITLE
[10.x] Make canCreate at QueryDataTable accept QueryBuilder only

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -82,7 +82,7 @@ class QueryDataTable extends DataTableAbstract
      */
     public static function canCreate($source): bool
     {
-        return $source instanceof QueryBuilder;
+        return $source instanceof QueryBuilder && ! ($source instanceof EloquentBuilder);
     }
 
     /**


### PR DESCRIPTION
[canCreate](https://github.com/yajra/laravel-datatables/blob/master/src/QueryDataTable.php#L85) function at [QueryDataTable](https://github.com/yajra/laravel-datatables/blob/master/src/QueryDataTable.php) should accept `QueryBuilder` only but it accepts `EloquentBuilder`  aslo because `EloquentBuilder` contract extends `QueryBuilder ` 