### PR TITLE
fix: prevent ambiguous column names

### DIFF
--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -167,7 +167,7 @@ class EloquentDataTable extends QueryDataTable
         $relation = str_replace('[]', '', implode('.', $parts));
 
         if ($this->isNotEagerLoaded($relation)) {
-            return $column;
+            return parent::resolveRelationColumn($column);
         }
 
         return $this->joinEagerLoadedColumn($relation, $columnName);
@@ -188,14 +188,14 @@ class EloquentDataTable extends QueryDataTable
         $lastQuery = $this->query;
         foreach (explode('.', $relation) as $eachRelation) {
             $model = $lastQuery->getRelation($eachRelation);
-            $lastAlias = $tableAlias ?: $lastQuery->getModel()->getTable();
+            $lastAlias = $tableAlias ?: $this->getTablePrefix($lastQuery);
             $tableAlias = $tableAlias.'_'.$eachRelation;
             $pivotAlias = $tableAlias.'_pivot';
             switch (true) {
                 case $model instanceof BelongsToMany:
                     $pivot = $model->getTable().' as '.$pivotAlias;
                     $pivotPK = $pivotAlias.'.'.$model->getForeignPivotKeyName();
-                    $pivotFK = $lastAlias.'.'.$model->getParentKeyName();
+                    $pivotFK = ltrim($lastAlias.'.'.$model->getParentKeyName(), '.');
                     $this->performJoin($pivot, $pivotPK, $pivotFK);
 
                     $related = $model->getRelated();
@@ -211,7 +211,7 @@ class EloquentDataTable extends QueryDataTable
                 case $model instanceof HasOneThrough:
                     $pivot = explode('.', $model->getQualifiedParentKeyName())[0].' as '.$pivotAlias; // extract pivot table from key
                     $pivotPK = $pivotAlias.'.'.$model->getFirstKeyName();
-                    $pivotFK = $lastAlias.'.'.$model->getLocalKeyName();
+                    $pivotFK = ltrim($lastAlias.'.'.$model->getLocalKeyName(), '.');
                     $this->performJoin($pivot, $pivotPK, $pivotFK);
 
                     $related = $model->getRelated();
@@ -227,12 +227,12 @@ class EloquentDataTable extends QueryDataTable
                 case $model instanceof HasOneOrMany:
                     $table = $model->getRelated()->getTable().' as '.$tableAlias;
                     $foreign = $tableAlias.'.'.$model->getForeignKeyName();
-                    $other = $lastAlias.'.'.$model->getLocalKeyName();
+                    $other = ltrim($lastAlias.'.'.$model->getLocalKeyName(), '.');
                     break;
 
                 case $model instanceof BelongsTo:
                     $table = $model->getRelated()->getTable().' as '.$tableAlias;
-                    $foreign = $lastAlias.'.'.$model->getForeignKeyName();
+                    $foreign = ltrim($lastAlias.'.'.$model->getForeignKeyName(), '.');
                     $other = $tableAlias.'.'.$model->getOwnerKeyName();
                     break;
 


### PR DESCRIPTION
When using complex queries with joins, I am often facing ambiguous column name errors when sorting a column of the base table sharing the same name as a column of a relation table field (eg: created_at)

Until now, the workaround I used was to rename my columns
``` php
// From
DateColumn::make('created_at')`
// To
DateColumn::make('created_at', 'table.created_at')
```
But it's probably better to fix the root cause by forcing the table name if the column is not a relation.

And it's consistent with `$this->joinEagerLoadedColumn()` which is returning columns name with alias.