### PR TITLE
feat: Optimize countQuery with complex select

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -158,7 +158,7 @@ class QueryDataTable extends DataTableAbstract
 
         if ($this->isComplexQuery($builder)) {
             $builder->select(DB::raw('1'));
-            
+
             if (! $this->isComplexQuery($builder)) {
                 return $this->getConnection()
                     ->query()
@@ -167,6 +167,7 @@ class QueryDataTable extends DataTableAbstract
             }
 
             $builder = clone $this->query;
+
             return $this->getConnection()
                 ->query()
                 ->fromRaw('('.$builder->toSql().') count_row_table')

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -810,10 +810,10 @@ class QueryDataTable extends DataTableAbstract
     }
 
    /**
-     * Ignore the selects in count query.
-     *
-     * @return $this
-     */
+    * Ignore the selects in count query.
+    *
+    * @return $this
+    */
    public function ignoreSelectsInCountQuery()
    {
        $this->ignoreSelectInCountQuery = true;

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -164,16 +164,15 @@ class QueryDataTable extends DataTableAbstract
         $builder = clone $this->query;
 
         if ($this->isComplexQuery($builder)) {
-            $builder->select(DB::raw('1'));
+            $query_without_selects = clone $this->query;
+            $query_without_selects->select(DB::raw('1'));
 
-            if ($this->ignoreSelectInCountQuery || ! $this->isComplexQuery($builder)) {
+            if ($this->ignoreSelectInCountQuery || ! $this->isComplexQuery($query_without_selects)) {
                 return $this->getConnection()
                     ->query()
-                    ->fromRaw('('.$builder->toSql().') count_row_table')
-                    ->setBindings($builder->getBindings());
+                    ->fromRaw('('.$query_without_selects->toSql().') count_row_table')
+                    ->setBindings($query_without_selects->getBindings());
             }
-
-            $builder = clone $this->query;
 
             return $this->getConnection()
                 ->query()

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -57,13 +57,13 @@ class QueryDataTable extends DataTableAbstract
     protected bool $ignoreSelectInCountQuery = false;
 
     /**
-     * @param QueryBuilder $builder
+     * @param  QueryBuilder  $builder
      */
     public function __construct(QueryBuilder $builder)
     {
-        $this->query   = $builder;
+        $this->query = $builder;
         $this->request = app('datatables.request');
-        $this->config  = app('datatables.config');
+        $this->config = app('datatables.config');
         $this->columns = $builder->columns;
 
         if ($this->config->isDebugging()) {
@@ -85,18 +85,18 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Can the DataTable engine be created with these parameters.
      *
-     * @param mixed $source
+     * @param  mixed  $source
      * @return bool
      */
     public static function canCreate($source): bool
     {
-        return $source instanceof QueryBuilder && !($source instanceof EloquentBuilder);
+        return $source instanceof QueryBuilder && ! ($source instanceof EloquentBuilder);
     }
 
     /**
      * Organizes works.
      *
-     * @param bool $mDataSupport
+     * @param  bool  $mDataSupport
      * @return \Illuminate\Http\JsonResponse
      *
      * @throws \Exception
@@ -104,9 +104,9 @@ class QueryDataTable extends DataTableAbstract
     public function make($mDataSupport = true): JsonResponse
     {
         try {
-            $results   = $this->prepareQuery()->results();
+            $results = $this->prepareQuery()->results();
             $processed = $this->processResults($results, $mDataSupport);
-            $data      = $this->transform($results, $processed);
+            $data = $this->transform($results, $processed);
 
             return $this->render($data);
         } catch (\Exception $exception) {
@@ -131,7 +131,7 @@ class QueryDataTable extends DataTableAbstract
      */
     protected function prepareQuery(): static
     {
-        if (!$this->prepared) {
+        if (! $this->prepared) {
             $this->totalRecords = $this->totalCount();
 
             $this->filterRecords();
@@ -164,26 +164,25 @@ class QueryDataTable extends DataTableAbstract
         $builder = clone $this->query;
 
         if ($this->isComplexQuery($builder)) {
-            $builder->select(DB::raw('1'));
+            $query_without_selects = clone $this->query;
+            $query_without_selects->select(DB::raw('1'));
 
-            if ($this->ignoreSelectInCountQuery || ! $this->isComplexQuery($builder)) {
+            if ($this->ignoreSelectInCountQuery || ! $this->isComplexQuery($query_without_selects)) {
                 return $this->getConnection()
-                            ->query()
-                            ->fromRaw('('.$builder->toSql().') count_row_table')
-                            ->setBindings($builder->getBindings());
+                    ->query()
+                    ->fromRaw('('.$query_without_selects->toSql().') count_row_table')
+                    ->setBindings($query_without_selects->getBindings());
             }
 
-            $builder = clone $this->query;
-
             return $this->getConnection()
-                        ->query()
-                        ->fromRaw('(' . $builder->toSql() . ') count_row_table')
-                        ->setBindings($builder->getBindings());
+                ->query()
+                ->fromRaw('('.$builder->toSql().') count_row_table')
+                ->setBindings($builder->getBindings());
         }
 
         $row_count = $this->wrap('row_count');
         $builder->select($this->getConnection()->raw("'1' as {$row_count}"));
-        if (!$this->keepSelectBindings) {
+        if (! $this->keepSelectBindings) {
             $builder->setBindings([], 'select');
         }
 
@@ -193,7 +192,7 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Check if builder query uses complex sql.
      *
-     * @param QueryBuilder|EloquentBuilder $query
+     * @param  QueryBuilder|EloquentBuilder  $query
      * @return bool
      */
     protected function isComplexQuery($query): bool
@@ -204,7 +203,7 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Wrap column with DB grammar.
      *
-     * @param string $column
+     * @param  string  $column
      * @return string
      */
     protected function wrap(string $column): string
@@ -240,7 +239,7 @@ class QueryDataTable extends DataTableAbstract
                 continue;
             }
 
-            if (!$this->request->isColumnSearchable($index) || $this->isBlacklisted($column) && !$this->hasFilterColumn($column)) {
+            if (! $this->request->isColumnSearchable($index) || $this->isBlacklisted($column) && ! $this->hasFilterColumn($column)) {
                 continue;
             }
 
@@ -248,7 +247,7 @@ class QueryDataTable extends DataTableAbstract
                 $keyword = $this->getColumnSearchKeyword($index, true);
                 $this->applyFilterColumn($this->getBaseQueryBuilder(), $column, $keyword);
             } else {
-                $column  = $this->resolveRelationColumn($column);
+                $column = $this->resolveRelationColumn($column);
                 $keyword = $this->getColumnSearchKeyword($index);
                 $this->compileColumnSearch($index, $column, $keyword);
             }
@@ -258,7 +257,7 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Check if column has custom filter handler.
      *
-     * @param string $columnName
+     * @param  string  $columnName
      * @return bool
      */
     public function hasFilterColumn(string $columnName): bool
@@ -269,8 +268,8 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Get column keyword to use for search.
      *
-     * @param int  $i
-     * @param bool $raw
+     * @param  int  $i
+     * @param  bool  $raw
      * @return string
      */
     protected function getColumnSearchKeyword(int $i, bool $raw = false): string
@@ -286,15 +285,15 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Apply filterColumn api search.
      *
-     * @param QueryBuilder $query
-     * @param string       $columnName
-     * @param string       $keyword
-     * @param string       $boolean
+     * @param  QueryBuilder  $query
+     * @param  string  $columnName
+     * @param  string  $keyword
+     * @param  string  $boolean
      * @return void
      */
     protected function applyFilterColumn($query, string $columnName, string $keyword, string $boolean = 'and'): void
     {
-        $query    = $this->getBaseQueryBuilder($query);
+        $query = $this->getBaseQueryBuilder($query);
         $callback = $this->columnDef['filter'][$columnName]['method'];
 
         if ($this->query instanceof EloquentBuilder) {
@@ -313,12 +312,12 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Get the base query builder instance.
      *
-     * @param QueryBuilder|EloquentBuilder|null $instance
+     * @param  QueryBuilder|EloquentBuilder|null  $instance
      * @return QueryBuilder
      */
     protected function getBaseQueryBuilder($instance = null)
     {
-        if (!$instance) {
+        if (! $instance) {
             $instance = $this->query;
         }
 
@@ -342,7 +341,7 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Resolve the proper column name be used.
      *
-     * @param string $column
+     * @param  string  $column
      * @return string
      */
     protected function resolveRelationColumn(string $column): string
@@ -353,9 +352,9 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Compile queries for column search.
      *
-     * @param int    $i
-     * @param string $column
-     * @param string $keyword
+     * @param  int  $i
+     * @param  string  $column
+     * @param  string  $keyword
      * @return void
      */
     protected function compileColumnSearch(int $i, string $column, string $keyword): void
@@ -370,8 +369,8 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Compile regex query column search.
      *
-     * @param string $column
-     * @param string $keyword
+     * @param  string  $column
+     * @param  string  $keyword
      * @return void
      */
     protected function regexColumnSearch(string $column, string $keyword): void
@@ -380,20 +379,20 @@ class QueryDataTable extends DataTableAbstract
 
         switch ($this->getConnection()->getDriverName()) {
             case 'oracle':
-                $sql = !$this->config->isCaseInsensitive()
-                    ? 'REGEXP_LIKE( ' . $column . ' , ? )'
-                    : 'REGEXP_LIKE( LOWER(' . $column . ') , ?, \'i\' )';
+                $sql = ! $this->config->isCaseInsensitive()
+                    ? 'REGEXP_LIKE( '.$column.' , ? )'
+                    : 'REGEXP_LIKE( LOWER('.$column.') , ?, \'i\' )';
                 break;
 
             case 'pgsql':
                 $column = $this->castColumn($column);
-                $sql    = !$this->config->isCaseInsensitive() ? $column . ' ~ ?' : $column . ' ~* ? ';
+                $sql = ! $this->config->isCaseInsensitive() ? $column.' ~ ?' : $column.' ~* ? ';
                 break;
 
             default:
-                $sql     = !$this->config->isCaseInsensitive()
-                    ? $column . ' REGEXP ?'
-                    : 'LOWER(' . $column . ') REGEXP ?';
+                $sql = ! $this->config->isCaseInsensitive()
+                    ? $column.' REGEXP ?'
+                    : 'LOWER('.$column.') REGEXP ?';
                 $keyword = Str::lower($keyword);
         }
 
@@ -403,16 +402,16 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Wrap a column and cast based on database driver.
      *
-     * @param string $column
+     * @param  string  $column
      * @return string
      */
     protected function castColumn(string $column): string
     {
         switch ($this->getConnection()->getDriverName()) {
             case 'pgsql':
-                return 'CAST(' . $column . ' as TEXT)';
+                return 'CAST('.$column.' as TEXT)';
             case 'firebird':
-                return 'CAST(' . $column . ' as VARCHAR(255))';
+                return 'CAST('.$column.' as VARCHAR(255))';
             default:
                 return $column;
         }
@@ -421,46 +420,46 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Compile query builder where clause depending on configurations.
      *
-     * @param QueryBuilder|EloquentBuilder $query
-     * @param string                       $column
-     * @param string                       $keyword
-     * @param string                       $boolean
+     * @param  QueryBuilder|EloquentBuilder  $query
+     * @param  string  $column
+     * @param  string  $keyword
+     * @param  string  $boolean
      * @return void
      */
     protected function compileQuerySearch($query, string $column, string $keyword, string $boolean = 'or'): void
     {
         $column = $this->addTablePrefix($query, $column);
         $column = $this->castColumn($column);
-        $sql    = $column . ' LIKE ?';
+        $sql = $column.' LIKE ?';
 
         if ($this->config->isCaseInsensitive()) {
-            $sql = 'LOWER(' . $column . ') LIKE ?';
+            $sql = 'LOWER('.$column.') LIKE ?';
         }
 
-        $query->{$boolean . 'WhereRaw'}($sql, [$this->prepareKeyword($keyword)]);
+        $query->{$boolean.'WhereRaw'}($sql, [$this->prepareKeyword($keyword)]);
     }
 
     /**
      * Patch for fix about ambiguous field.
      * Ambiguous field error will appear when query use join table and search with keyword.
      *
-     * @param QueryBuilder|EloquentBuilder $query
-     * @param string                       $column
+     * @param  QueryBuilder|EloquentBuilder  $query
+     * @param  string  $column
      * @return string
      */
     protected function addTablePrefix($query, string $column): string
     {
-        if (!str_contains($column, '.')) {
-            $q    = $this->getBaseQueryBuilder($query);
+        if (! str_contains($column, '.')) {
+            $q = $this->getBaseQueryBuilder($query);
             $from = $q->from;
 
             /** @phpstan-ignore-next-line */
-            if (!$from instanceof Expression) {
+            if (! $from instanceof Expression) {
                 if (str_contains($from, ' as ')) {
                     $from = explode(' as ', $from)[1];
                 }
 
-                $column = $from . '.' . $column;
+                $column = $from.'.'.$column;
             }
         }
 
@@ -470,7 +469,7 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Prepare search keyword based on configurations.
      *
-     * @param string $keyword
+     * @param  string  $keyword
      * @return string
      */
     protected function prepareKeyword(string $keyword): string
@@ -497,8 +496,8 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Add custom filter handler for the give column.
      *
-     * @param string   $column
-     * @param callable $callback
+     * @param  string  $column
+     * @param  callable  $callback
      * @return $this
      */
     public function filterColumn($column, callable $callback): static
@@ -511,9 +510,9 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Order each given columns versus the given custom sql.
      *
-     * @param array  $columns
-     * @param string $sql
-     * @param array  $bindings
+     * @param  array  $columns
+     * @param  string  $sql
+     * @param  array  $bindings
      * @return $this
      */
     public function orderColumns(array $columns, $sql, $bindings = []): static
@@ -528,9 +527,9 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Override default column ordering.
      *
-     * @param string          $column
-     * @param string|\Closure $sql
-     * @param array           $bindings
+     * @param  string  $column
+     * @param  string|\Closure  $sql
+     * @param  array  $bindings
      * @return $this
      *
      * @internal string $1 Special variable that returns the requested order direction of the column.
@@ -561,7 +560,7 @@ class QueryDataTable extends DataTableAbstract
      */
     public function paging(): void
     {
-        $start  = $this->request->start();
+        $start = $this->request->start();
         $length = $this->request->length();
 
         $limit = $length > 0 ? $length : 10;
@@ -578,7 +577,7 @@ class QueryDataTable extends DataTableAbstract
      * Paginate dataTable using limit without offset
      * with additional where clause via callback.
      *
-     * @param callable $callback
+     * @param  callable  $callback
      * @return $this
      */
     public function limit(callable $callback): static
@@ -591,9 +590,9 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Add column in collection.
      *
-     * @param string          $name
-     * @param string|callable $content
-     * @param bool|int        $order
+     * @param  string  $name
+     * @param  string|callable  $content
+     * @param  bool|int  $order
      * @return $this
      */
     public function addColumn($name, $content, $order = false): static
@@ -656,7 +655,7 @@ class QueryDataTable extends DataTableAbstract
                 return $orderable;
             })
             ->reject(function ($orderable) {
-                return $this->isBlacklisted($orderable['name']) && !$this->hasOrderColumn($orderable['name']);
+                return $this->isBlacklisted($orderable['name']) && ! $this->hasOrderColumn($orderable['name']);
             })
             ->each(function ($orderable) {
                 $column = $this->resolveRelationColumn($orderable['name']);
@@ -667,8 +666,8 @@ class QueryDataTable extends DataTableAbstract
                     $this->applyOrderColumn($column, $orderable);
                 } else {
                     $nullsLastSql = $this->getNullsLastSql($column, $orderable['direction']);
-                    $normalSql    = $this->wrap($column) . ' ' . $orderable['direction'];
-                    $sql          = $this->nullsLast ? $nullsLastSql : $normalSql;
+                    $normalSql = $this->wrap($column).' '.$orderable['direction'];
+                    $sql = $this->nullsLast ? $nullsLastSql : $normalSql;
                     $this->query->orderByRaw($sql);
                 }
             });
@@ -677,7 +676,7 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Check if column has custom sort handler.
      *
-     * @param string $column
+     * @param  string  $column
      * @return bool
      */
     protected function hasOrderColumn(string $column): bool
@@ -688,8 +687,8 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Apply orderColumn custom query.
      *
-     * @param string $column
-     * @param array  $orderable
+     * @param  string  $column
+     * @param  array  $orderable
      */
     protected function applyOrderColumn(string $column, array $orderable): void
     {
@@ -701,7 +700,7 @@ class QueryDataTable extends DataTableAbstract
         if (is_callable($sql)) {
             call_user_func($sql, $this->query, $orderable['direction']);
         } else {
-            $sql      = str_replace('$1', $orderable['direction'], $sql);
+            $sql = str_replace('$1', $orderable['direction'], $sql);
             $bindings = $this->columnDef['order'][$column]['bindings'];
             $this->query->orderByRaw($sql, $bindings);
         }
@@ -710,8 +709,8 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Get NULLS LAST SQL.
      *
-     * @param string $column
-     * @param string $direction
+     * @param  string  $column
+     * @param  string  $direction
      * @return string
      *
      * @throws \Psr\Container\ContainerExceptionInterface
@@ -732,7 +731,7 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Perform global search for the given keyword.
      *
-     * @param string $keyword
+     * @param  string  $keyword
      * @return void
      */
     protected function globalSearch(string $keyword): void
@@ -744,7 +743,7 @@ class QueryDataTable extends DataTableAbstract
                 })
                 ->filter()
                 ->reject(function ($column) {
-                    return $this->isBlacklisted($column) && !$this->hasFilterColumn($column);
+                    return $this->isBlacklisted($column) && ! $this->hasFilterColumn($column);
                 })
                 ->each(function ($column) use ($keyword, $query) {
                     if ($this->hasFilterColumn($column)) {
@@ -759,7 +758,7 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Append debug parameters on output.
      *
-     * @param array $output
+     * @param  array  $output
      * @return array
      */
     protected function showDebugger(array $output): array
@@ -772,7 +771,7 @@ class QueryDataTable extends DataTableAbstract
         });
 
         $output['queries'] = $query_log;
-        $output['input']   = $this->request->all();
+        $output['input'] = $this->request->all();
 
         return $output;
     }
@@ -780,7 +779,7 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Attach custom with meta on response.
      *
-     * @param array $data
+     * @param  array  $data
      * @return array
      */
     protected function attachAppends(array $data): array
@@ -809,15 +808,15 @@ class QueryDataTable extends DataTableAbstract
         return $this->getQuery();
     }
 
-    /**
-     * Ignore the selects in count query.
-     *
-     * @return $this
-     */
-    public function ignoreSelectsInCountQuery(): static
-    {
-        $this->ignoreSelectInCountQuery = true;
+   /**
+    * Ignore the selects in count query.
+    *
+    * @return $this
+    */
+   public function ignoreSelectsInCountQuery()
+   {
+       $this->ignoreSelectInCountQuery = true;
 
-        return $this;
-    }
+       return $this;
+   }
 }

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -158,23 +158,23 @@ class QueryDataTable extends DataTableAbstract
 
         if ($this->isComplexQuery($builder)) {
             $builder->select(DB::raw('1'));
-            if (!$this->isComplexQuery($builder)) {
+            if (! $this->isComplexQuery($builder)) {
                 return $this->getConnection()
                     ->query()
-                    ->fromRaw('(' . $builder->toSql() . ') count_row_table')
+                    ->fromRaw('('.$builder->toSql().') count_row_table')
                     ->setBindings($builder->getBindings());
             }
 
             $builder = clone $this->query;
             return $this->getConnection()
                 ->query()
-                ->fromRaw('(' . $builder->toSql() . ') count_row_table')
+                ->fromRaw('('.$builder->toSql().') count_row_table')
                 ->setBindings($builder->getBindings());
         }
 
         $row_count = $this->wrap('row_count');
         $builder->select($this->getConnection()->raw("'1' as {$row_count}"));
-        if (!$this->keepSelectBindings) {
+        if (! $this->keepSelectBindings) {
             $builder->setBindings([], 'select');
         }
 

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -158,6 +158,7 @@ class QueryDataTable extends DataTableAbstract
 
         if ($this->isComplexQuery($builder)) {
             $builder->select(DB::raw('1'));
+            
             if (! $this->isComplexQuery($builder)) {
                 return $this->getConnection()
                     ->query()

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -164,15 +164,15 @@ class QueryDataTable extends DataTableAbstract
         $builder = clone $this->query;
 
         if ($this->isComplexQuery($builder)) {
-            $query_without_selects = clone $this->query;
-            $query_without_selects->select(DB::raw('1'));
-
-            if ($this->ignoreSelectInCountQuery || ! $this->isComplexQuery($query_without_selects)) {
+            $builder->select(DB::raw('1'));
+            if ($this->ignoreSelectInCountQuery || ! $this->isComplexQuery($builder)) {
                 return $this->getConnection()
                     ->query()
-                    ->fromRaw('('.$query_without_selects->toSql().') count_row_table')
-                    ->setBindings($query_without_selects->getBindings());
+                    ->fromRaw('('.$builder->toSql().') count_row_table')
+                    ->setBindings($builder->getBindings());
             }
+
+            $builder = clone $this->query;
 
             return $this->getConnection()
                 ->query()
@@ -813,7 +813,7 @@ class QueryDataTable extends DataTableAbstract
     *
     * @return $this
     */
-   public function ignoreSelectsInCountQuery()
+   public function ignoreSelectsInCountQuery(): static
    {
        $this->ignoreSelectInCountQuery = true;
 

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -809,10 +809,15 @@ class QueryDataTable extends DataTableAbstract
         return $this->getQuery();
     }
 
-    public function ignoreSelectsInCountQuery()
-    {
-        $this->ignoreSelectInCountQuery = true;
+   /**
+     * Ignore the selects in count query.
+     *
+     * @return $this
+     */
+   public function ignoreSelectsInCountQuery()
+   {
+       $this->ignoreSelectInCountQuery = true;
 
-        return $this;
-    }
+       return $this;
+   }
 }

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -49,6 +49,13 @@ class QueryDataTable extends DataTableAbstract
      */
     protected bool $keepSelectBindings = false;
 
+     /**
+     * Flag to ignore the selects in count query.
+     *
+     * @var bool
+     */
+    public bool $ignoreSelectInCountQuery = false;
+
     /**
      * @param  QueryBuilder  $builder
      */
@@ -159,7 +166,7 @@ class QueryDataTable extends DataTableAbstract
         if ($this->isComplexQuery($builder)) {
             $builder->select(DB::raw('1'));
 
-            if (! $this->isComplexQuery($builder)) {
+            if ($this->ignoreSelectInCountQuery || ! $this->isComplexQuery($builder)) {
                 return $this->getConnection()
                     ->query()
                     ->fromRaw('('.$builder->toSql().') count_row_table')
@@ -800,5 +807,12 @@ class QueryDataTable extends DataTableAbstract
         $this->prepareQuery();
 
         return $this->getQuery();
+    }
+
+    public function ignoreSelectsInCountQuery()
+    {
+        $this->ignoreSelectInCountQuery = true;
+
+        return $this;
     }
 }

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -49,7 +49,7 @@ class QueryDataTable extends DataTableAbstract
      */
     protected bool $keepSelectBindings = false;
 
-     /**
+    /**
      * Flag to ignore the selects in count query.
      *
      * @var bool

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -57,13 +57,13 @@ class QueryDataTable extends DataTableAbstract
     protected bool $ignoreSelectInCountQuery = false;
 
     /**
-     * @param  QueryBuilder  $builder
+     * @param QueryBuilder $builder
      */
     public function __construct(QueryBuilder $builder)
     {
-        $this->query = $builder;
+        $this->query   = $builder;
         $this->request = app('datatables.request');
-        $this->config = app('datatables.config');
+        $this->config  = app('datatables.config');
         $this->columns = $builder->columns;
 
         if ($this->config->isDebugging()) {
@@ -85,18 +85,18 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Can the DataTable engine be created with these parameters.
      *
-     * @param  mixed  $source
+     * @param mixed $source
      * @return bool
      */
     public static function canCreate($source): bool
     {
-        return $source instanceof QueryBuilder && ! ($source instanceof EloquentBuilder);
+        return $source instanceof QueryBuilder && !($source instanceof EloquentBuilder);
     }
 
     /**
      * Organizes works.
      *
-     * @param  bool  $mDataSupport
+     * @param bool $mDataSupport
      * @return \Illuminate\Http\JsonResponse
      *
      * @throws \Exception
@@ -104,9 +104,9 @@ class QueryDataTable extends DataTableAbstract
     public function make($mDataSupport = true): JsonResponse
     {
         try {
-            $results = $this->prepareQuery()->results();
+            $results   = $this->prepareQuery()->results();
             $processed = $this->processResults($results, $mDataSupport);
-            $data = $this->transform($results, $processed);
+            $data      = $this->transform($results, $processed);
 
             return $this->render($data);
         } catch (\Exception $exception) {
@@ -131,7 +131,7 @@ class QueryDataTable extends DataTableAbstract
      */
     protected function prepareQuery(): static
     {
-        if (! $this->prepared) {
+        if (!$this->prepared) {
             $this->totalRecords = $this->totalCount();
 
             $this->filterRecords();
@@ -164,25 +164,26 @@ class QueryDataTable extends DataTableAbstract
         $builder = clone $this->query;
 
         if ($this->isComplexQuery($builder)) {
-            $query_without_selects = clone $this->query;
-            $query_without_selects->select(DB::raw('1'));
+            $builder->select(DB::raw('1'));
 
-            if ($this->ignoreSelectInCountQuery || ! $this->isComplexQuery($query_without_selects)) {
+            if ($this->ignoreSelectInCountQuery || ! $this->isComplexQuery($builder)) {
                 return $this->getConnection()
-                    ->query()
-                    ->fromRaw('('.$query_without_selects->toSql().') count_row_table')
-                    ->setBindings($query_without_selects->getBindings());
+                            ->query()
+                            ->fromRaw('('.$builder->toSql().') count_row_table')
+                            ->setBindings($builder->getBindings());
             }
 
+            $builder = clone $this->query;
+
             return $this->getConnection()
-                ->query()
-                ->fromRaw('('.$builder->toSql().') count_row_table')
-                ->setBindings($builder->getBindings());
+                        ->query()
+                        ->fromRaw('(' . $builder->toSql() . ') count_row_table')
+                        ->setBindings($builder->getBindings());
         }
 
         $row_count = $this->wrap('row_count');
         $builder->select($this->getConnection()->raw("'1' as {$row_count}"));
-        if (! $this->keepSelectBindings) {
+        if (!$this->keepSelectBindings) {
             $builder->setBindings([], 'select');
         }
 
@@ -192,7 +193,7 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Check if builder query uses complex sql.
      *
-     * @param  QueryBuilder|EloquentBuilder  $query
+     * @param QueryBuilder|EloquentBuilder $query
      * @return bool
      */
     protected function isComplexQuery($query): bool
@@ -203,7 +204,7 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Wrap column with DB grammar.
      *
-     * @param  string  $column
+     * @param string $column
      * @return string
      */
     protected function wrap(string $column): string
@@ -239,7 +240,7 @@ class QueryDataTable extends DataTableAbstract
                 continue;
             }
 
-            if (! $this->request->isColumnSearchable($index) || $this->isBlacklisted($column) && ! $this->hasFilterColumn($column)) {
+            if (!$this->request->isColumnSearchable($index) || $this->isBlacklisted($column) && !$this->hasFilterColumn($column)) {
                 continue;
             }
 
@@ -247,7 +248,7 @@ class QueryDataTable extends DataTableAbstract
                 $keyword = $this->getColumnSearchKeyword($index, true);
                 $this->applyFilterColumn($this->getBaseQueryBuilder(), $column, $keyword);
             } else {
-                $column = $this->resolveRelationColumn($column);
+                $column  = $this->resolveRelationColumn($column);
                 $keyword = $this->getColumnSearchKeyword($index);
                 $this->compileColumnSearch($index, $column, $keyword);
             }
@@ -257,7 +258,7 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Check if column has custom filter handler.
      *
-     * @param  string  $columnName
+     * @param string $columnName
      * @return bool
      */
     public function hasFilterColumn(string $columnName): bool
@@ -268,8 +269,8 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Get column keyword to use for search.
      *
-     * @param  int  $i
-     * @param  bool  $raw
+     * @param int  $i
+     * @param bool $raw
      * @return string
      */
     protected function getColumnSearchKeyword(int $i, bool $raw = false): string
@@ -285,15 +286,15 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Apply filterColumn api search.
      *
-     * @param  QueryBuilder  $query
-     * @param  string  $columnName
-     * @param  string  $keyword
-     * @param  string  $boolean
+     * @param QueryBuilder $query
+     * @param string       $columnName
+     * @param string       $keyword
+     * @param string       $boolean
      * @return void
      */
     protected function applyFilterColumn($query, string $columnName, string $keyword, string $boolean = 'and'): void
     {
-        $query = $this->getBaseQueryBuilder($query);
+        $query    = $this->getBaseQueryBuilder($query);
         $callback = $this->columnDef['filter'][$columnName]['method'];
 
         if ($this->query instanceof EloquentBuilder) {
@@ -312,12 +313,12 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Get the base query builder instance.
      *
-     * @param  QueryBuilder|EloquentBuilder|null  $instance
+     * @param QueryBuilder|EloquentBuilder|null $instance
      * @return QueryBuilder
      */
     protected function getBaseQueryBuilder($instance = null)
     {
-        if (! $instance) {
+        if (!$instance) {
             $instance = $this->query;
         }
 
@@ -341,7 +342,7 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Resolve the proper column name be used.
      *
-     * @param  string  $column
+     * @param string $column
      * @return string
      */
     protected function resolveRelationColumn(string $column): string
@@ -352,9 +353,9 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Compile queries for column search.
      *
-     * @param  int  $i
-     * @param  string  $column
-     * @param  string  $keyword
+     * @param int    $i
+     * @param string $column
+     * @param string $keyword
      * @return void
      */
     protected function compileColumnSearch(int $i, string $column, string $keyword): void
@@ -369,8 +370,8 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Compile regex query column search.
      *
-     * @param  string  $column
-     * @param  string  $keyword
+     * @param string $column
+     * @param string $keyword
      * @return void
      */
     protected function regexColumnSearch(string $column, string $keyword): void
@@ -379,20 +380,20 @@ class QueryDataTable extends DataTableAbstract
 
         switch ($this->getConnection()->getDriverName()) {
             case 'oracle':
-                $sql = ! $this->config->isCaseInsensitive()
-                    ? 'REGEXP_LIKE( '.$column.' , ? )'
-                    : 'REGEXP_LIKE( LOWER('.$column.') , ?, \'i\' )';
+                $sql = !$this->config->isCaseInsensitive()
+                    ? 'REGEXP_LIKE( ' . $column . ' , ? )'
+                    : 'REGEXP_LIKE( LOWER(' . $column . ') , ?, \'i\' )';
                 break;
 
             case 'pgsql':
                 $column = $this->castColumn($column);
-                $sql = ! $this->config->isCaseInsensitive() ? $column.' ~ ?' : $column.' ~* ? ';
+                $sql    = !$this->config->isCaseInsensitive() ? $column . ' ~ ?' : $column . ' ~* ? ';
                 break;
 
             default:
-                $sql = ! $this->config->isCaseInsensitive()
-                    ? $column.' REGEXP ?'
-                    : 'LOWER('.$column.') REGEXP ?';
+                $sql     = !$this->config->isCaseInsensitive()
+                    ? $column . ' REGEXP ?'
+                    : 'LOWER(' . $column . ') REGEXP ?';
                 $keyword = Str::lower($keyword);
         }
 
@@ -402,16 +403,16 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Wrap a column and cast based on database driver.
      *
-     * @param  string  $column
+     * @param string $column
      * @return string
      */
     protected function castColumn(string $column): string
     {
         switch ($this->getConnection()->getDriverName()) {
             case 'pgsql':
-                return 'CAST('.$column.' as TEXT)';
+                return 'CAST(' . $column . ' as TEXT)';
             case 'firebird':
-                return 'CAST('.$column.' as VARCHAR(255))';
+                return 'CAST(' . $column . ' as VARCHAR(255))';
             default:
                 return $column;
         }
@@ -420,46 +421,46 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Compile query builder where clause depending on configurations.
      *
-     * @param  QueryBuilder|EloquentBuilder  $query
-     * @param  string  $column
-     * @param  string  $keyword
-     * @param  string  $boolean
+     * @param QueryBuilder|EloquentBuilder $query
+     * @param string                       $column
+     * @param string                       $keyword
+     * @param string                       $boolean
      * @return void
      */
     protected function compileQuerySearch($query, string $column, string $keyword, string $boolean = 'or'): void
     {
         $column = $this->addTablePrefix($query, $column);
         $column = $this->castColumn($column);
-        $sql = $column.' LIKE ?';
+        $sql    = $column . ' LIKE ?';
 
         if ($this->config->isCaseInsensitive()) {
-            $sql = 'LOWER('.$column.') LIKE ?';
+            $sql = 'LOWER(' . $column . ') LIKE ?';
         }
 
-        $query->{$boolean.'WhereRaw'}($sql, [$this->prepareKeyword($keyword)]);
+        $query->{$boolean . 'WhereRaw'}($sql, [$this->prepareKeyword($keyword)]);
     }
 
     /**
      * Patch for fix about ambiguous field.
      * Ambiguous field error will appear when query use join table and search with keyword.
      *
-     * @param  QueryBuilder|EloquentBuilder  $query
-     * @param  string  $column
+     * @param QueryBuilder|EloquentBuilder $query
+     * @param string                       $column
      * @return string
      */
     protected function addTablePrefix($query, string $column): string
     {
-        if (! str_contains($column, '.')) {
-            $q = $this->getBaseQueryBuilder($query);
+        if (!str_contains($column, '.')) {
+            $q    = $this->getBaseQueryBuilder($query);
             $from = $q->from;
 
             /** @phpstan-ignore-next-line */
-            if (! $from instanceof Expression) {
+            if (!$from instanceof Expression) {
                 if (str_contains($from, ' as ')) {
                     $from = explode(' as ', $from)[1];
                 }
 
-                $column = $from.'.'.$column;
+                $column = $from . '.' . $column;
             }
         }
 
@@ -469,7 +470,7 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Prepare search keyword based on configurations.
      *
-     * @param  string  $keyword
+     * @param string $keyword
      * @return string
      */
     protected function prepareKeyword(string $keyword): string
@@ -496,8 +497,8 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Add custom filter handler for the give column.
      *
-     * @param  string  $column
-     * @param  callable  $callback
+     * @param string   $column
+     * @param callable $callback
      * @return $this
      */
     public function filterColumn($column, callable $callback): static
@@ -510,9 +511,9 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Order each given columns versus the given custom sql.
      *
-     * @param  array  $columns
-     * @param  string  $sql
-     * @param  array  $bindings
+     * @param array  $columns
+     * @param string $sql
+     * @param array  $bindings
      * @return $this
      */
     public function orderColumns(array $columns, $sql, $bindings = []): static
@@ -527,9 +528,9 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Override default column ordering.
      *
-     * @param  string  $column
-     * @param  string|\Closure  $sql
-     * @param  array  $bindings
+     * @param string          $column
+     * @param string|\Closure $sql
+     * @param array           $bindings
      * @return $this
      *
      * @internal string $1 Special variable that returns the requested order direction of the column.
@@ -560,7 +561,7 @@ class QueryDataTable extends DataTableAbstract
      */
     public function paging(): void
     {
-        $start = $this->request->start();
+        $start  = $this->request->start();
         $length = $this->request->length();
 
         $limit = $length > 0 ? $length : 10;
@@ -577,7 +578,7 @@ class QueryDataTable extends DataTableAbstract
      * Paginate dataTable using limit without offset
      * with additional where clause via callback.
      *
-     * @param  callable  $callback
+     * @param callable $callback
      * @return $this
      */
     public function limit(callable $callback): static
@@ -590,9 +591,9 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Add column in collection.
      *
-     * @param  string  $name
-     * @param  string|callable  $content
-     * @param  bool|int  $order
+     * @param string          $name
+     * @param string|callable $content
+     * @param bool|int        $order
      * @return $this
      */
     public function addColumn($name, $content, $order = false): static
@@ -655,7 +656,7 @@ class QueryDataTable extends DataTableAbstract
                 return $orderable;
             })
             ->reject(function ($orderable) {
-                return $this->isBlacklisted($orderable['name']) && ! $this->hasOrderColumn($orderable['name']);
+                return $this->isBlacklisted($orderable['name']) && !$this->hasOrderColumn($orderable['name']);
             })
             ->each(function ($orderable) {
                 $column = $this->resolveRelationColumn($orderable['name']);
@@ -666,8 +667,8 @@ class QueryDataTable extends DataTableAbstract
                     $this->applyOrderColumn($column, $orderable);
                 } else {
                     $nullsLastSql = $this->getNullsLastSql($column, $orderable['direction']);
-                    $normalSql = $this->wrap($column).' '.$orderable['direction'];
-                    $sql = $this->nullsLast ? $nullsLastSql : $normalSql;
+                    $normalSql    = $this->wrap($column) . ' ' . $orderable['direction'];
+                    $sql          = $this->nullsLast ? $nullsLastSql : $normalSql;
                     $this->query->orderByRaw($sql);
                 }
             });
@@ -676,7 +677,7 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Check if column has custom sort handler.
      *
-     * @param  string  $column
+     * @param string $column
      * @return bool
      */
     protected function hasOrderColumn(string $column): bool
@@ -687,8 +688,8 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Apply orderColumn custom query.
      *
-     * @param  string  $column
-     * @param  array  $orderable
+     * @param string $column
+     * @param array  $orderable
      */
     protected function applyOrderColumn(string $column, array $orderable): void
     {
@@ -700,7 +701,7 @@ class QueryDataTable extends DataTableAbstract
         if (is_callable($sql)) {
             call_user_func($sql, $this->query, $orderable['direction']);
         } else {
-            $sql = str_replace('$1', $orderable['direction'], $sql);
+            $sql      = str_replace('$1', $orderable['direction'], $sql);
             $bindings = $this->columnDef['order'][$column]['bindings'];
             $this->query->orderByRaw($sql, $bindings);
         }
@@ -709,8 +710,8 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Get NULLS LAST SQL.
      *
-     * @param  string  $column
-     * @param  string  $direction
+     * @param string $column
+     * @param string $direction
      * @return string
      *
      * @throws \Psr\Container\ContainerExceptionInterface
@@ -731,7 +732,7 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Perform global search for the given keyword.
      *
-     * @param  string  $keyword
+     * @param string $keyword
      * @return void
      */
     protected function globalSearch(string $keyword): void
@@ -743,7 +744,7 @@ class QueryDataTable extends DataTableAbstract
                 })
                 ->filter()
                 ->reject(function ($column) {
-                    return $this->isBlacklisted($column) && ! $this->hasFilterColumn($column);
+                    return $this->isBlacklisted($column) && !$this->hasFilterColumn($column);
                 })
                 ->each(function ($column) use ($keyword, $query) {
                     if ($this->hasFilterColumn($column)) {
@@ -758,7 +759,7 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Append debug parameters on output.
      *
-     * @param  array  $output
+     * @param array $output
      * @return array
      */
     protected function showDebugger(array $output): array
@@ -771,7 +772,7 @@ class QueryDataTable extends DataTableAbstract
         });
 
         $output['queries'] = $query_log;
-        $output['input'] = $this->request->all();
+        $output['input']   = $this->request->all();
 
         return $output;
     }
@@ -779,7 +780,7 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Attach custom with meta on response.
      *
-     * @param  array  $data
+     * @param array $data
      * @return array
      */
     protected function attachAppends(array $data): array
@@ -808,15 +809,15 @@ class QueryDataTable extends DataTableAbstract
         return $this->getQuery();
     }
 
-   /**
-    * Ignore the selects in count query.
-    *
-    * @return $this
-    */
-   public function ignoreSelectsInCountQuery()
-   {
-       $this->ignoreSelectInCountQuery = true;
+    /**
+     * Ignore the selects in count query.
+     *
+     * @return $this
+     */
+    public function ignoreSelectsInCountQuery(): static
+    {
+        $this->ignoreSelectInCountQuery = true;
 
-       return $this;
-   }
+        return $this;
+    }
 }

--- a/tests/Unit/QueryDataTableTest.php
+++ b/tests/Unit/QueryDataTableTest.php
@@ -34,7 +34,6 @@ class QueryDataTableTest extends TestCase
 
     public function test_simple_queries_with_complexe_select_are_wrapped_without_selects()
     {
-
         /** @var \Yajra\DataTables\QueryDataTable $dataTable */
         $dataTable = app('datatables')->of(
             DB::table('users')->select('users.*')->selectRaw('(select id from posts where posts.user_id = users.id order by created_at desc limit 1) as last_post_id')

--- a/tests/Unit/QueryDataTableTest.php
+++ b/tests/Unit/QueryDataTableTest.php
@@ -37,12 +37,12 @@ class QueryDataTableTest extends TestCase
 
         /** @var \Yajra\DataTables\QueryDataTable $dataTable */
         $dataTable = app('datatables')->of(
-            DB::table('posts')->select('posts.*')->selectRaw('(select name from users where posts.user_id = users.id order by id limit 1) as user_name')
+            DB::table('users')->select('posts.*')->selectRaw('(select id from posts where posts.user_id = users.id order by created_at desc limit 1) as user_name')
         );
 
         $this->assertQueryWrapped(true, $dataTable->prepareCountQuery());
         $this->assertQueryHasNoSelect(true, $dataTable->prepareCountQuery());
-        $this->assertEquals(60, $dataTable->count());
+        $this->assertEquals(20, $dataTable->count());
     }
 
     public function test_simple_queries_are_not_wrapped_and_countable()
@@ -76,7 +76,6 @@ class QueryDataTableTest extends TestCase
     public function assertQueryHasNoSelect($expected, $query)
     {
          $sql = $query->toSql();
-
 
         $this->assertSame($expected, Str::startsWith($sql, 'select * from (select 1 from'), "'{$sql}' is not wrapped");
 

--- a/tests/Unit/QueryDataTableTest.php
+++ b/tests/Unit/QueryDataTableTest.php
@@ -42,10 +42,10 @@ class QueryDataTableTest extends TestCase
                     'last_post_id' => DB::table('posts')
                                         ->whereColumn('posts.user_id', 'users.id')
                                         ->orderBy('created_at')
-                                        ->select('id')
+                                        ->select('id'),
                 ])
                 ->orderBy(DB::table('posts')->whereColumn('posts.user_id', 'users.id')->orderBy('created_at')->select('created_at')
-            )
+                )
         );
 
         $this->assertQueryHasNoSelect(false, $dataTable->prepareCountQuery());
@@ -62,10 +62,10 @@ class QueryDataTableTest extends TestCase
                     'last_post_id' => DB::table('posts')
                                         ->whereColumn('posts.user_id', 'users.id')
                                         ->orderBy('created_at')
-                                        ->select('id')
+                                        ->select('id'),
                 ])
                 ->orderBy(DB::table('posts')->whereColumn('posts.user_id', 'users.id')->orderBy('created_at')->select('created_at')
-            )
+                )
         )->ignoreSelectsInCountQuery();
 
         $this->assertQueryHasNoSelect(true, $dataTable->prepareCountQuery());

--- a/tests/Unit/QueryDataTableTest.php
+++ b/tests/Unit/QueryDataTableTest.php
@@ -82,7 +82,7 @@ class QueryDataTableTest extends TestCase
                   'last_post_id' => DB::table('posts')
                                       ->whereColumn('posts.user_id', 'users.id')
                                       ->orderBy('created_at')
-                                      ->select('id')
+                                      ->select('id'),
               ])
         );
 

--- a/tests/Unit/QueryDataTableTest.php
+++ b/tests/Unit/QueryDataTableTest.php
@@ -37,9 +37,9 @@ class QueryDataTableTest extends TestCase
 
         /** @var \Yajra\DataTables\QueryDataTable $dataTable */
         $dataTable = app('datatables')->of(
-            DB::table('users')->select('posts.*')->selectRaw('(select id from posts where posts.user_id = users.id order by created_at desc limit 1) as user_name')
+            DB::table('users')->select('users.*')->selectRaw('(select id from posts where posts.user_id = users.id order by created_at desc limit 1) as last_post_id')
         );
-
+        dd(DB::table('users')->select('users.*')->selectRaw('(select id from posts where posts.user_id = users.id order by created_at desc limit 1) as last_post_id')->toSql());
         $this->assertQueryWrapped(true, $dataTable->prepareCountQuery());
         $this->assertQueryHasNoSelect(true, $dataTable->prepareCountQuery());
         $this->assertEquals(20, $dataTable->count());

--- a/tests/Unit/QueryDataTableTest.php
+++ b/tests/Unit/QueryDataTableTest.php
@@ -114,8 +114,8 @@ class QueryDataTableTest extends TestCase
     }
 
     /**
-     * @param $expected bool
-     * @param $query \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder
+     * @param  $expected bool
+     * @param  $query \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder
      * @return void
      */
     protected function assertQueryWrapped($expected, $query)
@@ -126,8 +126,8 @@ class QueryDataTableTest extends TestCase
     }
 
     /**
-     * @param $expected bool
-     * @param $query \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder
+     * @param  $expected  bool
+     * @param  $query  \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder
      * @return void
      */
     public function assertQueryHasNoSelect($expected, $query)

--- a/tests/Unit/QueryDataTableTest.php
+++ b/tests/Unit/QueryDataTableTest.php
@@ -28,6 +28,20 @@ class QueryDataTableTest extends TestCase
         );
 
         $this->assertQueryWrapped(true, $dataTable->prepareCountQuery());
+        $this->assertQueryHasNoSelect(false, $dataTable->prepareCountQuery());
+        $this->assertEquals(60, $dataTable->count());
+    }
+
+    public function test_simple_queries_with_complexe_select_are_wrapped_without_selects()
+    {
+
+        /** @var \Yajra\DataTables\QueryDataTable $dataTable */
+        $dataTable = app('datatables')->of(
+            DB::table('posts')->select('posts.*')->selectRaw('(select name from users where posts.user_id = users.id order by id limit 1) as user_name')
+        );
+
+        $this->assertQueryWrapped(true, $dataTable->prepareCountQuery());
+        $this->assertQueryHasNoSelect(true, $dataTable->prepareCountQuery());
         $this->assertEquals(60, $dataTable->count());
     }
 
@@ -52,5 +66,20 @@ class QueryDataTableTest extends TestCase
         $sql = $query->toSql();
 
         $this->assertSame($expected, Str::endsWith($sql, 'count_row_table'), "'{$sql}' is not wrapped");
+    }
+
+    /**
+     * @param $expected bool
+     * @param $query \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder
+     * @return void
+     */
+    public function assertQueryHasNoSelect($expected, $query)
+    {
+         $sql = $query->toSql();
+
+
+        $this->assertSame($expected, Str::startsWith($sql, 'select * from (select 1 from'), "'{$sql}' is not wrapped");
+
+
     }
 }

--- a/tests/Unit/QueryDataTableTest.php
+++ b/tests/Unit/QueryDataTableTest.php
@@ -39,7 +39,7 @@ class QueryDataTableTest extends TestCase
         $dataTable = app('datatables')->of(
             DB::table('users')->select('users.*')->selectRaw('(select id from posts where posts.user_id = users.id order by created_at desc limit 1) as last_post_id')
         );
-        dd(DB::table('users')->select('users.*')->selectRaw('(select id from posts where posts.user_id = users.id order by created_at desc limit 1) as last_post_id')->toSql());
+
         $this->assertQueryWrapped(true, $dataTable->prepareCountQuery());
         $this->assertQueryHasNoSelect(true, $dataTable->prepareCountQuery());
         $this->assertEquals(20, $dataTable->count());
@@ -75,10 +75,8 @@ class QueryDataTableTest extends TestCase
      */
     public function assertQueryHasNoSelect($expected, $query)
     {
-         $sql = $query->toSql();
+        $sql = $query->toSql();
 
         $this->assertSame($expected, Str::startsWith($sql, 'select * from (select 1 from'), "'{$sql}' is not wrapped");
-
-
     }
 }


### PR DESCRIPTION
When performing subqueries, some of the keywords used to determine if a query is complexe can be found in subqueries inside the main query : 

```
protected function isComplexQuery($query): bool
{
     return Str::contains(Str::lower($query->toSql()), ['union', 'having', 'distinct', 'order by', 'group by']);
}
```

For exemple : 

```sql
select 
    "users".*,
    (select id from posts where posts.user_id = users.id order by created_at desc limit 1) as last_post_id
from "users"
```

This query was detected as complexe, but the subquery had no impact on the number of records returns, 
The subquery was executed and had a huge impact on performance

To force this behavior, you can use the `ignoreSelectsInCountQuery()` on a QueryDatatable : 

```php
 $dataTable = app('datatables')->of(
            DB::table('users')
                ->select('users.*')
                ->addSelect([
                    'last_post_id' => DB::table('posts')
                                        ->whereColumn('posts.user_id', 'users.id')
                                        ->orderBy('created_at')
                                        ->select('id'),
                ])
                ->orderBy(DB::table('posts')->whereColumn('posts.user_id', 'users.id')->orderBy('created_at')->select('created_at')
                )
        )->ignoreSelectsInCountQuery();
```