### PR TITLE
Fix return type for `setTransformer()` and `setSerializer`

### DIFF
--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -15,8 +15,8 @@ use Yajra\DataTables\Processors\DataProcessor;
 use Yajra\DataTables\Utilities\Helper;
 
 /**
- * @method DataTableAbstract setTransformer($transformer)
- * @method DataTableAbstract setSerializer($transformer)
+ * @method static setTransformer($transformer)
+ * @method static setSerializer($transformer)
  *
  * @property-read mixed $transformer
  * @property-read mixed $serializer


### PR DESCRIPTION
This PR https://github.com/yajra/laravel-datatables/pull/1383 added the `DataTableAbstract` return type for `setTransformer()` and `setSerializer` methods. This doesn't totally fix the IDE autocompletion, because the IDE cannot autocomplete methods from the actual datatable class that the method was called, it can't autocomplete methods from the `DataTableAbstract` class only. Returning `static` tells the IDE to autocomplete methods from the class that the method was called.