### PR TITLE
Prevent unwanted count query

### DIFF
--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -524,7 +524,6 @@ abstract class DataTableAbstract implements DataTable
     public function setTotalRecords(int $total): static
     {
         $this->totalRecords = $total;
-        $this->performedTotalRecordsCount = true;
 
         return $this;
     }

--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -524,6 +524,7 @@ abstract class DataTableAbstract implements DataTable
     public function setTotalRecords(int $total): static
     {
         $this->totalRecords = $total;
+        $this->performedTotalRecordsCount = true;
 
         return $this;
     }

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -161,6 +161,19 @@ class QueryDataTable extends DataTableAbstract
 
         return $this;
     }
+    
+    /**
+     * Set total records manually.
+     *
+     * @return $this
+     */
+    public function setTotalRecords(int $total): static
+    {
+        parent::setTotalRecords($total);
+        $this->performedTotalRecordsCount = true;
+
+        return $this;
+    }
 
     /**
      * Count total items.

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -161,7 +161,7 @@ class QueryDataTable extends DataTableAbstract
 
         return $this;
     }
-    
+
     /**
      * Set total records manually.
      *

--- a/tests/Integration/QueryDataTableTest.php
+++ b/tests/Integration/QueryDataTableTest.php
@@ -26,7 +26,7 @@ class QueryDataTableTest extends TestCase
         $crawler->assertJson([
             'draw' => 0,
             'recordsTotal' => 10,
-            'recordsFiltered' => 20,
+            'recordsFiltered' => 10,
         ]);
     }
 
@@ -37,7 +37,7 @@ class QueryDataTableTest extends TestCase
         $crawler->assertJson([
             'draw' => 0,
             'recordsTotal' => 0,
-            'recordsFiltered' => 20,
+            'recordsFiltered' => 0,
         ]);
     }
 


### PR DESCRIPTION
The only reason we're using `setTotalRecords` is to prevent the count query.

Even though we're seting the `totalRecords` we also need to set `performedTotalRecordsCount` so that;

IF -> there are filters applied to the query (any kind of search)
    THEN -> don't perform total count **AGAIN**

There was an update about this topic recently: https://github.com/yajra/laravel-datatables/commit/9f7169a1cea51ff22cf4154c5c0e6da35d19c558

Sadly it didn't cover all the cases.

Here is the related code in [QueryDataTable#L275](https://github.com/yajra/laravel-datatables/blob/9f7169a1cea51ff22cf4154c5c0e6da35d19c558/src/QueryDataTable.php#L275)

```php
// If no modification between the original query and the filtered one has been made
// the filteredRecords equals the totalRecords
if ($this->query == $initialQuery && $this->performedTotalRecordsCount) {
    $this->filteredRecords ??= $this->totalRecords;
} else {
    $this->filteredCount();
}
```