### PR TITLE
Fix ColumnControl search on non-searchable columns

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -319,7 +319,7 @@ class QueryDataTable extends DataTableAbstract
         foreach ($columns as $index => $column) {
             $columnName = $this->getColumnName($index);
 
-            if (is_null($columnName) || ! ($column['searchable'] ?? false)) {
+            if (is_null($columnName) || ! $this->request->isColumnSearchable($index, false)) {
                 continue;
             }
 

--- a/tests/Unit/QueryDataTableTest.php
+++ b/tests/Unit/QueryDataTableTest.php
@@ -5,6 +5,7 @@ namespace Yajra\DataTables\Tests\Unit;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Yajra\DataTables\QueryDataTable;
 use Yajra\DataTables\Tests\Models\User;
@@ -460,5 +461,49 @@ class QueryDataTableTest extends TestCase
             '"users"."id" = \'123\'',
             $dataTable->getQuery()->toRawSql()
         );
+    }
+
+    #[Test]
+    #[DataProvider('unsearchableColumnValues')]
+    public function it_skips_column_control_search_for_unsearchable_columns(bool|string $searchable): void
+    {
+        app('datatables.request')->merge([
+            'columns' => [
+                [
+                    'name' => 'id',
+                    'data' => 'id',
+                    'searchable' => $searchable,
+                    'orderable' => 'true',
+                    'search' => ['value' => null, 'regex' => 'false'],
+                    'columnControl' => [
+                        'search' => [
+                            'value' => '123',
+                            'logic' => 'equal',
+                            'type' => 'num',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        /** @var QueryDataTable $dataTable */
+        $dataTable = app('datatables')->of(
+            User::query()->select('users.*')
+        );
+
+        $dataTable->columnControlSearch();
+
+        $this->assertSame(
+            'select "users".* from "users"',
+            $dataTable->getQuery()->toSql()
+        );
+    }
+
+    public static function unsearchableColumnValues(): array
+    {
+        return [
+            'string false' => ['false'],
+            'boolean false' => [false],
+        ];
     }
 }


### PR DESCRIPTION
## Summary

  - Normalize ColumnControl searchability checks through the request helper
  - Prevent ColumnControl filters from applying to columns marked `searchable: false`
  - Add regression coverage for both string `'false'` and boolean `false`

  ## Verification

  - `./vendor/bin/phpunit tests/Unit/QueryDataTableTest.php --filter columnControl`
  - `composer test`