### PR TITLE
fix: remove @internal annotation from orderColumn() method

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -625,7 +625,7 @@ class QueryDataTable extends DataTableAbstract
      * @param  array  $bindings
      * @return $this
      *
-     * @internal string $1 Special variable that returns the requested order direction of the column.
+     * string $1 Special variable that returns the requested order direction of the column.
      */
     public function orderColumn($column, $sql, $bindings = []): static
     {


### PR DESCRIPTION
The orderColumn() method in QueryDataTable is documented and intended for public use (as shown in package docs), but was incorrectly marked as @internal. This caused static analyzers like PHPStan to report false positives when calling the method in userland code.

Removing the @internal annotation clarifies that orderColumn() is part of the public API.

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
