### PR TITLE
fix: ErrorException when direction is null

### DIFF
--- a/src/Utilities/Request.php
+++ b/src/Utilities/Request.php
@@ -86,7 +86,7 @@ class Request
             /** @var string $direction */
             $direction = $this->request->input("order.$i.dir");
 
-            $order_dir = strtolower($direction) === 'asc' ? 'asc' : 'desc';
+            $order_dir = $direction && strtolower($direction) === 'asc' ? 'asc' : 'desc';
             if ($this->isColumnOrderable($order_col)) {
                 $orderable[] = ['column' => $order_col, 'direction' => $order_dir];
             }


### PR DESCRIPTION
In most cases, the `dir` attribute is empty (null) which causes a notice error in the recent PHP version.

> ErrorException: strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/vendor/yajra/laravel-datatables-oracle/src/Utilities/Request.php:101