### PR TITLE
Resolve API resource collections before DataTable processing

### DIFF
--- a/src/ApiResourceDataTable.php
+++ b/src/ApiResourceDataTable.php
@@ -39,7 +39,7 @@ class ApiResourceDataTable extends CollectionDataTable
         $this->request = app('datatables.request');
         $this->config = app('datatables.config');
         /** @var Collection<(int|string), array> $collection */
-        $collection = collect($resourceCollection->toArray($this->request));
+        $collection = collect($resourceCollection->toArray(request()));
         $this->collection = $collection;
         $this->original = $collection;
         $this->columns = $collection->isEmpty() ? [] : array_keys($this->serialize($collection->first()));

--- a/src/ApiResourceDataTable.php
+++ b/src/ApiResourceDataTable.php
@@ -36,12 +36,12 @@ class ApiResourceDataTable extends CollectionDataTable
      */
     public function __construct(AnonymousResourceCollection $resourceCollection)
     {
-        /** @var Collection<(int|string), array> $collection */
-        $collection = collect($resourceCollection)->pluck('resource');
         $this->request = app('datatables.request');
         $this->config = app('datatables.config');
+        /** @var Collection<(int|string), array> $collection */
+        $collection = collect($resourceCollection->toArray($this->request));
         $this->collection = $collection;
         $this->original = $collection;
-        $this->columns = array_keys($this->serialize($collection->first()));
+        $this->columns = $collection->isEmpty() ? [] : array_keys($this->serialize($collection->first()));
     }
 }

--- a/tests/Integration/CollectionDataTableTest.php
+++ b/tests/Integration/CollectionDataTableTest.php
@@ -5,9 +5,11 @@ namespace Yajra\DataTables\Tests\Integration;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Http\JsonResponse;
 use PHPUnit\Framework\Attributes\Test;
+use Yajra\DataTables\ApiResourceDataTable;
 use Yajra\DataTables\CollectionDataTable;
 use Yajra\DataTables\DataTables;
 use Yajra\DataTables\Facades\DataTables as DatatablesFacade;
+use Yajra\DataTables\Tests\Http\Resources\UserResource;
 use Yajra\DataTables\Tests\Models\User;
 use Yajra\DataTables\Tests\TestCase;
 
@@ -89,6 +91,35 @@ class CollectionDataTableTest extends TestCase
                 ['id' => 19],
             ],
         ], $response->getData(true));
+    }
+
+    #[Test]
+    public function it_resolves_api_resources_before_processing_rows()
+    {
+        config()->set('app.debug', false);
+        request()->merge([
+            'columns' => [
+                ['data' => 'email', 'name' => 'email', 'searchable' => 'true', 'orderable' => 'true'],
+                ['data' => 'name', 'name' => 'name', 'searchable' => 'true', 'orderable' => 'true'],
+            ],
+            'start' => 0,
+            'length' => 1,
+            'draw' => 1,
+        ]);
+
+        $resourceCollection = UserResource::collection(User::query()->orderBy('id')->limit(1)->get());
+
+        $dataTable = app('datatables')->resource($resourceCollection);
+        /** @var JsonResponse $response */
+        $response = $dataTable->toJson();
+        $json = $response->getData(true);
+
+        $this->assertInstanceOf(ApiResourceDataTable::class, $dataTable);
+        $this->assertSame([
+            'email' => 'Email-1@example.com',
+            'name' => 'Record-1',
+        ], $json['data'][0]);
+        $this->assertArrayNotHasKey('id', $json['data'][0]);
     }
 
     #[Test]


### PR DESCRIPTION
### Motivation

- A change introduced collecting `AnonymousResourceCollection` items directly, which caused `JsonResource` instances to be treated as raw objects and risked exposing underlying model internals instead of the resource's whitelisted output. 
- The intent of this change is to ensure API Resource serialization (request-aware `toArray`) is applied before rows are handed to collection processors so resource-level field filtering and authorization are preserved.

### Description

- Update `ApiResourceDataTable::__construct` to resolve the incoming `AnonymousResourceCollection` via `toArray($this->request)` and wrap the result with `collect(...)` so rows are plain arrays produced by the resource serializer. 
- Use an `isEmpty()` check when deriving `columns` to avoid reading the first raw item from an empty collection. 
- Add an integration regression test `it_resolves_api_resources_before_processing_rows` validating that API Resource output fields are emitted and hidden model fields (e.g., `id`) are not present. 
- No other behavioral changes to downstream processors were introduced.

### Testing

- Ran `php -l src/ApiResourceDataTable.php` and `php -l tests/Integration/CollectionDataTableTest.php`, and both reported no syntax errors. 
- Attempted to run `composer install` but dependency installation failed due to Packagist access (`CONNECT tunnel` HTTP 403) in this environment. 
- Could not execute the PHPUnit integration test (`./vendor/bin/phpunit`) because `vendor/` dependencies could not be installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b846bafec8327819b80c91a7e9159)