### PR TITLE
feat: Public visibility for `resolveRelationColumn` method

### DIFF
--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -155,12 +155,11 @@ class EloquentDataTable extends QueryDataTable
     }
 
     /**
-     * Resolve the proper column name be used.
-     *
+     * {@inheritDoc}
      *
      * @throws \Yajra\DataTables\Exceptions\Exception
      */
-    protected function resolveRelationColumn(string $column): string
+    public function resolveRelationColumn(string $column): string
     {
         $parts = explode('.', $column);
         $columnName = array_pop($parts);

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -384,9 +384,9 @@ class QueryDataTable extends DataTableAbstract
     }
 
     /**
-     * Resolve the proper column name be used.
+     * Resolve the proper column name to be used.
      */
-    protected function resolveRelationColumn(string $column): string
+    public function resolveRelationColumn(string $column): string
     {
         return $column;
     }


### PR DESCRIPTION
Alternative to https://github.com/yajra/laravel-datatables/pull/3229

Not sure which implementation is better, I will let you choose what you prefer.

I would like to suggest to make `resolveRelationColumn()` a public method so we can reuse it in our custom filters:

```php
$datatable = new EloquentDataTable($query);

$datatable
    ->filter(function ($query) use ($datatable) {
        // resolveRelationColumn automatically create joins if needed
        $column = $datatable->resolveRelationColumn('foo.bar');
        $query->where($column, 'xxx');
    })
    ->filterColumn('foo.bar', function ($query, $keyword) use ($datatable) {
        // resolveRelationColumn automatically create joins if needed
        $column = $datatable->resolveRelationColumn('foo.bar');
        $query->where($column, 'xxx');
    })
;
```