### PR TITLE
Fixes deprecated the get() Method according to what´s new since Symfony 7.4 - Request Class Improvements

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -809,7 +809,7 @@ class QueryDataTable extends DataTableAbstract
     protected function searchPanesSearch(): void
     {
         /** @var string[] $columns */
-        $columns = (array)$this->request->searchPanes;
+        $columns = (array) $this->request->searchPanes;
 
         foreach ($columns as $column => $values) {
             if ($this->isBlacklisted($column)) {


### PR DESCRIPTION
<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
