### PR TITLE
fix: Custom Order on eager loaded relationships was not working

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -633,7 +633,7 @@ class QueryDataTable extends DataTableAbstract
 
                 if ($this->hasOrderColumn($orderable['name'])) {
                     $this->applyOrderColumn($orderable['name'], $orderable);
-                } else if ($this->hasOrderColumn($column)) {
+                } elseif ($this->hasOrderColumn($column)) {
                     $this->applyOrderColumn($column, $orderable);
                 } else {
                     $nullsLastSql = $this->getNullsLastSql($column, $orderable['direction']);

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -631,7 +631,9 @@ class QueryDataTable extends DataTableAbstract
             ->each(function ($orderable) {
                 $column = $this->resolveRelationColumn($orderable['name']);
 
-                if ($this->hasOrderColumn($column)) {
+                if ($this->hasOrderColumn($orderable['name'])) {
+                    $this->applyOrderColumn($orderable['name'], $orderable);
+                } else if ($this->hasOrderColumn($column)) {
                     $this->applyOrderColumn($column, $orderable);
                 } else {
                     $nullsLastSql = $this->getNullsLastSql($column, $orderable['direction']);

--- a/tests/Integration/CustomOrderTest.php
+++ b/tests/Integration/CustomOrderTest.php
@@ -15,21 +15,12 @@ class CustomOrderTest extends TestCase
     public function it_can_order_with_custom_order()
     {
         $response = $this->getJsonResponse([
-            'order'  => [
+            'order' => [
                 [
                     'column' => 0,
                     'dir'    => 'asc',
                 ],
             ],
-            'length' => 10,
-            'start'  => 0,
-            'draw'   => 1,
-        ]);
-
-        $response->assertJson([
-            'draw'            => 1,
-            'recordsTotal'    => 60,
-            'recordsFiltered' => 60,
         ]);
 
         $this->assertEquals(
@@ -43,12 +34,18 @@ class CustomOrderTest extends TestCase
         $data = [
             'columns' => [
                 ['data' => 'user.id', 'name' => 'user.id', 'searchable' => 'true', 'orderable' => 'true'],
-                ['data' => 'user.email', 'name' => 'user.email', 'searchable' => 'true', 'orderable' => 'true'],
                 ['data' => 'title', 'name' => 'posts.title', 'searchable' => 'true', 'orderable' => 'true'],
             ],
+            'length'  => 10,
+            'start'   => 0,
+            'draw'    => 1,
         ];
 
-        return $this->call('GET', '/relations/belongsTo', array_merge($data, $params));
+        return $this->call(
+            'GET',
+            '/relations/belongsTo',
+            array_merge($data, $params)
+        );
     }
 
     protected function setUp(): void
@@ -59,7 +56,8 @@ class CustomOrderTest extends TestCase
             return $datatables->eloquent(Post::with('user')->select('posts.*'))
                               ->orderColumn('user.id', function ($query, $order) {
                                   $query->orderBy('users.id', $order == 'desc' ? 'asc' : 'desc');
-                              })->toJson();
+                              })
+                              ->toJson();
         });
     }
 }

--- a/tests/Integration/CustomOrderTest.php
+++ b/tests/Integration/CustomOrderTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Yajra\DataTables\Tests\Integration;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Yajra\DataTables\DataTables;
+use Yajra\DataTables\Tests\Models\Post;
+use Yajra\DataTables\Tests\TestCase;
+
+class CustomOrderTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    function it_can_order_with_custom_order()
+    {
+        $response = $this->getJsonResponse([
+            'order'  => [
+                [
+                    'column' => 1,
+                    'dir'    => 'asc',
+                ],
+            ],
+            'length' => 10,
+            'start'  => 0,
+            'draw'   => 1,
+        ]);
+
+        $response->assertJson([
+            'draw'            => 1,
+            'recordsTotal'    => 60,
+            'recordsFiltered' => 60,
+        ]);
+
+        $this->assertEquals($response->json()['data'][0]['user']['id'], collect($response->json()['data'])->pluck('user.id')->max());
+    }
+
+    protected function getJsonResponse(array $params = [])
+    {
+        $data = [
+            'columns' => [
+                ['data' => 'user.id', 'name' => 'user.name', 'searchable' => 'true', 'orderable' => 'true'],
+                ['data' => 'user.email', 'name' => 'user.email', 'searchable' => 'true', 'orderable' => 'true'],
+                ['data' => 'title', 'name' => 'posts.title', 'searchable' => 'true', 'orderable' => 'true'],
+            ],
+        ];
+
+        return $this->call('GET', '/relations/belongsTo', array_merge($data, $params));
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app['router']->get('/relations/belongsTo', function (DataTables $datatables) {
+            return $datatables->eloquent(Post::with('user')->select('posts.*'))
+                              ->orderColumn('user.email', function ($query, $order) {
+                                  $query->orderBy('users.id', $order == 'desc' ? 'asc' : 'desc');
+                              })->toJson();
+        });
+    }
+}

