### PR TITLE
remove sorting from prepareCountQuery func.

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -171,7 +171,7 @@ class QueryDataTable extends DataTableAbstract
     public function prepareCountQuery(): QueryBuilder
     {
         $builder = clone $this->query;
-
+        $builder->reorder(); // remove all sorting from query, because here it's useless and take time.
         if ($this->isComplexQuery($builder)) {
             $builder->select(DB::raw('1 as dt_row_count'));
             if ($this->ignoreSelectInCountQuery || ! $this->isComplexQuery($builder)) {

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -172,8 +172,9 @@ class QueryDataTable extends DataTableAbstract
     {
         $builder = clone $this->query;
         $builder->reorder(); // remove all sorting from query, because here it's useless and take time.
+        $row_count = $this->wrap('row_count');
         if ($this->isComplexQuery($builder)) {
-            $builder->select(DB::raw('1 as dt_row_count'));
+            $builder->select(DB::raw("1 as {$row_count}"));
             if ($this->ignoreSelectInCountQuery || ! $this->isComplexQuery($builder)) {
                 return $this->getConnection()
                     ->query()
@@ -189,7 +190,6 @@ class QueryDataTable extends DataTableAbstract
                 ->setBindings($builder->getBindings());
         }
 
-        $row_count = $this->wrap('row_count');
         $builder->select($this->getConnection()->raw("'1' as {$row_count}"));
         if (! $this->keepSelectBindings) {
             $builder->setBindings([], 'select');

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -172,7 +172,7 @@ class QueryDataTable extends DataTableAbstract
     {
         $builder = clone $this->query;
         $builder->reorder(); // remove all sorting from query, because here it's useless and take time.
-        $row_count = $this->wrap('row_count');
+        $row_count = 'row_count';
         if ($this->isComplexQuery($builder)) {
             $builder->select(DB::raw("1 as {$row_count}"));
             if ($this->ignoreSelectInCountQuery || ! $this->isComplexQuery($builder)) {


### PR DESCRIPTION
remove all sorting from query, because here it's useless and take time.

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->

YES
