### PR TITLE
fix: case insensitive starts with search #2917

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -445,12 +445,12 @@ class QueryDataTable extends DataTableAbstract
      */
     protected function prepareKeyword(string $keyword): string
     {
-        if ($this->config->isStartsWithSearch()) {
-            return "$keyword%";
-        }
-
         if ($this->config->isCaseInsensitive()) {
             $keyword = Str::lower($keyword);
+        }
+
+        if ($this->config->isStartsWithSearch()) {
+            return "$keyword%";
         }
 
         if ($this->config->isWildcard()) {


### PR DESCRIPTION
```
'search'         => [
        'smart'            => false,
        'multi_term'       => false,
        'case_insensitive' => true,
        'use_wildcards'    => false,
        'starts_with'      => true,
    ],
```
If this is the case, line 449 would return keyword% without converting it to lower case first. The change suggested in this request will first check the sensitivity, convert to lower if set to true, and then return lower("$keyword%").
