### PR TITLE
Fixed the search column for same table relations

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -422,9 +422,15 @@ class QueryDataTable extends DataTableAbstract
     {
         if (! str_contains($column, '.')) {
             $q = $this->getBaseQueryBuilder($query);
+            $from = $q->from;
+
             /** @phpstan-ignore-next-line */
-            if (! $q->from instanceof Expression) {
-                $column = $q->from.'.'.$column;
+            if (! $from instanceof Expression) {
+                if (str_contains($from, ' as ')) {
+                    $from = explode(' as ', $from)[1];
+                }
+
+                $column = $from . '.' . $column;
             }
         }
 


### PR DESCRIPTION
I have a `customers` table which is related to `customers` via `parentCustomer`.

When I try to search it uses the following expression as the column name:

```sql
LOWER(`customers` as `laravel_reserved_0`.`name`)
```

which clearly doesn't make sense since the table alias should only be added to the `FROM table_name` section of the query.

My code above checks if our "searchable column name with table prefix" has an ` as ` inside and only gets the `table_alias.searchable_column` from it.

BEFORE:

```sql
LOWER(`customers` as `laravel_reserved_0`.`name`)
```

AFTER

```sql
LOWER(`laravel_reserved_0`.`name`)
```
