### PR TITLE
feat: Allow any callable in ->addColumn()

### DIFF
--- a/src/Utilities/Helper.php
+++ b/src/Utilities/Helper.php
@@ -55,10 +55,11 @@ class Helper
     }
 
     /**
-     * Gets the parameter of a callable thing (from is_callable) and returns it's arguments using reflection
+     * Gets the parameter of a callable thing (from is_callable) and returns it's arguments using reflection.
      *
-     * @param callable $callable
+     * @param  callable  $callable
      * @return \ReflectionParameter[]
+     *
      * @throws \ReflectionException
      * @throws \InvalidArgumentException
      */
@@ -70,14 +71,14 @@ class Helper
         */
         if ($callable instanceof Closure) {
             $reflection = new ReflectionFunction($callable);
-        } else if (is_string($callable) && function_exists($callable)) {
+        } elseif (is_string($callable) && function_exists($callable)) {
             $reflection = new ReflectionFunction($callable);
-        } else if (is_string($callable) && str_contains($callable, '::')) {
+        } elseif (is_string($callable) && str_contains($callable, '::')) {
             $reflection = new ReflectionMethod($callable);
-        } else if (is_object($callable) && method_exists($callable, '__invoke')) {
+        } elseif (is_object($callable) && method_exists($callable, '__invoke')) {
             $reflection = new ReflectionMethod($callable, '__invoke');
         } else {
-            throw new \InvalidArgumentException("argument is not callable or the code is wrong");
+            throw new \InvalidArgumentException('argument is not callable or the code is wrong');
         }
 
         return $reflection->getParameters();

--- a/tests/Unit/HelperTest.php
+++ b/tests/Unit/HelperTest.php
@@ -116,7 +116,8 @@ class HelperTest extends TestCase
 
     public function test_compile_content_callable_class()
     {
-        $content = new class {
+        $content = new class
+        {
             public function __invoke($obj)
             {
                 return $obj->id;


### PR DESCRIPTION
This PR fixes https://github.com/yajra/laravel-datatables/issues/2976

After upgrading our app to laravel-datatables 9.21 and above, you can't pass a class implementing __invoke() to addColumn. While this has never been supported according to the [docs](https://yajrabox.com/docs/laravel-datatables/master/add-column), it has worked until now. The fix is simple and should break other things.