### PR TITLE
feat: Ability to pass static data to a blade render

### DIFF
--- a/src/Utilities/Helper.php
+++ b/src/Utilities/Helper.php
@@ -109,6 +109,13 @@ class Helper
 
             return $content($param);
         }
+        
+
+        if (is_array($content)) {
+            [$view, $viewData] = $content;
+
+            return static::compileBlade($view, static::getMixedValue($data, $param)  + $viewData);
+        }
 
         return $content;
     }


### PR DESCRIPTION
Usage:

```php
$builder->editColumn('permissions_display', [
    'admin.roles.data-table.permissions-display', ['groupedPermissions' => $groupedPermissions],
]);
```

I couldn't decide if I should make it an associative array or not, but this seems simple enough. If the `$content` is an array get the split it and add the second value to its view data.

Extremely straightforward code for mini extra function.

```php
if (is_array($content)) {
    [$view, $viewData] = $content;

    return static::compileBlade($view, static::getMixedValue($data, $param)  + $viewData);
}
```
