### PR TITLE
feat: add relation resolver param to order callback

### DIFF
--- a/tests/Integration/CustomOrderTest.php
+++ b/tests/Integration/CustomOrderTest.php
@@ -54,8 +54,8 @@ class CustomOrderTest extends TestCase
         parent::setUp();
 
         $this->app['router']->get('/relations/belongsTo', fn (DataTables $datatables) => $datatables->eloquent(Post::with('user')->select('posts.*'))
-            ->orderColumn('user.id', function ($query, $order, $column) {
-                $query->orderBy($column, $order == 'desc' ? 'asc' : 'desc');
+            ->orderColumn('user.id', function ($query, $order, $resolver) {
+                $query->orderBy($resolver('user.id'), $order == 'desc' ? 'asc' : 'desc');
             })
             ->toJson());
     }


### PR DESCRIPTION
Same as https://github.com/yajra/laravel-datatables/pull/3229 but for `orderColumn()`

In https://github.com/yajra/laravel-datatables/pull/3216, I added the `$column` parameter to pass the current column alias to the order callback function, but this is not really helpful when we want to work on other columns as reported by @Arkhas.

So I decided to replace this param by the resolver in the same way as `filterColumn()`

```php
$datatable = new EloquentDataTable($query);

$datatable
    ->orderColumn('foo.bar', function ($query, $order, $resolver) {
        // $resolver automatically create joins if needed
        $query->orderBy($resolver('foo.bar'), $order);
        // or
        $query->orderBy(DB::raw("{$resolver('foo.amount')} * {$resolver('foo.quantity')}"), $order);
    })
;
```

