### PR TITLE
Set maximum records limit per-page in config.

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -569,7 +569,7 @@ class QueryDataTable extends DataTableAbstract
         $start = $this->request->start();
         $length = $this->request->length();
 
-        $limit = $length > 0 ? $length : 10;
+        $limit = $length > 0 ? min($length, $this->config->maxLimit()) : 10;
 
         if (is_callable($this->limitCallback)) {
             $this->query->limit($limit);

--- a/src/Utilities/Config.php
+++ b/src/Utilities/Config.php
@@ -93,4 +93,14 @@ class Config
     {
         return (array) $this->repository->get('datatables.json.header', []);
     }
+
+    /**
+     * Get the maximum record limit for one page.
+     *
+     * @return int The maximum limit value.
+     */
+    public function maxLimit(): int
+    {
+        return (int) $this->repository->get('datatables.max_limit', 100);
+    }
 }

--- a/src/config/datatables.php
+++ b/src/config/datatables.php
@@ -124,4 +124,10 @@ return [
      * Callbacks needs to start by those terms, or they will be cast to string.
      */
     'callback' => ['$', '$.', 'function'],
+
+    /*
+     * Maximum record limit per-page. To prevent user from arbitrarily request large record set.
+     * If 'limit' query parameter in the request exceed this limit, it will be automatically set to this value.
+     */
+    'max_limit' => 100,
 ];


### PR DESCRIPTION
This PR adds a `max_limit` configuration to prevent end-users from arbitrarily setting a large value for the `length` request parameter, which could otherwise cause the server to overload if not handled manually (e.g., in middleware).

If the `length` value exceeds this limit, it will be overridden with the specified `max_limit`. 

The default value is 100.
<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
