### PR TITLE
feat: add min search length control

### DIFF
--- a/src/CollectionDataTable.php
+++ b/src/CollectionDataTable.php
@@ -143,6 +143,8 @@ class CollectionDataTable extends DataTableAbstract
     public function make(bool $mDataSupport = true): JsonResponse
     {
         try {
+            $this->validateMinLengthSearch();
+
             $this->totalRecords = $this->totalCount();
 
             if ($this->totalRecords) {

--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -122,6 +122,8 @@ abstract class DataTableAbstract implements DataTable
 
     protected bool $editOnlySelectedColumns = false;
 
+    protected int $minSearchLength = 0;
+
     /**
      * Can the DataTable engine be created with these parameters.
      *
@@ -989,4 +991,27 @@ abstract class DataTableAbstract implements DataTable
     {
         return 'id';
     }
+
+    public function minSearchLength(int $length): static
+    {
+        $this->minSearchLength = $length;
+
+        return $this;
+    }
+
+    protected function validateMinLengthSearch(): void
+    {
+        if ($this->request->isSearchable()
+            && $this->minSearchLength > 0
+            && Str::length($this->request->keyword()) < $this->minSearchLength
+        ) {
+            $this->totalRecords = 0;
+            $this->filteredRecords = 0;
+            throw new \Exception(
+                __('Please enter at least :length characters to search.', ['length' => $this->minSearchLength]),
+                400
+            );
+        }
+    }
+
 }

--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -1013,5 +1013,4 @@ abstract class DataTableAbstract implements DataTable
             );
         }
     }
-
 }

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -124,6 +124,8 @@ class QueryDataTable extends DataTableAbstract
     public function make(bool $mDataSupport = true): JsonResponse
     {
         try {
+            $this->validateMinLengthSearch();
+
             $results = $this->prepareQuery()->results();
             $processed = $this->processResults($results, $mDataSupport);
             $data = $this->transform($results, $processed);

--- a/tests/Integration/MinSearchLengthDataTableTest.php
+++ b/tests/Integration/MinSearchLengthDataTableTest.php
@@ -92,7 +92,7 @@ class MinSearchLengthDataTableTest extends TestCase
     {
         parent::setUp();
 
-        Route::get('/eloquent/min-length', fn() => (new EloquentDataTable(User::query()))
+        Route::get('/eloquent/min-length', fn () => (new EloquentDataTable(User::query()))
             ->minSearchLength(5)
             ->toJson());
     }

--- a/tests/Integration/MinSearchLengthDataTableTest.php
+++ b/tests/Integration/MinSearchLengthDataTableTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Yajra\DataTables\Tests\Integration;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\Test;
+use Yajra\DataTables\EloquentDataTable;
+use Yajra\DataTables\Tests\Models\User;
+use Yajra\DataTables\Tests\TestCase;
+
+class MinSearchLengthDataTableTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_returns_all_records_when_search_is_empty()
+    {
+        $crawler = $this->call('GET', '/eloquent/min-length', [
+            'start' => 0,
+            'length' => 10,
+            'columns' => [
+                ['data' => 'id'],
+                ['data' => 'name'],
+                ['data' => 'email'],
+            ],
+            'search' => [
+                'value' => '',
+                'regex' => false,
+            ],
+        ]);
+
+        $crawler->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 20,
+            'recordsFiltered' => 20,
+        ]);
+    }
+
+    #[Test]
+    public function it_returns_an_error_when_search_keyword_length_is_less_than_required()
+    {
+        $crawler = $this->call('GET', '/eloquent/min-length', [
+            'start' => 0,
+            'length' => 10,
+            'columns' => [
+                ['data' => 'id'],
+                ['data' => 'name'],
+                ['data' => 'email'],
+            ],
+            'search' => [
+                'value' => 'abc',
+                'regex' => false,
+            ],
+        ]);
+
+        $crawler->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 0,
+            'recordsFiltered' => 0,
+            'data' => [],
+            'error' => "Exception Message:\n\nPlease enter at least 5 characters to search.",
+        ]);
+    }
+
+    #[Test]
+    public function it_returns_filtered_records_when_search_keyword_length_is_met()
+    {
+        $crawler = $this->call('GET', '/eloquent/min-length', [
+            'draw' => 1,
+            'start' => 0,
+            'length' => 10,
+            'columns' => [
+                ['data' => 'id'],
+                ['data' => 'name'],
+                ['data' => 'email'],
+            ],
+            'search' => [
+                'value' => 'Record-17',
+                'regex' => false,
+            ],
+        ]);
+
+        $crawler->assertJson([
+            'draw' => 1,
+            'recordsTotal' => 20,
+            'recordsFiltered' => 1,
+        ]);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Route::get('/eloquent/min-length', fn() => (new EloquentDataTable(User::query()))
+            ->minSearchLength(5)
+            ->toJson());
+    }
+}


### PR DESCRIPTION
fix: #3241

## Usage

```php
    public function dataTable(QueryBuilder $query): EloquentDataTable
    {
        return (new EloquentDataTable($query))
            ->minSearchLength(5)
            ->setRowId('id');
    }
```

## Response

```json
{
    "draw": 2,
    "recordsTotal": 0,
    "recordsFiltered": 0,
    "data": [],
    "error": "Exception Message:\n\nPlease enter at least 5 characters to search."
}
```