### PR TITLE
Methods pointing to the "uncustomizable" classes.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
   },
   "require-dev": {
     "nunomaduro/larastan": "^2.1",
-    "orchestra/testbench": "^7.3"
+    "orchestra/testbench": "^7.3",
+    "yajra/laravel-datatables-html": "^9.0"
   },
   "suggest": {
     "yajra/laravel-datatables-buttons": "Plugin for server-side exporting of dataTables.",

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
   },
   "require-dev": {
     "nunomaduro/larastan": "^2.1",
-    "orchestra/testbench": "^7.3",
-    "yajra/laravel-datatables-html": "^9.0"
+    "orchestra/testbench": "^7.3"
   },
   "suggest": {
     "yajra/laravel-datatables-buttons": "Plugin for server-side exporting of dataTables.",

--- a/src/DataTables.php
+++ b/src/DataTables.php
@@ -114,11 +114,8 @@ class DataTables
     {
         $dataTable = config('datatables.engines.query');
 
-        if (! is_subclass_of($dataTable, QueryDataTable::class)) {
-            $this->throwInvalidEngineException($dataTable, QueryDataTable::class);
-        }
+        $this->validateDataTable($dataTable, QueryDataTable::class);
 
-        /** @phpstan-ignore-next-line */
         return $dataTable::create($builder);
     }
 
@@ -132,11 +129,8 @@ class DataTables
     {
         $dataTable = config('datatables.engines.eloquent');
 
-        if (! is_subclass_of($dataTable, EloquentDataTable::class)) {
-            $this->throwInvalidEngineException($dataTable, EloquentDataTable::class);
-        }
+        $this->validateDataTable($dataTable, EloquentDataTable::class);
 
-        /** @phpstan-ignore-next-line */
         return $dataTable::create($builder);
     }
 
@@ -150,11 +144,8 @@ class DataTables
     {
         $dataTable = config('datatables.engines.collection');
 
-        if (! is_subclass_of($dataTable, CollectionDataTable::class)) {
-            $this->throwInvalidEngineException($dataTable, CollectionDataTable::class);
-        }
+        $this->validateDataTable($dataTable, CollectionDataTable::class);
 
-        /** @phpstan-ignore-next-line */
         return $dataTable::create($collection);
     }
 
@@ -177,7 +168,22 @@ class DataTables
     /**
      * @param string $engine
      * @param string $parent
-     * 
+     *
+     * @return void
+     *
+     * @throws \Yajra\DataTables\Exceptions\Exception
+     */
+    public function validateDataTable(string $engine, string $parent)
+    {
+        if (! ($engine == $parent || is_subclass_of($engine, $parent))) {
+            $this->throwInvalidEngineException($engine, $parent);
+        }
+    }
+
+    /**
+     * @param string $engine
+     * @param string $parent
+     *
      * @throws \Yajra\DataTables\Exceptions\Exception
      */
     public function throwInvalidEngineException(string $engine, string $parent)

--- a/src/DataTables.php
+++ b/src/DataTables.php
@@ -113,7 +113,11 @@ class DataTables
     public function query(QueryBuilder $builder): QueryDataTable
     {
         $dataTable = config('datatables.engines.query');
-        
+
+        if (! is_subclass_of($dataTable, QueryDataTable::class)) {
+            $this->throwInvalidEngineException($dataTable, QueryDataTable::class);
+        }
+
         return $dataTable::create($builder);
     }
 
@@ -126,7 +130,11 @@ class DataTables
     public function eloquent(EloquentBuilder $builder): EloquentDataTable
     {
         $dataTable = config('datatables.engines.eloquent');
-        
+
+        if (! is_subclass_of($dataTable, EloquentDataTable::class)) {
+            $this->throwInvalidEngineException($dataTable, EloquentDataTable::class);
+        }
+
         return $dataTable::create($builder);
     }
 
@@ -139,7 +147,11 @@ class DataTables
     public function collection($collection): CollectionDataTable
     {
         $dataTable = config('datatables.engines.collection');
-        
+
+        if (! is_subclass_of($dataTable, CollectionDataTable::class)) {
+            $this->throwInvalidEngineException($dataTable, CollectionDataTable::class);
+        }
+
         return $dataTable::create($collection);
     }
 
@@ -157,5 +169,16 @@ class DataTables
         }
 
         return $this->html ?: $this->html = app('datatables.html');
