### PR TITLE
fix: scout search with smart search

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -854,6 +854,23 @@ class QueryDataTable extends DataTableAbstract
     }
 
     /**
+     * Perform multi-term search by splitting keyword into
+     * individual words and searches for each of them.
+     *
+     * @param  string  $keyword
+     * @return void
+     */
+    protected function smartGlobalSearch($keyword): void
+    {
+        // Try scout search first & fall back to default search if disabled/failed
+        if ($this->applyScoutSearch($keyword)) {
+            return;
+        }
+
+        parent::smartGlobalSearch($keyword);
+    }
+
+    /**
      * Append debug parameters on output.
      *
      * @param  array  $output


### PR DESCRIPTION
Hi !

Here is a optimization for scout search (if smart search is enabled).

Old: keyword is exploded using spaces into multiple keywords and then each keyword gets scout-searched
New: whole keyword gets scout-searched (without exploding), the search engine deals with multiple words