### PR TITLE
feat: convert prepareQuery from protected to public

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -129,7 +129,7 @@ class QueryDataTable extends DataTableAbstract
      *
      * @return $this
      */
-    protected function prepareQuery(): static
+    public function prepareQuery(): static
     {
         if (! $this->prepared) {
             $this->totalRecords = $this->totalCount();


### PR DESCRIPTION
This is a very important update for advanced customizations.

I currently have a `footer` method on some of my datatables which allows me to query the datatable and sum up the rows via PHP.


```php
public function footer(): array
{
    request()->offsetUnset('order');

    $results = $this->ajaxBase()
        // if filtering is needed
        // ->filter($this->getFilter(), true)
        ->skipPaging()
        ->prepareQuery()
        ->results();

    $footer = [
        'footer_col_1' => 0,
        'footer_col_2' => 0,
    ];

    foreach ($results as $result) {
        $footer['footer_col_1'] += $result->col_1;
        $footer['footer_col_2'] += $result->col_2;
    }

    return $footer;
}
```
