### PR TITLE
Fix Collection skipTotalRecords processing to still apply filtering, ordering and pagination

### DIFF
--- a/src/CollectionDataTable.php
+++ b/src/CollectionDataTable.php
@@ -149,18 +149,21 @@ class CollectionDataTable extends DataTableAbstract
 
             $this->totalRecords = $this->totalCount();
 
-            if ($this->totalRecords) {
-                $results = $this->results();
-                $processed = $this->processResults($results, $mDataSupport);
-                $output = $this->transform($results, $processed);
+            $results = $this->results();
+            $processed = $this->processResults($results, $mDataSupport);
+            $output = $this->transform($results, $processed);
 
-                $this->collection = collect($output);
-                $this->ordering();
-                $this->filterRecords();
-                $this->paginate();
+            $this->collection = collect($output);
+            $this->ordering();
+            $this->filterRecords();
 
-                $this->revertIndexColumn($mDataSupport);
+            if ($this->skipTotalRecords) {
+                $this->totalRecords = $this->filteredRecords;
             }
+
+            $this->paginate();
+
+            $this->revertIndexColumn($mDataSupport);
 
             return $this->render($this->collection->values()->all());
         } catch (Exception $exception) {

--- a/tests/Integration/CollectionDataTableTest.php
+++ b/tests/Integration/CollectionDataTableTest.php
@@ -40,6 +40,27 @@ class CollectionDataTableTest extends TestCase
     }
 
     #[Test]
+    public function it_can_skip_total_records_count_with_filter_and_pagination_applied()
+    {
+        $crawler = $this->call('GET', '/collection/skip-total-records', [
+            'columns' => [
+                ['data' => 'name', 'name' => 'name', 'searchable' => 'true', 'orderable' => 'true'],
+                ['data' => 'email', 'name' => 'email', 'searchable' => 'true', 'orderable' => 'true'],
+            ],
+            'search' => ['value' => 'Record 1'],
+            'start' => 0,
+            'length' => 3,
+        ]);
+
+        $crawler->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 11,
+            'recordsFiltered' => 11,
+        ]);
+        $crawler->assertJsonCount(3, 'data');
+    }
+
+    #[Test]
     public function it_can_perform_global_search()
     {
         $crawler = $this->call('GET', '/collection/users', [
@@ -325,5 +346,7 @@ class CollectionDataTableTest extends TestCase
         $this->app['router']->get('/collection/users', fn (DataTables $datatables) => $datatables->collection(User::all())->toJson());
 
         $this->app['router']->get('/collection/empty', fn (DataTables $datatables) => $datatables->collection([])->toJson());
+
+        $this->app['router']->get('/collection/skip-total-records', fn (DataTables $datatables) => $datatables->collection(User::all())->skipTotalRecords()->toJson());
     }
 }


### PR DESCRIPTION
### Motivation
- `skipTotalRecords()` previously set `totalRecords` to `0`, which made a truthy guard in `CollectionDataTable::make` skip filtering, ordering, pagination, and index restoration resulting in unfiltered/unpaginated responses and potential data overexposure.
- The change aims to preserve the performance benefit of skipping the total-count query while still applying the processing pipeline so collection endpoints return correctly filtered and paginated results.

### Description
- Removed the truthy `if ($this->totalRecords)` guard in `CollectionDataTable::make` so `results()`, processing, ordering, and filtering always run for collections.
- When `skipTotalRecords` is enabled, set `totalRecords` to the computed `filteredRecords` after filters run so `recordsTotal` is aligned with the filtered count.
- Ensured pagination and `revertIndexColumn` still execute for collection responses.
- Added an integration regression test and route (`it_can_skip_total_records_count_with_filter_and_pagination_applied`) to assert that `skipTotalRecords()` still applies search and pagination for collections.

### Testing
- `php -l src/CollectionDataTable.php` passed with no syntax errors.
- `php -l tests/Integration/CollectionDataTableTest.php` passed with no syntax errors.
- `git diff --check` showed no issues and changes were committed to the branch.
- `composer install` and `vendor/bin/phpunit` could not run because dependency installation failed due to Packagist access returning HTTP 403, so full test suite execution was not possible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b873f9ac48327a09bbde51fea13e7)