### PR TITLE
fix: improve column alias detection

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -480,7 +480,8 @@ class QueryDataTable extends DataTableAbstract
         // Column is an alias, no prefix required
         foreach ($q->columns ?? [] as $select) {
             $sql = trim($select instanceof Expression ? $select->getValue($this->getConnection()->getQueryGrammar()) : $select);
-            if (str_ends_with($sql, ' as '.$column) || str_ends_with($sql, ' as '.$this->wrap($column))) {
+            $match = preg_quote($column).'\b|'.preg_quote($this->wrap($column));
+            if (preg_match("/(\s)as(\s+)($match)/i", $sql)) {
                 return $column;
             }
         }


### PR DESCRIPTION
Fixes https://github.com/yajra/laravel-datatables/issues/3235

This PR improves detection of column aliases.

Before, it could detect only if the alias has exactly 1 space between `as` and alias name.
Now it supports (I hope) all cases:
```php
DB::raw('table.column as   alias'); // multiple spaces
DB::raw('table.column as `alias`'); // escaped (wrapped) aliases
DB::raw('table.column as alias, table.column2 as alias2'); // multiple aliases in 1 definition
// multiple lines
DB::raw('table.column as  
alias');
```