### PR TITLE
Add skip total records back

### DIFF
--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -69,6 +69,11 @@ abstract class DataTableAbstract implements DataTable
     protected ?int $filteredRecords = null;
 
     /**
+     * Flag to check if the total records count should be skipped.
+     */
+    protected bool $skipTotalRecords = false;
+
+    /**
      * Auto-filter flag.
      */
     protected bool $autoFilter = true;
@@ -533,12 +538,11 @@ abstract class DataTableAbstract implements DataTable
      * This will improve the performance by skipping the total count query.
      *
      * @return $this
-     *
-     * @deprecated Just use setTotalRecords instead.
      */
     public function skipTotalRecords(): static
     {
         $this->totalRecords = 0;
+        $this->skipTotalRecords = true;
 
         return $this;
     }

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -26,11 +26,6 @@ class QueryDataTable extends DataTableAbstract
     protected bool $prepared = false;
 
     /**
-     * Flag to check if the total records count query has been performed.
-     */
-    protected bool $performedTotalRecordsCount = false;
-
-    /**
      * Query callback for custom pagination using limit without offset.
      *
      * @var callable|null
@@ -163,20 +158,6 @@ class QueryDataTable extends DataTableAbstract
     }
 
     /**
-     * Count total items.
-     */
-    public function totalCount(): int
-    {
-        if ($this->totalRecords !== null) {
-            return $this->totalRecords;
-        }
-
-        $this->performedTotalRecordsCount = true;
-
-        return $this->totalRecords = $this->count();
-    }
-
-    /**
      * Counts current query.
      */
     public function count(): int
@@ -272,7 +253,7 @@ class QueryDataTable extends DataTableAbstract
 
         // If no modification between the original query and the filtered one has been made
         // the filteredRecords equals the totalRecords
-        if ($this->query == $initialQuery && $this->performedTotalRecordsCount) {
+        if (! $this->skipTotalRecords && $this->query == $initialQuery) {
             $this->filteredRecords ??= $this->totalRecords;
         } else {
             $this->filteredCount();

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -257,6 +257,10 @@ class QueryDataTable extends DataTableAbstract
             $this->filteredRecords ??= $this->totalRecords;
         } else {
             $this->filteredCount();
+
+            if ($this->skipTotalRecords) {
+                $this->totalRecords = $this->filteredRecords;
+            }
         }
     }
 

--- a/tests/Integration/QueryDataTableTest.php
+++ b/tests/Integration/QueryDataTableTest.php
@@ -26,7 +26,7 @@ class QueryDataTableTest extends TestCase
         $crawler->assertJson([
             'draw' => 0,
             'recordsTotal' => 10,
-            'recordsFiltered' => 20,
+            'recordsFiltered' => 10,
         ]);
     }
 
@@ -37,8 +37,26 @@ class QueryDataTableTest extends TestCase
         $crawler->assertJson([
             'draw' => 0,
             'recordsTotal' => 0,
+            'recordsFiltered' => 0,
+        ]);
+    }
+
+    #[Test]
+    public function it_can_set_skip_total_records()
+    {
+        DB::enableQueryLog();
+
+        $crawler = $this->call('GET', '/skip-total-records');
+        $crawler->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 0,
             'recordsFiltered' => 20,
         ]);
+
+        DB::disableQueryLog();
+        $queryLog = DB::getQueryLog();
+
+        $this->assertCount(2, $queryLog);
     }
 
     #[Test]
@@ -461,6 +479,10 @@ class QueryDataTableTest extends TestCase
 
         $router->get('/zero-total-records', fn (DataTables $dataTable) => $dataTable->query(DB::table('users'))
             ->setTotalRecords(0)
+            ->toJson());
+
+        $router->get('/skip-total-records', fn (DataTables $dataTable) => $dataTable->query(DB::table('users'))
+            ->skipTotalRecords()
             ->toJson());
 
         $router->get('/set-filtered-records', fn (DataTables $dataTable) => $dataTable->query(DB::table('users'))

--- a/tests/Integration/QueryDataTableTest.php
+++ b/tests/Integration/QueryDataTableTest.php
@@ -42,24 +42,6 @@ class QueryDataTableTest extends TestCase
     }
 
     #[Test]
-    public function it_can_set_skip_total_records()
-    {
-        DB::enableQueryLog();
-
-        $crawler = $this->call('GET', '/skip-total-records');
-        $crawler->assertJson([
-            'draw' => 0,
-            'recordsTotal' => 0,
-            'recordsFiltered' => 20,
-        ]);
-
-        DB::disableQueryLog();
-        $queryLog = DB::getQueryLog();
-
-        $this->assertCount(2, $queryLog);
-    }
-
-    #[Test]
     public function it_can_set_total_filtered_records()
     {
         $crawler = $this->call('GET', '/set-filtered-records');
@@ -109,7 +91,27 @@ class QueryDataTableTest extends TestCase
     #[Test]
     public function it_can_skip_total_records_count_query()
     {
-        $crawler = $this->call('GET', '/query/simple', [
+        DB::enableQueryLog();
+
+        $crawler = $this->call('GET', '/skip-total-records');
+        $crawler->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 20,
+            'recordsFiltered' => 20,
+        ]);
+
+        DB::disableQueryLog();
+        $queryLog = DB::getQueryLog();
+
+        $this->assertCount(2, $queryLog);
+    }
+
+    #[Test]
+    public function it_can_skip_total_records_count_query_with_filter_applied()
+    {
+        DB::enableQueryLog();
+
+        $crawler = $this->call('GET', '/skip-total-records', [
             'columns' => [
                 ['data' => 'name', 'name' => 'name', 'searchable' => 'true', 'orderable' => 'true'],
                 ['data' => 'email', 'name' => 'email', 'searchable' => 'true', 'orderable' => 'true'],
@@ -119,9 +121,14 @@ class QueryDataTableTest extends TestCase
 
         $crawler->assertJson([
             'draw' => 0,
-            'recordsTotal' => 0,
+            'recordsTotal' => 1,
             'recordsFiltered' => 1,
         ]);
+
+        DB::disableQueryLog();
+        $queryLog = DB::getQueryLog();
+
+        $this->assertCount(2, $queryLog);
     }
 
     #[Test]
@@ -410,8 +417,6 @@ class QueryDataTableTest extends TestCase
         $router->get('/query/formatColumn', fn (DataTables $dataTable) => $dataTable->query(DB::table('users'))
             ->formatColumn('created_at', new DateFormatter('Y-m-d'))
             ->toJson());
-
-        $router->get('/query/simple', fn (DataTables $dataTable) => $dataTable->query(DB::table('users'))->skipTotalRecords()->toJson());
 
         $router->get('/query/addColumn', fn (DataTables $dataTable) => $dataTable->query(DB::table('users'))
             ->addColumn('foo', 'bar')


### PR DESCRIPTION
<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->

This PR undoes the deprecation of `skipTotalRecords` and restores the working of `setTotalRecords(0)` back to how it was in [v10.4.3](https://github.com/yajra/laravel-datatables/releases/tag/v10.4.3).

Alternative to #3169.
Partially reverts #3157.