### PR TITLE
fix: prevent prefixing null/empty string

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -485,8 +485,12 @@ class QueryDataTable extends DataTableAbstract
             }
         }
 
+        if (! ($prefix = $this->getTablePrefix($query))) {
+            return $column;
+        }
+
         // Add table prefix to column
-        return $this->getTablePrefix($query).'.'.$column;
+        return $prefix.'.'.$column;
     }
 
     /**


### PR DESCRIPTION
This is a bug fix to this recently merged PR: https://github.com/yajra/laravel-datatables/pull/3227

QueryDataTable::getTablePrefix() returns string or null. It causes an issue to QueryDataTable::addTablePrefix() method where in it returns a column name with a null/empty prefix (.column_name) instead of (prefix.column_name).

I added a guard clause to check if the table prefix returned by QueryDataTable::getTablePrefix() is not null/empty string before prefixing it to the column.