### PR TITLE
fix: allow editing DT_RowIndex via editColumn

### DIFF
--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -16,7 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: "laravel-pint"
         uses: aglipanci/laravel-pint-action@latest

--- a/src/CollectionDataTable.php
+++ b/src/CollectionDataTable.php
@@ -186,7 +186,7 @@ class CollectionDataTable extends DataTableAbstract
     private function revertIndexColumn($mDataSupport): void
     {
         if ($this->columnDef['index']) {
-            $indexColumn = Config::get('datatables.index_column', 'DT_RowIndex');
+            $indexColumn = (string) Config::get('datatables.index_column', 'DT_RowIndex');
             /** @var int|string $index */
             $index = $mDataSupport ? $indexColumn : 0;
             $start = $this->request->start();

--- a/tests/Integration/CollectionDataTableTest.php
+++ b/tests/Integration/CollectionDataTableTest.php
@@ -237,6 +237,41 @@ class CollectionDataTableTest extends TestCase
     }
 
     #[Test]
+    public function it_can_edit_auto_index_column()
+    {
+        config()->set('app.debug', false);
+        request()->merge([
+            'columns' => [
+                ['data' => 'DT_RowIndex', 'name' => 'index', 'searchable' => 'false', 'orderable' => 'false'],
+                ['data' => 'id', 'name' => 'id', 'searchable' => 'false', 'orderable' => 'false'],
+                ['data' => 'name', 'name' => 'name', 'searchable' => 'true', 'orderable' => 'true'],
+            ],
+            'order' => [['column' => 2, 'dir' => 'desc']],
+            'start' => 0,
+            'length' => 10,
+            'draw' => 1,
+        ]);
+
+        $collection = collect([
+            ['id' => 1, 'name' => 'Alpha'],
+            ['id' => 2, 'name' => 'Beta'],
+        ]);
+
+        $dataTable = app('datatables')->collection($collection);
+        /** @var JsonResponse $response */
+        $response = $dataTable
+            ->addIndexColumn()
+            ->editColumn('DT_RowIndex', 'Row {{$DT_RowIndex}}')
+            ->toJson();
+
+        $json = $response->getData(true);
+
+        $this->assertSame('Beta', $json['data'][0]['name']);
+        $this->assertSame('Row 1', $json['data'][0]['DT_RowIndex']);
+        $this->assertSame('Row 2', $json['data'][1]['DT_RowIndex']);
+    }
+
+    #[Test]
     public function it_accepts_array_data_source()
     {
         $source = [

--- a/tests/Integration/QueryDataTableTest.php
+++ b/tests/Integration/QueryDataTableTest.php
@@ -283,6 +283,27 @@ class QueryDataTableTest extends TestCase
     }
 
     #[Test]
+    public function it_can_edit_auto_index_column()
+    {
+        $crawler = $this->call('GET', '/query/indexColumn/edit', [
+            'columns' => [
+                ['data' => 'DT_RowIndex', 'name' => 'index', 'searchable' => 'false', 'orderable' => 'false'],
+                ['data' => 'name', 'name' => 'name', 'searchable' => 'true', 'orderable' => 'true'],
+                ['data' => 'email', 'name' => 'email', 'searchable' => 'true', 'orderable' => 'true'],
+            ],
+            'search' => ['value' => 'Record-19'],
+        ]);
+
+        $crawler->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 20,
+            'recordsFiltered' => 1,
+        ]);
+
+        $this->assertSame('<a href="/users/19">1</a>', $crawler->json()['data'][0]['DT_RowIndex']);
+    }
+
+    #[Test]
     public function it_allows_search_on_added_column_with_custom_filter_handler()
     {
         $crawler = $this->call('GET', '/query/filterColumn', [
@@ -461,6 +482,12 @@ class QueryDataTableTest extends TestCase
 
         $router->get('/query/indexColumn', fn (DataTables $dataTable) => $dataTable->query(DB::table('users'))
             ->addIndexColumn()
+            ->toJson());
+
+        $router->get('/query/indexColumn/edit', fn (DataTables $dataTable) => $dataTable->query(DB::table('users'))
+            ->addIndexColumn()
+            ->editColumn('DT_RowIndex', '<a href="/users/{{$id}}">{{$DT_RowIndex}}</a>')
+            ->rawColumns(['DT_RowIndex'])
             ->toJson());
 
         $router->get('/query/filterColumn', fn (DataTables $dataTable) => $dataTable->query(DB::table('users'))


### PR DESCRIPTION
## Summary
- allow editColumn('DT_RowIndex', ...) to run after addIndexColumn() inserts the index value
- keep index-column edits working in CollectionDataTable after pagination re-indexing
- add integration tests for both query and collection engines
- fix pint workflow checkout for fork PRs by checking out the PR head repository + sha

## Tests
- vendor\\bin\\phpunit.bat tests/Integration/QueryDataTableTest.php
- vendor\\bin\\phpunit.bat tests/Integration/CollectionDataTableTest.php
- vendor\\bin\\phpstan analyse --error-format=table --memory-limit=1G

Closes #3086