### PR TITLE
fix: handle schema-qualified Eloquent table searches

### DIFF
--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -3,6 +3,7 @@
 namespace Yajra\DataTables;
 
 use Illuminate\Contracts\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Contracts\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -169,7 +170,7 @@ class EloquentDataTable extends QueryDataTable
     /**
      * Check if a column is already prefixed by the current schema-qualified table.
      */
-    protected function isTableQualifiedColumn($query, string $column): bool
+    protected function isTableQualifiedColumn(QueryBuilder|EloquentBuilder $query, string $column): bool
     {
         $table = $this->getTablePrefix($query);
 

--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -82,6 +82,12 @@ class EloquentDataTable extends QueryDataTable
     protected function compileQuerySearch($query, string $column, string $keyword, string $boolean = 'or', bool $nested = false): void
     {
         if (substr_count($column, '.') > 1) {
+            if ($this->isTableQualifiedColumn($query, $column)) {
+                parent::compileQuerySearch($query, $column, $keyword, $boolean);
+
+                return;
+            }
+
             $parts = explode('.', $column);
             $firstRelation = array_shift($parts);
             $column = implode('.', $parts);
@@ -158,6 +164,18 @@ class EloquentDataTable extends QueryDataTable
         }
 
         return $isMorph;
+    }
+
+    /**
+     * Check if a column is already prefixed by the current schema-qualified table.
+     */
+    protected function isTableQualifiedColumn($query, string $column): bool
+    {
+        $table = $this->getTablePrefix($query);
+
+        return is_string($table)
+            && str_contains($table, '.')
+            && str_starts_with($column, $table.'.');
     }
 
     /**

--- a/tests/Integration/EloquentDataTableTest.php
+++ b/tests/Integration/EloquentDataTableTest.php
@@ -49,6 +49,28 @@ class EloquentDataTableTest extends TestCase
     }
 
     #[Test]
+    public function it_can_perform_column_search_on_model_with_schema_qualified_table()
+    {
+        $crawler = $this->call('GET', '/eloquent/schema-users', [
+            'columns' => [
+                [
+                    'data' => 'name',
+                    'name' => 'name',
+                    'searchable' => 'true',
+                    'orderable' => 'true',
+                    'search' => ['value' => 'Record-19'],
+                ],
+            ],
+        ]);
+
+        $crawler->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 20,
+            'recordsFiltered' => 1,
+        ]);
+    }
+
+    #[Test]
     public function it_accepts_a_model_using_of_factory()
     {
         $dataTable = DataTables::of(User::query());
@@ -233,6 +255,15 @@ class EloquentDataTableTest extends TestCase
 
         $router = $this->app['router'];
         $router->get('/eloquent/users', fn (DataTables $datatables) => $datatables->eloquent(User::query())->toJson());
+
+        $router->get('/eloquent/schema-users', function (DataTables $datatables) {
+            $model = new class extends User
+            {
+                protected $table = 'main.users';
+            };
+
+            return $datatables->eloquent($model->newQuery())->toJson();
+        });
 
         $router->get('/eloquent/only', fn (DataTables $datatables) => $datatables->eloquent(Post::with('user'))
             ->only(['title', 'user.name'])


### PR DESCRIPTION
Fixes #3276.

## Summary
- Treat columns already qualified by the current schema-qualified Eloquent table as plain SQL columns during search.
- Preserve the existing deep relation search path for real relation chains.
- Add a regression test for a model using a dotted table name and a column search on an unqualified column name.

## Root cause
Laravel 12 can leave schema-qualified model table names such as `schema.table` in the query prefix. DataTables then prefixes the request column into `schema.table.column`, and the Eloquent search compiler was treating any column with more than one dot as a nested relation path. That made the schema segment look like a relation method.

## Validation
- `composer pr`
- GitHub checks: PHPStan, phplint, CI on PHP 8.3/8.4/8.5, and SonarCloud