### PR TITLE
fix: allow non-latin characters in column names

### DIFF
--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -975,7 +975,7 @@ abstract class DataTableAbstract implements DataTable
         // Only allow characters valid in unquoted SQL identifiers: alphanumeric, underscore, dot, dash, and space.
         // Allows `>` for JSON path operators (e.g. column->path) handled by the query grammar.
         // This is a defense-in-depth measure to prevent SQL injection via columns[N][data] or columns[N][name].
-        if (! preg_match('/^[a-zA-Z0-9_.\-> ]+$/', (string) $validated)) {
+        if (! preg_match('/^[\p{L}\p{N}_.\-> ]+$/u', (string) $validated)) {
             throw new InvalidArgumentException("Invalid column name: \"$column\".");
         }
 

--- a/tests/Unit/QueryDataTableTest.php
+++ b/tests/Unit/QueryDataTableTest.php
@@ -209,6 +209,34 @@ class QueryDataTableTest extends TestCase
     }
 
     #[Test]
+    public function it_accepts_column_name_with_non_latin_characters()
+    {
+        app('datatables.request')->merge([
+            'columns' => [
+                [
+                    'name' => '',
+                    'data' => 'Βάρος',
+                    'searchable' => 'true',
+                    'orderable' => 'true',
+                    'search' => ['value' => null, 'regex' => 'false'],
+                ],
+            ],
+            'order' => [
+                ['column' => 0, 'dir' => 'asc'],
+            ],
+        ]);
+
+        /** @var QueryDataTable $dataTable */
+        $dataTable = app('datatables')->of(
+            DB::table('users')->select('users.*')
+        );
+
+        $dataTable->ordering();
+
+        $this->assertTrue(true);
+    }
+
+    #[Test]
     public function it_handles_normal_column_name_search()
     {
         app('datatables.request')->merge([


### PR DESCRIPTION
The column-name allowlist added in #3283 only permits ASCII characters, so legitimate non-Latin column names such as the Greek `Βάρος` are now rejected as invalid. This widens the allowlist to any Unicode letter or number (`\p{L}\p{N}` with the `u` flag) while still blocking the quotes, semicolons, parentheses and other characters the allowlist exists to guard against.

Fixes #3284
