### PR TITLE
fix: Fix anonymous resource collection data formatting

### DIFF
--- a/src/ApiResourceDataTable.php
+++ b/src/ApiResourceDataTable.php
@@ -31,14 +31,16 @@ class ApiResourceDataTable extends CollectionDataTable
     /**
      * CollectionEngine constructor.
      *
-     * @param  \Illuminate\Http\Resources\Json\AnonymousResourceCollection<array-key, array>  $collection
+     * @param  \Illuminate\Http\Resources\Json\AnonymousResourceCollection<array-key, array>  $resourceCollection
      */
-    public function __construct(AnonymousResourceCollection $collection)
+    public function __construct(AnonymousResourceCollection $resourceCollection)
     {
+        /** @var \Illuminate\Support\Collection<(int|string), array> $collection */
+        $collection = collect($resourceCollection)->pluck('request');
         $this->request = app('datatables.request');
         $this->config = app('datatables.config');
-        $this->collection = collect($collection)->pluck('resource');
-        $this->original = collect($collection)->pluck('resource');
-        $this->columns = array_keys($this->serialize(collect($collection)->pluck('resource')->first()));
+        $this->collection = $collection;
+        $this->original = $collection;
+        $this->columns = array_keys($this->serialize($collection->first()));
     }
 }

--- a/src/ApiResourceDataTable.php
+++ b/src/ApiResourceDataTable.php
@@ -37,8 +37,8 @@ class ApiResourceDataTable extends CollectionDataTable
     {
         $this->request = app('datatables.request');
         $this->config = app('datatables.config');
-        $this->collection = collect($collection);
-        $this->original = collect($collection);
-        $this->columns = array_keys($this->serialize(collect($collection)->first()));
+        $this->collection = collect($collection)->pluck('resource');
+        $this->original = collect($collection)->pluck('resource');
+        $this->columns = array_keys($this->serialize(collect($collection)->pluck('resource')->first()));
     }
 }

--- a/src/ApiResourceDataTable.php
+++ b/src/ApiResourceDataTable.php
@@ -36,7 +36,7 @@ class ApiResourceDataTable extends CollectionDataTable
     public function __construct(AnonymousResourceCollection $resourceCollection)
     {
         /** @var \Illuminate\Support\Collection<(int|string), array> $collection */
-        $collection = collect($resourceCollection)->pluck('request');
+        $collection = collect($resourceCollection)->pluck('resource');
         $this->request = app('datatables.request');
         $this->config = app('datatables.config');
         $this->collection = $collection;


### PR DESCRIPTION
Fixes #2943 
Issue seems to be due to an extra layer of properties when converting a resource to a collection.

Normal Collection :
![image](https://user-images.githubusercontent.com/24486552/216758301-9bc3984e-8829-4212-969f-ee5c89015a4b.png)


Converted Resource Collection : 
![image](https://user-images.githubusercontent.com/24486552/216758259-1692da44-6c0f-4815-b9a4-2ac0415365eb.png)