+    }
+
+    /**
+     * @param string $engine
+     * @param string $parent
+     * 
+     * @throws \Yajra\DataTables\Exceptions\Exception
+     */
+    public function throwInvalidEngineException(string $engine, string $parent)
+    {
+        throw new Exception("The given datatable engine `{$engine}` is not compatible with `{$parent}`.");
     }
 }

--- a/src/DataTables.php
+++ b/src/DataTables.php
@@ -140,7 +140,7 @@ class DataTables
     {
         $dataTable = config('datatables.engines.collection');
         
-        return $dataTable::create($builder);
+        return $dataTable::create($collection);
     }
 
     /**

--- a/src/DataTables.php
+++ b/src/DataTables.php
@@ -112,6 +112,7 @@ class DataTables
      */
     public function query(QueryBuilder $builder): QueryDataTable
     {
+        /** @var string */
         $dataTable = config('datatables.engines.query');
 
         $this->validateDataTable($dataTable, QueryDataTable::class);
@@ -127,6 +128,7 @@ class DataTables
      */
     public function eloquent(EloquentBuilder $builder): EloquentDataTable
     {
+        /** @var string */
         $dataTable = config('datatables.engines.eloquent');
 
         $this->validateDataTable($dataTable, EloquentDataTable::class);
@@ -142,6 +144,7 @@ class DataTables
      */
     public function collection($collection): CollectionDataTable
     {
+        /** @var string */
         $dataTable = config('datatables.engines.collection');
 
         $this->validateDataTable($dataTable, CollectionDataTable::class);
@@ -173,7 +176,7 @@ class DataTables
      *
      * @throws \Yajra\DataTables\Exceptions\Exception
      */
-    public function validateDataTable(string $engine, string $parent)
+    public function validateDataTable(string $engine, string $parent): void
     {
         if (! ($engine == $parent || is_subclass_of($engine, $parent))) {
             $this->throwInvalidEngineException($engine, $parent);
@@ -184,9 +187,11 @@ class DataTables
      * @param string $engine
      * @param string $parent
      *
+     * @return void
+     *
      * @throws \Yajra\DataTables\Exceptions\Exception
      */
-    public function throwInvalidEngineException(string $engine, string $parent)
+    public function throwInvalidEngineException(string $engine, string $parent): void
     {
         throw new Exception("The given datatable engine `{$engine}` is not compatible with `{$parent}`.");
     }

--- a/src/DataTables.php
+++ b/src/DataTables.php
@@ -118,6 +118,7 @@ class DataTables
             $this->throwInvalidEngineException($dataTable, QueryDataTable::class);
         }
 
+        /** @phpstan-ignore-next-line */
         return $dataTable::create($builder);
     }
 
@@ -135,6 +136,7 @@ class DataTables
             $this->throwInvalidEngineException($dataTable, EloquentDataTable::class);
         }
 
+        /** @phpstan-ignore-next-line */
         return $dataTable::create($builder);
     }
 
@@ -152,6 +154,7 @@ class DataTables
             $this->throwInvalidEngineException($dataTable, CollectionDataTable::class);
         }
 
+        /** @phpstan-ignore-next-line */
         return $dataTable::create($collection);
     }
 

--- a/src/DataTables.php
+++ b/src/DataTables.php
@@ -112,7 +112,9 @@ class DataTables
      */
     public function query(QueryBuilder $builder): QueryDataTable
     {
-        return QueryDataTable::create($builder);
+        $dataTable = config('datatables.engines.query');
+        
+        return $dataTable::create($builder);
     }
 
     /**
@@ -123,7 +125,9 @@ class DataTables
      */
     public function eloquent(EloquentBuilder $builder): EloquentDataTable
     {
-        return EloquentDataTable::create($builder);
+        $dataTable = config('datatables.engines.eloquent');
+        
+        return $dataTable::create($builder);
     }
 
     /**
@@ -134,7 +138,9 @@ class DataTables
      */
     public function collection($collection): CollectionDataTable
     {
-        return CollectionDataTable::create($collection);
+        $dataTable = config('datatables.engines.collection');
+        
+        return $dataTable::create($builder);
     }
 
     /**


### PR DESCRIPTION
This allows people to use corresponding method calls like:

```
$builder = datatables()->eloquent($query);
```

instead of needing to use the `make` method.

```
$builder = datatables()->make($query);
```

Since only the `make` is using the classes from `datatables.engines`, the code is not consistent.