### PR TITLE
feat: add ability to disable eloquent getter mutator

### DIFF
--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -225,7 +225,7 @@ abstract class DataTableAbstract implements DataTable
 
     /**
      * Prevent the getters Mutators to be applied when converting a collection
-     * of the Models into the final JSON
+     * of the Models into the final JSON.
      *
      * @return $this
      */

--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -53,6 +53,7 @@ abstract class DataTableAbstract implements DataTable
      */
     protected array $columnDef = [
         'index' => false,
+        'ignore_getters' => false,
         'append' => [],
         'edit' => [],
         'filter' => [],
@@ -218,6 +219,18 @@ abstract class DataTableAbstract implements DataTable
     public function addIndexColumn(): static
     {
         $this->columnDef['index'] = true;
+
+        return $this;
+    }
+
+    /**
+     * Prevent the getters Mutators to be applied when converting a collection
+     * of the Models into the final JSON
+     * @return $this
+     */
+    public function ignoreGetters(): static
+    {
+        $this->columnDef['ignore_getters'] = true;
 
         return $this;
     }

--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -226,6 +226,7 @@ abstract class DataTableAbstract implements DataTable
     /**
      * Prevent the getters Mutators to be applied when converting a collection
      * of the Models into the final JSON
+     *
      * @return $this
      */
     public function ignoreGetters(): static

--- a/src/Processors/DataProcessor.php
+++ b/src/Processors/DataProcessor.php
@@ -79,6 +79,11 @@ class DataProcessor
     protected bool $includeIndex = false;
 
     /**
+     * @var bool
+     */
+    protected bool $ignoreGetters;
+
+    /**
      * @param  iterable  $results
      * @param  array  $columnDef
      * @param  array  $templates
@@ -96,6 +101,7 @@ class DataProcessor
         $this->rawColumns = $columnDef['raw'] ?? [];
         $this->makeHidden = $columnDef['hidden'] ?? [];
         $this->makeVisible = $columnDef['visible'] ?? [];
+        $this->ignoreGetters = $columnDef['ignore_getters'] ?? false;
         $this->templates = $templates;
         $this->start = $start;
     }
@@ -112,7 +118,7 @@ class DataProcessor
         $indexColumn = config('datatables.index_column', 'DT_RowIndex');
 
         foreach ($this->results as $row) {
-            $data = Helper::convertToArray($row, ['hidden' => $this->makeHidden, 'visible' => $this->makeVisible]);
+            $data = Helper::convertToArray($row, ['hidden' => $this->makeHidden, 'visible' => $this->makeVisible, 'ignore_getters' => $this->ignoreGetters]);
             $value = $this->addColumns($data, $row);
             $value = $this->editColumns($value, $row);
             $value = $this->setupRowVariables($value, $row);

--- a/src/Processors/DataProcessor.php
+++ b/src/Processors/DataProcessor.php
@@ -81,7 +81,7 @@ class DataProcessor
     /**
      * @var bool
      */
-    protected bool $ignoreGetters;
+    protected bool $ignoreGetters = false;
 
     /**
      * @param  iterable  $results

--- a/src/Utilities/Helper.php
+++ b/src/Utilities/Helper.php
@@ -198,8 +198,14 @@ class Helper
     {
         if (config('datatables.ignore_getters') && is_object($row) && method_exists($row, 'getAttributes')) {
             $data = $row->getAttributes();
-            foreach ($row->getRelations() as $relationName => $collection) {
-                $data[$relationName] = self::convertToArray($collection);
+            foreach ($row->getRelations() as $relationName => $relation) {
+                if (is_iterable($relation)) {
+                    foreach ($relation as $relationItem) {
+                         $data[$relationName][] = self::convertToArray($relationItem);
+                    }
+                }else{
+                    $data[$relationName] = self::convertToArray($relation);
+                }
             }
 
             return $data;

--- a/src/Utilities/Helper.php
+++ b/src/Utilities/Helper.php
@@ -197,7 +197,7 @@ class Helper
     public static function convertToArray($row, $filters = [])
     {
         if (config('datatables.ignore_getters') && is_object($row) && method_exists($row, 'getAttributes')) {
-            $data = $row instanceof Arrayable ? $row->getAttributes() : (array)$row;
+            $data = $row instanceof Arrayable ? $row->getAttributes() : (array) $row;
             foreach ($row->getRelations() as $key => $value) {
                 $data[$key] = self::convertToArray($value);
             }
@@ -207,7 +207,7 @@ class Helper
             $row = is_object($row) && method_exists($row, 'makeVisible') ? $row->makeVisible(Arr::get($filters, 'visible',
                 [])) : $row;
 
-            $data = $row instanceof Arrayable ? $row->toArray() : (array)$row;
+            $data = $row instanceof Arrayable ? $row->toArray() : (array) $row;
             foreach ($data as &$value) {
                 if (is_object($value) || is_array($value)) {
                     $value = self::convertToArray($value);

--- a/src/Utilities/Helper.php
+++ b/src/Utilities/Helper.php
@@ -197,24 +197,26 @@ class Helper
     public static function convertToArray($row, $filters = [])
     {
         if (config('datatables.ignore_getters') && is_object($row) && method_exists($row, 'getAttributes')) {
-            $data = $row instanceof Arrayable ? $row->getAttributes() : (array) $row;
-            foreach ($row->getRelations() as $key => $value) {
-                $data[$key] = self::convertToArray($value);
+            $data = $row->getAttributes();
+            foreach ($row->getRelations() as $relationName => $collection) {
+                $data[$relationName] = self::convertToArray($collection);
             }
-        } else {
-            $row = is_object($row) && method_exists($row, 'makeHidden') ? $row->makeHidden(Arr::get($filters, 'hidden',
-                [])) : $row;
-            $row = is_object($row) && method_exists($row, 'makeVisible') ? $row->makeVisible(Arr::get($filters, 'visible',
-                [])) : $row;
 
-            $data = $row instanceof Arrayable ? $row->toArray() : (array) $row;
-            foreach ($data as &$value) {
-                if (is_object($value) || is_array($value)) {
-                    $value = self::convertToArray($value);
-                }
+            return $data;
+        }
 
-                unset($value);
+        $row = is_object($row) && method_exists($row, 'makeHidden') ? $row->makeHidden(Arr::get($filters, 'hidden',
+            [])) : $row;
+        $row = is_object($row) && method_exists($row, 'makeVisible') ? $row->makeVisible(Arr::get($filters, 'visible',
+            [])) : $row;
+
+        $data = $row instanceof Arrayable ? $row->toArray() : (array) $row;
+        foreach ($data as &$value) {
+            if (is_object($value) || is_array($value)) {
+                $value = self::convertToArray($value);
             }
+
+            unset($value);
         }
 
         return $data;

--- a/src/Utilities/Helper.php
+++ b/src/Utilities/Helper.php
@@ -198,13 +198,15 @@ class Helper
     {
         if (Arr::get($filters, 'ignore_getters') && is_object($row) && method_exists($row, 'getAttributes')) {
             $data = $row->getAttributes();
-            foreach ($row->getRelations() as $relationName => $relation) {
-                if (is_iterable($relation)) {
-                    foreach ($relation as $relationItem) {
-                        $data[$relationName][] = self::convertToArray($relationItem, ['ignore_getters' => true]);
+            if(method_exists($row, 'getRelations')) {
+                foreach ($row->getRelations() as $relationName => $relation) {
+                    if (is_iterable($relation)) {
+                        foreach ($relation as $relationItem) {
+                            $data[$relationName][] = self::convertToArray($relationItem, ['ignore_getters' => true]);
+                        }
+                    } else {
+                        $data[$relationName] = self::convertToArray($relation, ['ignore_getters' => true]);
                     }
-                } else {
-                    $data[$relationName] = self::convertToArray($relation, ['ignore_getters' => true]);
                 }
             }
 

--- a/src/Utilities/Helper.php
+++ b/src/Utilities/Helper.php
@@ -196,15 +196,15 @@ class Helper
      */
     public static function convertToArray($row, $filters = [])
     {
-        if (config('datatables.ignore_getters') && is_object($row) && method_exists($row, 'getAttributes')) {
+        if (Arr::get($filters, 'ignore_getters') && is_object($row) && method_exists($row, 'getAttributes')) {
             $data = $row->getAttributes();
             foreach ($row->getRelations() as $relationName => $relation) {
                 if (is_iterable($relation)) {
                     foreach ($relation as $relationItem) {
-                         $data[$relationName][] = self::convertToArray($relationItem);
+                         $data[$relationName][] = self::convertToArray($relationItem, ['ignore_getters' => true]);
                     }
                 }else{
-                    $data[$relationName] = self::convertToArray($relation);
+                    $data[$relationName] = self::convertToArray($relation, ['ignore_getters' => true]);
                 }
             }
 

--- a/src/Utilities/Helper.php
+++ b/src/Utilities/Helper.php
@@ -15,8 +15,8 @@ class Helper
     /**
      * Places item of extra columns into results by care of their order.
      *
-     * @param array $item
-     * @param array $array
+     * @param  array  $item
+     * @param  array  $array
      * @return array
      */
     public static function includeInArray($item, $array)
@@ -26,7 +26,7 @@ class Helper
         }
 
         $count = 0;
-        $last  = $array;
+        $last = $array;
         $first = [];
         foreach ($array as $key => $value) {
             if ($count == $item['order']) {
@@ -45,8 +45,8 @@ class Helper
     /**
      * Check if item order is valid.
      *
-     * @param array $item
-     * @param array $array
+     * @param  array  $item
+     * @param  array  $array
      * @return bool
      */
     protected static function isItemOrderInvalid($item, $array)
@@ -57,7 +57,7 @@ class Helper
     /**
      * Gets the parameter of a callable thing (from is_callable) and returns it's arguments using reflection.
      *
-     * @param callable $callable
+     * @param  callable  $callable
      * @return \ReflectionParameter[]
      *
      * @throws \ReflectionException
@@ -87,9 +87,9 @@ class Helper
     /**
      * Determines if content is callable or blade string, processes and returns.
      *
-     * @param mixed        $content Pre-processed content
-     * @param array        $data    data to use with blade template
-     * @param array|object $param   parameter to call with callable
+     * @param  mixed  $content  Pre-processed content
+     * @param  array  $data  data to use with blade template
+     * @param  array|object  $param  parameter to call with callable
      * @return mixed
      *
      * @throws \ReflectionException
@@ -116,8 +116,8 @@ class Helper
     /**
      * Parses and compiles strings by using Blade Template System.
      *
-     * @param string $str
-     * @param array  $data
+     * @param  string  $str
+     * @param  array  $data
      * @return false|string
      */
     public static function compileBlade($str, $data = [])
@@ -128,7 +128,7 @@ class Helper
         }
 
         ob_start() && extract($data, EXTR_SKIP);
-        eval('?>' . app('blade.compiler')->compileString($str));
+        eval('?>'.app('blade.compiler')->compileString($str));
         $str = ob_get_contents();
         ob_end_clean();
 
@@ -138,8 +138,8 @@ class Helper
     /**
      * Get a mixed value of custom data and the parameters.
      *
-     * @param array        $data
-     * @param array|object $param
+     * @param  array  $data
+     * @param  array|object  $param
      * @return array
      */
     public static function getMixedValue(array $data, array|object $param)
@@ -160,7 +160,7 @@ class Helper
     /**
      * Cast the parameter into an array.
      *
-     * @param array|object $param
+     * @param  array|object  $param
      * @return array
      */
     public static function castToArray(array|object $param): array
@@ -169,19 +169,19 @@ class Helper
             return $param->toArray();
         }
 
-        return (array)$param;
+        return (array) $param;
     }
 
     /**
      * Get equivalent or method of query builder.
      *
-     * @param string $method
+     * @param  string  $method
      * @return string
      */
     public static function getOrMethod($method)
     {
-        if (!Str::contains(Str::lower($method), 'or')) {
-            return 'or' . ucfirst($method);
+        if (! Str::contains(Str::lower($method), 'or')) {
+            return 'or'.ucfirst($method);
         }
 
         return $method;
@@ -190,8 +190,8 @@ class Helper
     /**
      * Converts array object values to associative array.
      *
-     * @param mixed $row
-     * @param array $filters
+     * @param  mixed  $row
+     * @param  array  $filters
      * @return array
      */
     public static function convertToArray($row, $filters = [])
@@ -221,7 +221,7 @@ class Helper
     }
 
     /**
-     * @param array $data
+     * @param  array  $data
      * @return array
      */
     public static function transform(array $data)
@@ -234,7 +234,7 @@ class Helper
     /**
      * Transform row data into an array.
      *
-     * @param array $row
+     * @param  array  $row
      * @return array
      */
     protected static function transformRow($row)
@@ -257,7 +257,7 @@ class Helper
     /**
      * Build parameters depending on # of arguments passed.
      *
-     * @param array $args
+     * @param  array  $args
      * @return array
      */
     public static function buildParameters(array $args)
@@ -281,9 +281,9 @@ class Helper
     /**
      * Replace all pattern occurrences with keyword.
      *
-     * @param array  $subject
-     * @param string $keyword
-     * @param string $pattern
+     * @param  array  $subject
+     * @param  string  $keyword
+     * @param  string  $pattern
      * @return array
      */
     public static function replacePatternWithKeyword(array $subject, $keyword, $pattern = '$1')
@@ -303,8 +303,8 @@ class Helper
     /**
      * Get column name from string.
      *
-     * @param string $str
-     * @param bool   $wantsAlias
+     * @param  string  $str
+     * @param  bool  $wantsAlias
      * @return string
      */
     public static function extractColumnName($str, $wantsAlias)
@@ -329,8 +329,8 @@ class Helper
     /**
      * Adds % wildcards to the given string.
      *
-     * @param string $str
-     * @param bool   $lowercase
+     * @param  string  $str
+     * @param  bool  $lowercase
      * @return string
      */
     public static function wildcardLikeString($str, $lowercase = true)
@@ -341,19 +341,19 @@ class Helper
     /**
      * Adds wildcards to the given string.
      *
-     * @param string $str
-     * @param string $wildcard
-     * @param bool   $lowercase
+     * @param  string  $str
+     * @param  string  $wildcard
+     * @param  bool  $lowercase
      * @return string
      */
     public static function wildcardString($str, $wildcard, $lowercase = true)
     {
-        $wild  = $wildcard;
-        $chars = (array)preg_split('//u', $str, -1, PREG_SPLIT_NO_EMPTY);
+        $wild = $wildcard;
+        $chars = (array) preg_split('//u', $str, -1, PREG_SPLIT_NO_EMPTY);
 
         if (count($chars) > 0) {
             foreach ($chars as $char) {
-                $wild .= $char . $wildcard;
+                $wild .= $char.$wildcard;
             }
         }
 
@@ -366,14 +366,14 @@ class Helper
 
     public static function toJsonScript(array $parameters, int $options = 0): string
     {
-        $values       = [];
+        $values = [];
         $replacements = [];
 
         foreach (Arr::dot($parameters) as $key => $value) {
             if (self::isJavascript($value, $key)) {
                 $values[] = trim($value);
-                Arr::set($parameters, $key, '%' . $key . '%');
-                $replacements[] = '"%' . $key . '%"';
+                Arr::set($parameters, $key, '%'.$key.'%');
+                $replacements[] = '"%'.$key.'%"';
             }
         }
 
@@ -382,7 +382,7 @@ class Helper
             Arr::set($new, $key, $value);
         }
 
-        $json = (string)json_encode($new, $options);
+        $json = (string) json_encode($new, $options);
 
         return str_replace($replacements, $values, $json);
     }

--- a/src/Utilities/Helper.php
+++ b/src/Utilities/Helper.php
@@ -15,8 +15,8 @@ class Helper
     /**
      * Places item of extra columns into results by care of their order.
      *
-     * @param  array  $item
-     * @param  array  $array
+     * @param array $item
+     * @param array $array
      * @return array
      */
     public static function includeInArray($item, $array)
@@ -26,7 +26,7 @@ class Helper
         }
 
         $count = 0;
-        $last = $array;
+        $last  = $array;
         $first = [];
         foreach ($array as $key => $value) {
             if ($count == $item['order']) {
@@ -45,8 +45,8 @@ class Helper
     /**
      * Check if item order is valid.
      *
-     * @param  array  $item
-     * @param  array  $array
+     * @param array $item
+     * @param array $array
      * @return bool
      */
     protected static function isItemOrderInvalid($item, $array)
@@ -57,7 +57,7 @@ class Helper
     /**
      * Gets the parameter of a callable thing (from is_callable) and returns it's arguments using reflection.
      *
-     * @param  callable  $callable
+     * @param callable $callable
      * @return \ReflectionParameter[]
      *
      * @throws \ReflectionException
@@ -87,9 +87,9 @@ class Helper
     /**
      * Determines if content is callable or blade string, processes and returns.
      *
-     * @param  mixed  $content  Pre-processed content
-     * @param  array  $data  data to use with blade template
-     * @param  array|object  $param  parameter to call with callable
+     * @param mixed        $content Pre-processed content
+     * @param array        $data    data to use with blade template
+     * @param array|object $param   parameter to call with callable
      * @return mixed
      *
      * @throws \ReflectionException
@@ -116,8 +116,8 @@ class Helper
     /**
      * Parses and compiles strings by using Blade Template System.
      *
-     * @param  string  $str
-     * @param  array  $data
+     * @param string $str
+     * @param array  $data
      * @return false|string
      */
     public static function compileBlade($str, $data = [])
@@ -128,7 +128,7 @@ class Helper
         }
 
         ob_start() && extract($data, EXTR_SKIP);
-        eval('?>'.app('blade.compiler')->compileString($str));
+        eval('?>' . app('blade.compiler')->compileString($str));
         $str = ob_get_contents();
         ob_end_clean();
 
@@ -138,8 +138,8 @@ class Helper
     /**
      * Get a mixed value of custom data and the parameters.
      *
-     * @param  array  $data
-     * @param  array|object  $param
+     * @param array        $data
+     * @param array|object $param
      * @return array
      */
     public static function getMixedValue(array $data, array|object $param)
@@ -160,7 +160,7 @@ class Helper
     /**
      * Cast the parameter into an array.
      *
-     * @param  array|object  $param
+     * @param array|object $param
      * @return array
      */
     public static function castToArray(array|object $param): array
@@ -169,19 +169,19 @@ class Helper
             return $param->toArray();
         }
 
-        return (array) $param;
+        return (array)$param;
     }
 
     /**
      * Get equivalent or method of query builder.
      *
-     * @param  string  $method
+     * @param string $method
      * @return string
      */
     public static function getOrMethod($method)
     {
-        if (! Str::contains(Str::lower($method), 'or')) {
-            return 'or'.ucfirst($method);
+        if (!Str::contains(Str::lower($method), 'or')) {
+            return 'or' . ucfirst($method);
         }
 
         return $method;
@@ -190,31 +190,38 @@ class Helper
     /**
      * Converts array object values to associative array.
      *
-     * @param  mixed  $row
-     * @param  array  $filters
+     * @param mixed $row
+     * @param array $filters
      * @return array
      */
     public static function convertToArray($row, $filters = [])
     {
-        $row = is_object($row) && method_exists($row, 'makeHidden') ? $row->makeHidden(Arr::get($filters, 'hidden',
-            [])) : $row;
-        $row = is_object($row) && method_exists($row, 'makeVisible') ? $row->makeVisible(Arr::get($filters, 'visible',
-            [])) : $row;
-        $data = $row instanceof Arrayable ? $row->toArray() : (array) $row;
-
-        foreach ($data as &$value) {
-            if (is_object($value) || is_array($value)) {
-                $value = self::convertToArray($value);
+        if (config('datatables.ignore_getters') && is_object($row) && method_exists($row, 'getAttributes')) {
+            $data = $row instanceof Arrayable ? $row->getAttributes() : (array)$row;
+            foreach ($row->getRelations() as $key => $value) {
+                $data[$key] = self::convertToArray($value);
             }
+        } else {
+            $row = is_object($row) && method_exists($row, 'makeHidden') ? $row->makeHidden(Arr::get($filters, 'hidden',
+                [])) : $row;
+            $row = is_object($row) && method_exists($row, 'makeVisible') ? $row->makeVisible(Arr::get($filters, 'visible',
+                [])) : $row;
 
-            unset($value);
+            $data = $row instanceof Arrayable ? $row->toArray() : (array)$row;
+            foreach ($data as &$value) {
+                if (is_object($value) || is_array($value)) {
+                    $value = self::convertToArray($value);
+                }
+
+                unset($value);
+            }
         }
 
         return $data;
     }
 
     /**
-     * @param  array  $data
+     * @param array $data
      * @return array
      */
     public static function transform(array $data)
@@ -227,7 +234,7 @@ class Helper
     /**
      * Transform row data into an array.
      *
-     * @param  array  $row
+     * @param array $row
      * @return array
      */
     protected static function transformRow($row)
@@ -250,7 +257,7 @@ class Helper
     /**
      * Build parameters depending on # of arguments passed.
      *
-     * @param  array  $args
+     * @param array $args
      * @return array
      */
     public static function buildParameters(array $args)
@@ -274,9 +281,9 @@ class Helper
     /**
      * Replace all pattern occurrences with keyword.
      *
-     * @param  array  $subject
-     * @param  string  $keyword
-     * @param  string  $pattern
+     * @param array  $subject
+     * @param string $keyword
+     * @param string $pattern
      * @return array
      */
     public static function replacePatternWithKeyword(array $subject, $keyword, $pattern = '$1')
@@ -296,8 +303,8 @@ class Helper
     /**
      * Get column name from string.
      *
-     * @param  string  $str
-     * @param  bool  $wantsAlias
+     * @param string $str
+     * @param bool   $wantsAlias
      * @return string
      */
     public static function extractColumnName($str, $wantsAlias)
@@ -322,8 +329,8 @@ class Helper
     /**
      * Adds % wildcards to the given string.
      *
-     * @param  string  $str
-     * @param  bool  $lowercase
+     * @param string $str
+     * @param bool   $lowercase
      * @return string
      */
     public static function wildcardLikeString($str, $lowercase = true)
@@ -334,19 +341,19 @@ class Helper
     /**
      * Adds wildcards to the given string.
      *
-     * @param  string  $str
-     * @param  string  $wildcard
-     * @param  bool  $lowercase
+     * @param string $str
+     * @param string $wildcard
+     * @param bool   $lowercase
      * @return string
      */
     public static function wildcardString($str, $wildcard, $lowercase = true)
     {
-        $wild = $wildcard;
-        $chars = (array) preg_split('//u', $str, -1, PREG_SPLIT_NO_EMPTY);
+        $wild  = $wildcard;
+        $chars = (array)preg_split('//u', $str, -1, PREG_SPLIT_NO_EMPTY);
 
         if (count($chars) > 0) {
             foreach ($chars as $char) {
-                $wild .= $char.$wildcard;
+                $wild .= $char . $wildcard;
             }
         }
 
@@ -359,14 +366,14 @@ class Helper
 
     public static function toJsonScript(array $parameters, int $options = 0): string
     {
-        $values = [];
+        $values       = [];
         $replacements = [];
 
         foreach (Arr::dot($parameters) as $key => $value) {
             if (self::isJavascript($value, $key)) {
                 $values[] = trim($value);
-                Arr::set($parameters, $key, '%'.$key.'%');
-                $replacements[] = '"%'.$key.'%"';
+                Arr::set($parameters, $key, '%' . $key . '%');
+                $replacements[] = '"%' . $key . '%"';
             }
         }
 
@@ -375,7 +382,7 @@ class Helper
             Arr::set($new, $key, $value);
         }
 
-        $json = (string) json_encode($new, $options);
+        $json = (string)json_encode($new, $options);
 
         return str_replace($replacements, $values, $json);
     }

--- a/src/Utilities/Helper.php
+++ b/src/Utilities/Helper.php
@@ -198,7 +198,7 @@ class Helper
     {
         if (Arr::get($filters, 'ignore_getters') && is_object($row) && method_exists($row, 'getAttributes')) {
             $data = $row->getAttributes();
-            if(method_exists($row, 'getRelations')) {
+            if (method_exists($row, 'getRelations')) {
                 foreach ($row->getRelations() as $relationName => $relation) {
                     if (is_iterable($relation)) {
                         foreach ($relation as $relationItem) {

--- a/src/Utilities/Helper.php
+++ b/src/Utilities/Helper.php
@@ -201,9 +201,9 @@ class Helper
             foreach ($row->getRelations() as $relationName => $relation) {
                 if (is_iterable($relation)) {
                     foreach ($relation as $relationItem) {
-                         $data[$relationName][] = self::convertToArray($relationItem, ['ignore_getters' => true]);
+                        $data[$relationName][] = self::convertToArray($relationItem, ['ignore_getters' => true]);
                     }
-                }else{
+                } else {
                     $data[$relationName] = self::convertToArray($relation, ['ignore_getters' => true]);
                 }
             }

--- a/src/config/datatables.php
+++ b/src/config/datatables.php
@@ -124,4 +124,10 @@ return [
      * Callbacks needs to start by those terms, or they will be cast to string.
      */
     'callback' => ['$', '$.', 'function'],
+
+    /*
+     * Prevent the getters Mutators to be applied when converting a collection
+     * of the Models into the final JSON
+     */
+    'ignore_getters' => false
 ];

--- a/src/config/datatables.php
+++ b/src/config/datatables.php
@@ -124,10 +124,4 @@ return [
      * Callbacks needs to start by those terms, or they will be cast to string.
      */
     'callback' => ['$', '$.', 'function'],
-
-    /*
-     * Prevent the getters Mutators to be applied when converting a collection
-     * of the Models into the final JSON
-     */
-    'ignore_getters' => false,
 ];

--- a/src/config/datatables.php
+++ b/src/config/datatables.php
@@ -129,5 +129,5 @@ return [
      * Prevent the getters Mutators to be applied when converting a collection
      * of the Models into the final JSON
      */
-    'ignore_getters' => false
+    'ignore_getters' => false,
 ];

--- a/tests/Integration/IgnoreGettersTest.php
+++ b/tests/Integration/IgnoreGettersTest.php
@@ -4,7 +4,6 @@ namespace Yajra\DataTables\Tests\Integration;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Yajra\DataTables\DataTables;
-use Yajra\DataTables\Tests\Models\Post;
 use Yajra\DataTables\Tests\Models\User;
 use Yajra\DataTables\Tests\TestCase;
 
@@ -41,7 +40,7 @@ class IgnoreGettersTest extends TestCase
         $this->assertCount(20, $response->json()['data']);
     }
 
-     /** @test */
+    /** @test */
     public function it_ignore_the_getter_value_with_ignore_getters_config()
     {
         app('config')->set('datatables.ignore_getters', true);

--- a/tests/Integration/IgnoreGettersTest.php
+++ b/tests/Integration/IgnoreGettersTest.php
@@ -29,7 +29,7 @@ class IgnoreGettersTest extends TestCase
     }
 
     /** @test */
-    function it_return_the_getter_value_without_ignore_getters_config()
+    public function it_return_the_getter_value_without_ignore_getters_config()
     {
         $response = $this->call('GET', '/ignore-getters');
         $response->assertJson([
@@ -42,7 +42,7 @@ class IgnoreGettersTest extends TestCase
     }
 
      /** @test */
-    function it_ignore_the_getter_value_with_ignore_getters_config()
+    public function it_ignore_the_getter_value_with_ignore_getters_config()
     {
         app('config')->set('datatables.ignore_getters', true);
 

--- a/tests/Integration/IgnoreGettersTest.php
+++ b/tests/Integration/IgnoreGettersTest.php
@@ -3,6 +3,7 @@
 namespace Yajra\DataTables\Tests\Integration;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Arr;
 use Yajra\DataTables\DataTables;
 use Yajra\DataTables\Tests\Models\User;
 use Yajra\DataTables\Tests\TestCase;
@@ -36,7 +37,13 @@ class IgnoreGettersTest extends TestCase
             'recordsTotal'    => 20,
             'recordsFiltered' => 20,
         ]);
+
+        $this->assertNotNull($response->json()['data'][0]['posts']);
+        // Assert the getter color is not call on primary Model
         $this->assertNotNull($response->json()['data'][0]['color']);
+        // Assert the getter color is not call on relationships
+        $this->assertNotNull($response->json()['data'][0]['posts'][0]['user']['color']);
+        $this->assertNull(Arr::get($response->json()['data'][0], 'roles'));
         $this->assertCount(20, $response->json()['data']);
     }
 
@@ -51,7 +58,14 @@ class IgnoreGettersTest extends TestCase
             'recordsTotal'    => 20,
             'recordsFiltered' => 20,
         ]);
-        $this->assertNull($response->json()['data'][0]['color']);
+
+        $this->assertNotNull($response->json()['data'][0]['posts']);
+
+       // Assert the getter color is not call on primary Model
+        $this->assertNotNull($response->json()['data'][0]['color']);
+        // Assert the getter color is not call on relationships
+        $this->assertNull($response->json()['data'][0]['posts'][0]['user']['color']);
+        $this->assertNull(Arr::get($response->json()['data'][0], 'roles'));
         $this->assertCount(20, $response->json()['data']);
     }
 
@@ -60,7 +74,7 @@ class IgnoreGettersTest extends TestCase
         parent::setUp();
 
         $this->app['router']->get('/ignore-getters', function (DataTables $datatables) {
-            return $datatables->eloquent(User::with('posts')->select('users.*'))->toJson();
+            return $datatables->eloquent(User::with('posts.user')->select('users.*'))->toJson();
         });
     }
 }

--- a/tests/Integration/IgnoreGettersTest.php
+++ b/tests/Integration/IgnoreGettersTest.php
@@ -12,6 +12,19 @@ class IgnoreGettersTest extends TestCase
     use DatabaseTransactions;
 
     /** @test */
+    function it_return_the_default_value_when_attribute_is_null()
+    {
+        $user = User::create([
+                'name'  => 'foo',
+                'email' => 'foo@bar.com',
+                'color' => null
+            ]);
+
+        $this->assertEquals('#000000', $user->color);
+        $this->assertEquals('#000000', $user->refresh()->toArray()['color']);
+    }
+
+    /** @test */
     public function it_return_the_getter_value_without_ignore_getters()
     {
         $this->app['router']->get('/ignore-getters', function (DataTables $datatables) {

--- a/tests/Integration/IgnoreGettersTest.php
+++ b/tests/Integration/IgnoreGettersTest.php
@@ -3,7 +3,6 @@
 namespace Yajra\DataTables\Tests\Integration;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
-use Illuminate\Support\Arr;
 use Yajra\DataTables\DataTables;
 use Yajra\DataTables\Tests\Models\User;
 use Yajra\DataTables\Tests\TestCase;
@@ -49,7 +48,7 @@ class IgnoreGettersTest extends TestCase
         ]);
 
         $this->assertNotNull($response->json()['data'][0]['posts']);
-       // Assert the getter color is not call on primary Model
+        // Assert the getter color is not call on primary Model
         $this->assertNull($response->json()['data'][0]['color']);
         // Assert the getter color is not call on relationships
         $this->assertNull($response->json()['data'][0]['posts'][0]['user']['color']);

--- a/tests/Integration/IgnoreGettersTest.php
+++ b/tests/Integration/IgnoreGettersTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Yajra\DataTables\Tests\Integration;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Yajra\DataTables\DataTables;
+use Yajra\DataTables\Tests\Models\Post;
+use Yajra\DataTables\Tests\Models\User;
+use Yajra\DataTables\Tests\TestCase;
+
+class IgnoreGettersTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function it_returns_all_records_with_the_relation_when_called_without_parameters()
+    {
+        app('config')->set('datatables.ignore_getters', true);
+
+        $response = $this->call('GET', '/ignore-getters');
+        $response->assertJson([
+            'draw'            => 0,
+            'recordsTotal'    => 20,
+            'recordsFiltered' => 20,
+        ]);
+
+        $this->assertArrayHasKey('posts', $response->json()['data'][0]);
+        $this->assertCount(20, $response->json()['data']);
+    }
+
+    /** @test */
+    function it_return_the_getter_value_without_ignore_getters_config()
+    {
+        $response = $this->call('GET', '/ignore-getters');
+        $response->assertJson([
+            'draw'            => 0,
+            'recordsTotal'    => 20,
+            'recordsFiltered' => 20,
+        ]);
+        $this->assertNotNull($response->json()['data'][0]['color']);
+        $this->assertCount(20, $response->json()['data']);
+    }
+
+     /** @test */
+    function it_ignore_the_getter_value_with_ignore_getters_config()
+    {
+        app('config')->set('datatables.ignore_getters', true);
+
+        $response = $this->call('GET', '/ignore-getters');
+        $response->assertJson([
+            'draw'            => 0,
+            'recordsTotal'    => 20,
+            'recordsFiltered' => 20,
+        ]);
+        $this->assertNull($response->json()['data'][0]['color']);
+        $this->assertCount(20, $response->json()['data']);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app['router']->get('/ignore-getters', function (DataTables $datatables) {
+            return $datatables->eloquent(User::with('posts')->select('users.*'))->toJson();
+        });
+    }
+}

--- a/tests/Integration/IgnoreGettersTest.php
+++ b/tests/Integration/IgnoreGettersTest.php
@@ -12,7 +12,7 @@ class IgnoreGettersTest extends TestCase
     use DatabaseTransactions;
 
     /** @test */
-    function it_return_the_default_value_when_attribute_is_null()
+    public function it_return_the_default_value_when_attribute_is_null()
     {
         $user = User::create([
                 'name'  => 'foo',

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -2,7 +2,6 @@
 
 namespace Yajra\DataTables\Tests\Models;
 
-use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 
 class User extends Model

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace Yajra\DataTables\Tests\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 
 class User extends Model
@@ -26,5 +27,10 @@ class User extends Model
     public function user()
     {
         return $this->morphTo();
+    }
+
+    public function getColorAttribute()
+    {
+        return $this->color ?? '#000000';
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -29,6 +29,7 @@ abstract class TestCase extends BaseTestCase
                 $table->increments('id');
                 $table->string('name');
                 $table->string('email');
+                $table->string('color')->nullable();
                 $table->string('user_type')->nullable();
                 $table->unsignedInteger('user_id')->nullable();
                 $table->timestamps();


### PR DESCRIPTION
The issue was when a model have a getter overwriting an existing attribute in the database (See the new User Migration and User Model)

we have now a "color" column and a getColorAttribute() which override the value if null.

For simplicity, in the test, there is no real issue with it, but if you have this type of getter (poor code quality, but it is for the sake of the example): 

```php
public function getColorAttribute(){
	return $this->posts->count() ? '#000000' : '#ff0000'
}
```

with this query : 

```php
User::select('users.*')
```

This would result in a n+1 as every User row will call this getter and make a query to the posts table for each row

Facing this issue, you have multiple solution : 

Eager loading your posts (even if not needing it): 

```php
User::with('posts')->select('users.*')

//	If you want to create a Table of post your query would have to be like : 

Post::with('user.posts')->select('posts.*')
```

Not selecting the problematics columns : 

```php
User::select('users.id', 'users.name', 'users.email')
```

So, I propose to add a key in the config `ignore_getters` false, by default to keep the actual behavior
