### PR TITLE
Fix duplicate format() call and warning on missing column

### DIFF
--- a/src/Processors/DataProcessor.php
+++ b/src/Processors/DataProcessor.php
@@ -104,10 +104,7 @@ class DataProcessor
             if ($content instanceof Formatter) {
                 $column = str_replace('_formatted', '', $value['name']);
 
-                $value['content'] = $content->format($data[$column], $row);
-                if (isset($data[$column])) {
-                    $value['content'] = $content->format($data[$column], $row);
-                }
+                $value['content'] = $content->format($data[$column] ?? null, $row);
             } else {
                 $value['content'] = Helper::compileContent($content, $data, $row);
             }

--- a/tests/Integration/EloquentDataTableTest.php
+++ b/tests/Integration/EloquentDataTableTest.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Http\JsonResponse;
 use PHPUnit\Framework\Attributes\Test;
+use Yajra\DataTables\Contracts\Formatter;
 use Yajra\DataTables\DataTables;
 use Yajra\DataTables\EloquentDataTable;
 use Yajra\DataTables\Facades\DataTables as DatatablesFacade;
@@ -120,6 +121,59 @@ class EloquentDataTableTest extends TestCase
         $this->assertTrue(isset($data['created_at_formatted']));
 
         $this->assertEquals(Carbon::parse($user->created_at)->format('Y-m-d'), $data['created_at_formatted']);
+    }
+
+    #[Test]
+    public function it_formats_formatter_columns_once_and_passes_null_for_missing_source_columns()
+    {
+        $formatter = new class implements Formatter
+        {
+            public array $values = [];
+
+            public function format(mixed $value, $row): string
+            {
+                $this->values[] = $value;
+
+                return $value === null ? 'missing-source' : 'formatted-'.$value;
+            }
+        };
+        $warnings = [];
+
+        set_error_handler(function (int $severity, string $message) use (&$warnings): bool {
+            if ($severity === E_WARNING) {
+                $warnings[] = $message;
+
+                return true;
+            }
+
+            return false;
+        });
+
+        try {
+            $response = app('datatables')->eloquent(User::query()->whereKey(1))
+                ->formatColumn(['name', 'missing_source'], $formatter)
+                ->toJson();
+        } finally {
+            restore_error_handler();
+        }
+
+        $data = $response->getData(true)['data'][0];
+
+        $this->assertSame([
+            'values' => ['Record-1', null],
+            'warnings' => [],
+            'formatted' => [
+                'name' => 'formatted-Record-1',
+                'missing_source' => 'missing-source',
+            ],
+        ], [
+            'values' => $formatter->values,
+            'warnings' => $warnings,
+            'formatted' => [
+                'name' => $data['name_formatted'],
+                'missing_source' => $data['missing_source_formatted'],
+            ],
+        ]);
     }
 
     #[Test]


### PR DESCRIPTION
- Fixed duplicate `Formatter::format()` call in `DataProcessor` — `format()` was invoked twice per column when using `formatColumn()` with a `Formatter` object
- Prevent PHP warnings when the source column is missing from row data — now passes `null` via `$data[$column] ?? null` instead of accessing an undefined array key
- Added test `it_formats_formatter_columns_once_and_passes_null_for_missing_source_columns` verifying single invocation and null-passing behavior