### PR TITLE
fix: mariadb support for scout search

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -926,6 +926,7 @@ class QueryDataTable extends DataTableAbstract
             ->map(fn ($value) => $connection->escape($value));
 
         switch ($driverName) {
+            case 'mariadb':
             case 'mysql':
                 $this->query->orderByRaw("FIELD($keyName, ".$orderedKeys->implode(',').')');
 


### PR DESCRIPTION
Laravel 11 introduced a mariadb database driver. We can use the same code as for mysql.