### PR TITLE
feat: add relation resolver param to filter callbacks

### DIFF
--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -155,8 +155,7 @@ class EloquentDataTable extends QueryDataTable
     }
 
     /**
-     * Resolve the proper column name be used.
-     *
+     * {@inheritDoc}
      *
      * @throws \Yajra\DataTables\Exceptions\Exception
      */

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -350,7 +350,7 @@ class QueryDataTable extends DataTableAbstract
             $builder = $this->query->newQuery();
         }
 
-        $callback($builder, $keyword);
+        $callback($builder, $keyword, fn ($column) => $this->resolveRelationColumn($column));
 
         /** @var \Illuminate\Database\Query\Builder $baseQueryBuilder */
         $baseQueryBuilder = $this->getBaseQueryBuilder($builder);
@@ -384,7 +384,7 @@ class QueryDataTable extends DataTableAbstract
     }
 
     /**
-     * Resolve the proper column name be used.
+     * Resolve the proper column name to be used.
      */
     protected function resolveRelationColumn(string $column): string
     {
@@ -646,7 +646,7 @@ class QueryDataTable extends DataTableAbstract
      */
     protected function resolveCallbackParameter(): array
     {
-        return [$this->query, $this->scoutSearched];
+        return [$this->query, $this->scoutSearched, fn ($column) => $this->resolveRelationColumn($column)];
     }
 
     /**


### PR DESCRIPTION
Alternative to https://github.com/yajra/laravel-datatables/pull/3228

Not sure which implementation is better, I will let you choose what you prefer.

I would like to suggest to add resolveRelationColumn() as new param to the filter callbacks:

```php
$datatable = new EloquentDataTable($query);

$datatable
    ->filter(function ($query, $scoutSearch, $resolver) {
        // $resolver automatically create joins if needed
        $query->where($resolver('foo.bar'), 'xxx');
    })
    ->filterColumn('foo.bar', function ($query, $keyword, $resolver) {
        // $resolver automatically create joins if needed
        $query->where($resolver('foo.bar'), 'xxx');
    })
;
```