### PR TITLE
Fix collection global search for non-string values

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -34,7 +34,7 @@ jobs:
           coverage: none
 
       - name: Setup Memcached
-        uses: niden/actions-memcached@v7
+        uses: niden/actions-memcached@v8
 
       - name: Install dependencies
         uses: nick-invision/retry@v1

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -14,9 +14,16 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout pull request head
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Checkout branch
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@v4
 
       - name: "laravel-pint"
         uses: aglipanci/laravel-pint-action@latest
@@ -25,5 +32,6 @@ jobs:
           verboseMode: true
 
       - uses: stefanzweifel/git-auto-commit-action@v5
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           commit_message: "fix: pint :robot:"

--- a/src/CollectionDataTable.php
+++ b/src/CollectionDataTable.php
@@ -224,11 +224,14 @@ class CollectionDataTable extends DataTableAbstract
             foreach ($this->request->searchableColumnIndex() as $index) {
                 $column = $this->getColumnName($index);
                 $value = Arr::get($data, $column);
-                if (! is_string($value)) {
+                if (is_bool($value)) {
+                    $value = $value ? '1' : '0';
+                } elseif (! is_scalar($value) && ! $value instanceof \Stringable) {
                     continue;
-                } else {
-                    $value = $this->config->isCaseInsensitive() ? Str::lower($value) : $value;
                 }
+
+                $value = (string) $value;
+                $value = $this->config->isCaseInsensitive() ? Str::lower($value) : $value;
 
                 if (Str::contains($value, $keyword)) {
                     return true;

--- a/tests/Integration/CollectionDataTableTest.php
+++ b/tests/Integration/CollectionDataTableTest.php
@@ -58,6 +58,40 @@ class CollectionDataTableTest extends TestCase
     }
 
     #[Test]
+    public function it_can_perform_global_search_on_non_string_values()
+    {
+        config()->set('app.debug', false);
+        request()->merge([
+            'columns' => [
+                ['data' => 'id', 'name' => 'id', 'searchable' => 'true', 'orderable' => 'true'],
+            ],
+            'search' => ['value' => '19'],
+            'start' => 0,
+            'length' => 10,
+            'draw' => 1,
+        ]);
+
+        $collection = collect([
+            ['id' => 1],
+            ['id' => 19],
+            ['id' => 200],
+        ]);
+
+        $dataTable = app('datatables')->collection($collection);
+        /** @var JsonResponse $response */
+        $response = $dataTable->toJson();
+
+        $this->assertEquals([
+            'draw' => 1,
+            'recordsTotal' => 3,
+            'recordsFiltered' => 1,
+            'data' => [
+                ['id' => 19],
+            ],
+        ], $response->getData(true));
+    }
+
+    #[Test]
     public function it_accepts_a_model_collection_using_of_factory()
     {
         $dataTable = DataTables::of(User::all());


### PR DESCRIPTION
### Summary
Fix collection global search so non-string values can be matched instead of being skipped.

### Changes
- Update `CollectionDataTable::globalSearch` to handle non-string values safely.
- Convert booleans to `'1'`/`'0'`.
- Accept scalar and `Stringable` values and cast them to string before matching.
- Keep skipping unsupported complex values (e.g. arrays/objects without string representation).
- Add integration regression test for searching numeric values in collection rows.

### CI compatibility updates
- Fix `PHP Linting` checkout for fork-based pull requests.
- Bump `niden/actions-memcached` from `v7` to `v8` to avoid Docker API compatibility failures on newer runners.

### Testing
- `./vendor/bin/phpunit tests/Integration/CollectionDataTableTest.php`

Closes #2992