--- a/tests/Integration/CustomOrderTest.php
+++ b/tests/Integration/CustomOrderTest.php
@@ -17,7 +17,7 @@ class CustomOrderTest extends TestCase
         $response = $this->getJsonResponse([
             'order'  => [
                 [
-                    'column' => 1,
+                    'column' => 0,
                     'dir'    => 'asc',
                 ],
             ],
@@ -39,7 +39,7 @@ class CustomOrderTest extends TestCase
     {
         $data = [
             'columns' => [
-                ['data' => 'user.id', 'name' => 'user.name', 'searchable' => 'true', 'orderable' => 'true'],
+                ['data' => 'user.id', 'name' => 'user.id', 'searchable' => 'true', 'orderable' => 'true'],
                 ['data' => 'user.email', 'name' => 'user.email', 'searchable' => 'true', 'orderable' => 'true'],
                 ['data' => 'title', 'name' => 'posts.title', 'searchable' => 'true', 'orderable' => 'true'],
             ],
@@ -54,7 +54,7 @@ class CustomOrderTest extends TestCase
 
         $this->app['router']->get('/relations/belongsTo', function (DataTables $datatables) {
             return $datatables->eloquent(Post::with('user')->select('posts.*'))
-                              ->orderColumn('user.email', function ($query, $order) {
+                              ->orderColumn('user.id', function ($query, $order) {
                                   $query->orderBy('users.id', $order == 'desc' ? 'asc' : 'desc');
                               })->toJson();
         });

--- a/tests/Integration/CustomOrderTest.php
+++ b/tests/Integration/CustomOrderTest.php
@@ -12,7 +12,7 @@ class CustomOrderTest extends TestCase
     use DatabaseTransactions;
 
     /** @test */
-    function it_can_order_with_custom_order()
+    public function it_can_order_with_custom_order()
     {
         $response = $this->getJsonResponse([
             'order'  => [

--- a/tests/Integration/CustomOrderTest.php
+++ b/tests/Integration/CustomOrderTest.php
@@ -32,7 +32,10 @@ class CustomOrderTest extends TestCase
             'recordsFiltered' => 60,
         ]);
 
-        $this->assertEquals($response->json()['data'][0]['user']['id'], collect($response->json()['data'])->pluck('user.id')->max());
+        $this->assertEquals(
+            $response->json()['data'][0]['user']['id'],
+            collect($response->json()['data'])->pluck('user.id')->max()
+        );
     }
 
     protected function getJsonResponse(array $params = [])


### PR DESCRIPTION
Following this issue : https://github.com/yajra/laravel-datatables/discussions/2905

When creating custom order for a column with dot notation, 

if the column name was `relation.column` (`user.id`)
AND the relationship was eagerloaded, 
the default order would be `relation_table.column` (`users.id`)

BUT if we would customise the order of that column like that : 

```
->orderColumn('user.id', function ($query, $order) {
    // For testing purposes, revert the order
    $query->orderBy('users.id', $order == 'desc' ? 'asc' : 'desc');
})
```

the custom order would not be applied

by checking if a custom order exists for our column definition name, we fix that behavior