### PR TITLE
fix: support for array notation

### DIFF
--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -169,7 +169,7 @@ class EloquentDataTable extends QueryDataTable
     {
         $parts = explode('.', $column);
         $columnName = array_pop($parts);
-        $relation = str_replace('[]', '', implode('.', $parts));
+        $relation = preg_replace('/\[.*?\]/', '', implode('.', $parts));
 
         if ($this->isNotEagerLoaded($relation)) {
             return parent::resolveRelationColumn($column);


### PR DESCRIPTION
See https://datatables.net/reference/option/columns.data#string

It's possible to specify the separator of array values inside the brackets: `name[, ]`

Before this patch, only `name[]` was working.