### PR TITLE
fix: make query for filteredRecords when totalRecords was manually set

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -26,6 +26,11 @@ class QueryDataTable extends DataTableAbstract
     protected bool $prepared = false;
 
     /**
+     * Flag to check if the total records count query has been performed.
+     */
+    protected bool $performedTotalRecordsCount = false;
+
+    /**
      * Query callback for custom pagination using limit without offset.
      *
      * @var callable|null
@@ -158,6 +163,20 @@ class QueryDataTable extends DataTableAbstract
     }
 
     /**
+     * Count total items.
+     */
+    public function totalCount(): int
+    {
+        if ($this->totalRecords !== null) {
+            return $this->totalRecords;
+        }
+
+        $this->performedTotalRecordsCount = true;
+
+        return $this->totalRecords = $this->count();
+    }
+
+    /**
      * Counts current query.
      */
     public function count(): int
@@ -253,7 +272,7 @@ class QueryDataTable extends DataTableAbstract
 
         // If no modification between the original query and the filtered one has been made
         // the filteredRecords equals the totalRecords
-        if ($this->query == $initialQuery) {
+        if ($this->query == $initialQuery && $this->performedTotalRecordsCount) {
             $this->filteredRecords ??= $this->totalRecords;
         } else {
             $this->filteredCount();

--- a/tests/Integration/QueryDataTableTest.php
+++ b/tests/Integration/QueryDataTableTest.php
@@ -26,7 +26,7 @@ class QueryDataTableTest extends TestCase
         $crawler->assertJson([
             'draw' => 0,
             'recordsTotal' => 10,
-            'recordsFiltered' => 10,
+            'recordsFiltered' => 20,
         ]);
     }
 
@@ -37,7 +37,7 @@ class QueryDataTableTest extends TestCase
         $crawler->assertJson([
             'draw' => 0,
             'recordsTotal' => 0,
-            'recordsFiltered' => 0,
+            'recordsFiltered' => 20,
         ]);
     }
 

--- a/tests/Integration/QueryDataTableTest.php
+++ b/tests/Integration/QueryDataTableTest.php
@@ -55,12 +55,19 @@ class QueryDataTableTest extends TestCase
     #[Test]
     public function it_returns_all_records_when_no_parameters_is_passed()
     {
+        DB::enableQueryLog();
+
         $crawler = $this->call('GET', '/query/users');
         $crawler->assertJson([
             'draw' => 0,
             'recordsTotal' => 20,
             'recordsFiltered' => 20,
         ]);
+
+        DB::disableQueryLog();
+        $queryLog = DB::getQueryLog();
+
+        $this->assertCount(2, $queryLog);
     }
 
     #[Test]


### PR DESCRIPTION
Hi, we always use `setTotalRecords(0)` since we only show the filtered records count. After upgrading to Laravel 11 we noticed that our pagination stopped working. This seems to be caused by c37494f11f0b6e198fa7428edd38e5d5b2a6d9de. This PR changes the logic to always query the filtered count if the total count was set manually.

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
