### PR TITLE
fix: Prevent error when PHP extension iconv not enabled.

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -943,6 +943,7 @@ class QueryDataTable extends DataTableAbstract
      * @param  string  $model
      * @param  int  $max_hits
      * @return $this
+     *
      * @throws \Exception
      */
     public function enableScoutSearch(string $model, int $max_hits = 1000): static
@@ -1083,6 +1084,7 @@ class QueryDataTable extends DataTableAbstract
      * @param  string  $searchKeyword
      * @param  mixed  $searchFilters
      * @return array
+     *
      * @throws \Exception
      */
     protected function performScoutSearch(string $searchKeyword, mixed $searchFilters = []): array

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -863,7 +863,7 @@ class QueryDataTable extends DataTableAbstract
     {
         $query_log = $this->getConnection()->getQueryLog();
         array_walk_recursive($query_log, function (&$item) {
-            if (is_string($item)) {
+            if (is_string($item) && extension_loaded('iconv')) {
                 $item = iconv('iso-8859-1', 'utf-8', $item);
             }
         });
@@ -943,7 +943,6 @@ class QueryDataTable extends DataTableAbstract
      * @param  string  $model
      * @param  int  $max_hits
      * @return $this
-     *
      * @throws \Exception
      */
     public function enableScoutSearch(string $model, int $max_hits = 1000): static
@@ -1084,7 +1083,6 @@ class QueryDataTable extends DataTableAbstract
      * @param  string  $searchKeyword
      * @param  mixed  $searchFilters
      * @return array
-     *
      * @throws \Exception
      */
     protected function performScoutSearch(string $searchKeyword, mixed $searchFilters = []): array


### PR DESCRIPTION
This PR will fix error when PHP extension `iconv` not enabled, so we can't use function `iconv()`.

```
Call to undefined function Yajra\DataTables\iconv()
 {"userId":1,"exception":"[object] (Error(code: 0): Call to undefined function Yajra\\DataTables\\iconv() 
at .../vendor/yajra/laravel-datatables-oracle/src/QueryDataTable.php:867)
```
