### PR TITLE
feat: allow closure on formatColumn

### DIFF
--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -173,7 +173,7 @@ abstract class DataTableAbstract implements DataTable
 
     /**
      * @param  string|array  $columns
-     * @param  string|\Yajra\DataTables\Contracts\Formatter  $formatter
+     * @param  string|callable|\Yajra\DataTables\Contracts\Formatter  $formatter
      * @return $this
      */
     public function formatColumn($columns, $formatter): static

--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -10,7 +10,6 @@ use Illuminate\Support\Traits\Macroable;
 use Psr\Log\LoggerInterface;
 use Yajra\DataTables\Contracts\DataTable;
 use Yajra\DataTables\Contracts\Formatter;
-use Yajra\DataTables\Exceptions\Exception;
 use Yajra\DataTables\Processors\DataProcessor;
 use Yajra\DataTables\Utilities\Helper;
 

--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -176,8 +176,6 @@ abstract class DataTableAbstract implements DataTable
      * @param  string|array  $columns
      * @param  string|\Yajra\DataTables\Contracts\Formatter  $formatter
      * @return $this
-     *
-     * @throws \Yajra\DataTables\Exceptions\Exception
      */
     public function formatColumn($columns, $formatter): static
     {
@@ -193,7 +191,29 @@ abstract class DataTableAbstract implements DataTable
             return $this;
         }
 
-        throw new Exception('$formatter must be an instance of '.Formatter::class);
+        if (is_callable($formatter)) {
+            foreach ((array) $columns as $column) {
+                $this->addColumn(
+                    $column.'_formatted',
+                    function ($row) use ($column, $formatter) {
+                        return $formatter(data_get($row, $column), $row);
+                    }
+                );
+            }
+
+            return $this;
+        }
+
+        foreach ((array) $columns as $column) {
+            $this->addColumn(
+                $column.'_formatted',
+                function ($row) use ($column) {
+                    return data_get($row, $column);
+                }
+            );
+        }
+
+        return $this;
     }
 
     /**

--- a/tests/Integration/EloquentDataTableTest.php
+++ b/tests/Integration/EloquentDataTableTest.php
@@ -192,6 +192,7 @@ class EloquentDataTableTest extends TestCase
                              ->formatColumn('created_at', new DateFormatter('Y-m-d'))
                              ->toJson();
         });
+
         $router->get('/eloquent/formatColumn-closure', function (DataTables $dataTable) {
             return $dataTable->eloquent(User::query())
                              ->formatColumn('created_at', fn ($value, $row) => Carbon::parse($value)->format('Y-m-d'))

--- a/tests/Integration/EloquentDataTableTest.php
+++ b/tests/Integration/EloquentDataTableTest.php
@@ -142,6 +142,26 @@ class EloquentDataTableTest extends TestCase
     }
 
     /** @test */
+    public function it_can_return_formatted_column_on_invalid_formatter()
+    {
+        $crawler = $this->call('GET', '/eloquent/formatColumn-fallback');
+
+        $crawler->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 20,
+            'recordsFiltered' => 20,
+        ]);
+
+        $user = User::find(1);
+        $data = $crawler->json('data')[0];
+
+        $this->assertTrue(isset($data['created_at']));
+        $this->assertTrue(isset($data['created_at_formatted']));
+
+        $this->assertEquals($user->created_at, $data['created_at_formatted']);
+    }
+
+    /** @test */
     public function it_accepts_a_relation()
     {
         $user = User::first();
@@ -175,6 +195,12 @@ class EloquentDataTableTest extends TestCase
         $router->get('/eloquent/formatColumn-closure', function (DataTables $dataTable) {
             return $dataTable->eloquent(User::query())
                              ->formatColumn('created_at', fn($value, $row) => Carbon::parse($value)->format('Y-m-d'))
+                             ->toJson();
+        });
+
+        $router->get('/eloquent/formatColumn-fallback', function (DataTables $dataTable) {
+            return $dataTable->eloquent(User::query())
+                             ->formatColumn('created_at', 'InvalidFormatter::class')
                              ->toJson();
         });
     }

--- a/tests/Integration/EloquentDataTableTest.php
+++ b/tests/Integration/EloquentDataTableTest.php
@@ -122,6 +122,26 @@ class EloquentDataTableTest extends TestCase
     }
 
     /** @test */
+    public function it_can_return_formatted_column_using_closure()
+    {
+        $crawler = $this->call('GET', '/eloquent/formatColumn-closure');
+
+        $crawler->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 20,
+            'recordsFiltered' => 20,
+        ]);
+
+        $user = User::find(1);
+        $data = $crawler->json('data')[0];
+
+        $this->assertTrue(isset($data['created_at']));
+        $this->assertTrue(isset($data['created_at_formatted']));
+
+        $this->assertEquals(Carbon::parse($user->created_at)->format('Y-m-d'), $data['created_at_formatted']);
+    }
+
+    /** @test */
     public function it_accepts_a_relation()
     {
         $user = User::first();
@@ -150,6 +170,11 @@ class EloquentDataTableTest extends TestCase
         $router->get('/eloquent/formatColumn', function (DataTables $dataTable) {
             return $dataTable->eloquent(User::query())
                              ->formatColumn('created_at', new DateFormatter('Y-m-d'))
+                             ->toJson();
+        });
+        $router->get('/eloquent/formatColumn-closure', function (DataTables $dataTable) {
+            return $dataTable->eloquent(User::query())
+                             ->formatColumn('created_at', fn($value, $row) => Carbon::parse($value)->format('Y-m-d'))
                              ->toJson();
         });
     }


### PR DESCRIPTION
The PR will allow formatColumn to use a closure. The exception was also removed and will fall back to the original column value instead.

## Usage

```php
->formatColumn('created_at', fn($value, $row) => Carbon::parse($value)->format('m/d/Y'))
```