### PR TITLE
feat: support LengthAwarePaginator sources

### DIFF
--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -14,9 +14,16 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout pull request head
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Checkout branch
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@v4
 
       - name: "laravel-pint"
         uses: aglipanci/laravel-pint-action@latest
@@ -25,5 +32,6 @@ jobs:
           verboseMode: true
 
       - uses: stefanzweifel/git-auto-commit-action@v5
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           commit_message: "fix: pint :robot:"

--- a/src/PaginatorDataTable.php
+++ b/src/PaginatorDataTable.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Yajra\DataTables;
+
+use Illuminate\Pagination\LengthAwarePaginator;
+
+class PaginatorDataTable extends CollectionDataTable
+{
+    public function __construct(protected LengthAwarePaginator $paginator)
+    {
+        parent::__construct(collect($paginator->items()));
+
+        $this->skipPaging();
+    }
+
+    /**
+     * Can the DataTable engine be created with these parameters.
+     *
+     * @param  mixed  $source
+     */
+    public static function canCreate($source): bool
+    {
+        return $source instanceof LengthAwarePaginator;
+    }
+
+    /**
+     * Count total items from paginator.
+     */
+    public function totalCount(): int
+    {
+        return $this->totalRecords ??= $this->paginator->total();
+    }
+
+    /**
+     * Skip datatable-side filtering since the source is pre-paginated.
+     */
+    protected function filterRecords(): void
+    {
+        $this->filteredRecords = $this->totalCount();
+    }
+}

--- a/src/PaginatorDataTable.php
+++ b/src/PaginatorDataTable.php
@@ -6,6 +6,9 @@ use Illuminate\Pagination\LengthAwarePaginator;
 
 class PaginatorDataTable extends CollectionDataTable
 {
+    /**
+     * @param  LengthAwarePaginator<int, mixed>  $paginator
+     */
     public function __construct(protected LengthAwarePaginator $paginator)
     {
         parent::__construct(collect($paginator->items()));

--- a/src/config/datatables.php
+++ b/src/config/datatables.php
@@ -48,6 +48,7 @@ return [
         'eloquent' => Yajra\DataTables\EloquentDataTable::class,
         'query' => Yajra\DataTables\QueryDataTable::class,
         'collection' => Yajra\DataTables\CollectionDataTable::class,
+        'paginator' => Yajra\DataTables\PaginatorDataTable::class,
         'resource' => Yajra\DataTables\ApiResourceDataTable::class,
     ],
 
@@ -61,6 +62,7 @@ return [
         // Illuminate\Database\Eloquent\Builder::class            => 'eloquent',
         // Illuminate\Database\Query\Builder::class               => 'query',
         // Illuminate\Support\Collection::class                   => 'collection',
+        // Illuminate\Pagination\LengthAwarePaginator::class      => 'paginator',
     ],
 
     /*

--- a/tests/Integration/PaginatorDataTableTest.php
+++ b/tests/Integration/PaginatorDataTableTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Yajra\DataTables\Tests\Integration;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Http\JsonResponse;
+use PHPUnit\Framework\Attributes\Test;
+use Yajra\DataTables\DataTables;
+use Yajra\DataTables\Facades\DataTables as DatatablesFacade;
+use Yajra\DataTables\PaginatorDataTable;
+use Yajra\DataTables\Tests\Models\User;
+use Yajra\DataTables\Tests\TestCase;
+
+class PaginatorDataTableTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_returns_paginator_records_without_engine_exception()
+    {
+        $crawler = $this->call('GET', '/paginator/users');
+
+        $crawler->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 20,
+            'recordsFiltered' => 20,
+        ]);
+
+        $this->assertCount(10, $crawler->json('data'));
+    }
+
+    #[Test]
+    public function it_accepts_length_aware_paginator_using_of_factory()
+    {
+        $dataTable = DataTables::of(User::query()->paginate(10));
+        $response = $dataTable->toJson();
+
+        $this->assertInstanceOf(PaginatorDataTable::class, $dataTable);
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertEquals(20, $response->getData(true)['recordsTotal']);
+        $this->assertEquals(20, $response->getData(true)['recordsFiltered']);
+    }
+
+    #[Test]
+    public function it_accepts_length_aware_paginator_using_facade()
+    {
+        $dataTable = DatatablesFacade::of(User::query()->paginate(10));
+        $response = $dataTable->toJson();
+
+        $this->assertInstanceOf(PaginatorDataTable::class, $dataTable);
+        $this->assertInstanceOf(JsonResponse::class, $response);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app['router']->get('/paginator/users', fn (DataTables $dataTables) => $dataTables->of(User::query()->paginate(10))->toJson());
+    }
+}


### PR DESCRIPTION
### Summary
Add a dedicated DataTable engine for `LengthAwarePaginator` so `DataTables::of($paginator)` no longer throws `No available engine`.

### Changes
- Add `PaginatorDataTable` engine:
  - detects `Illuminate\Pagination\LengthAwarePaginator` sources
  - uses paginator items as the collection payload
  - reports total/filtered record counts from paginator total
  - skips DataTables-side paging for pre-paginated sources
- Register new engine in `src/config/datatables.php` as `paginator`.
- Add integration tests for route usage, factory usage, and facade usage.
- Add phpstan generic annotation for paginator type.
- Update `pint.yml` checkout logic so the lint workflow can run on fork-based pull requests.

### Tests
- `./vendor/bin/phpunit tests/Integration/PaginatorDataTableTest.php`
- `./vendor/bin/phpunit tests/Integration/CollectionDataTableTest.php tests/Integration/PaginatorDataTableTest.php`

Closes #2334