### PR TITLE
chore: improve datatables() helper docblock for better return type clarity

### DIFF
--- a/src/helper.php
+++ b/src/helper.php
@@ -6,7 +6,7 @@ if (! function_exists('datatables')) {
      * Or return the factory if source is not set.
      *
      * @param  \Illuminate\Contracts\Database\Query\Builder|\Illuminate\Contracts\Database\Eloquent\Builder|\Illuminate\Support\Collection|array|null  $source
-     * @return \Yajra\DataTables\DataTables|\Yajra\DataTables\DataTableAbstract
+     * @return ($source is null ? \Yajra\DataTables\DataTables : \Yajra\DataTables\DataTableAbstract)
      *
      * @throws \Yajra\DataTables\Exceptions\Exception
      */


### PR DESCRIPTION
### Summary
This PR improves the `datatables()` helper docblock by making the return type more explicit and IDE-friendly.

### Changes
- Updated the `@return` annotation to conditionally specify the type:
  - `\Yajra\DataTables\DataTables` when `$source` is `null`.
  - `\Yajra\DataTables\DataTableAbstract` when `$source` is provided.

### Why
- Enhances IDE autocompletion and static analysis.
- Provides clearer context for developers using the helper.
- No runtime or behavioral changes were made.


### Notes
This is a documentation-only update. No tests required.
