### PR TITLE
Replace unsafe eval() with Blade::render() in Helper::compileBlade

### DIFF
--- a/src/Utilities/Helper.php
+++ b/src/Utilities/Helper.php
@@ -6,6 +6,7 @@ use Closure;
 use DateTime;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Str;
 use ReflectionFunction;
 use ReflectionMethod;
@@ -124,12 +125,7 @@ class Helper
             return view($str, $data)->render();
         }
 
-        ob_start() && extract($data, EXTR_SKIP);
-        eval('?>'.app('blade.compiler')->compileString($str));
-        $str = ob_get_contents();
-        ob_end_clean();
-
-        return $str;
+        return Blade::render($str, $data);
     }
 
     /**


### PR DESCRIPTION
### Overview
This PR improves the `Helper::compileBlade` method by replacing the use of `eval()` with the safer and Laravel-native `Blade::render()` method.

### Changes
- Removed the `eval()` approach to compile Blade strings.
- Added `Blade::render($str, $data)` for string compilation.
- Maintains existing functionality while improving security and maintainability.

### Benefits
- ✅ Safer: Eliminates potential security risks from `eval()`.
- ✅ Cleaner: Uses Laravel's built-in Blade rendering.
- ✅ More maintainable and testable code.

### Notes
- No behavioral changes for existing functionality.
- Fully backward compatible.
