### PR TITLE
fix: avoid double wildcarding column search keywords

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -302,7 +302,7 @@ class QueryDataTable extends DataTableAbstract
             }
 
             if ($this->hasFilterColumn($columnName)) {
-                $keyword = $this->getColumnSearchKeyword($index, true);
+                $keyword = $this->getColumnSearchKeyword($index);
                 $this->applyFilterColumn($this->getBaseQueryBuilder(), $columnName, $keyword);
             } else {
                 $columnName = $this->resolveRelationColumn($columnName);
@@ -432,14 +432,9 @@ class QueryDataTable extends DataTableAbstract
     /**
      * Get column keyword to use for search.
      */
-    protected function getColumnSearchKeyword(int $i, bool $raw = false): string
+    protected function getColumnSearchKeyword(int $i): string
     {
-        $keyword = $this->request->columnKeyword($i);
-        if ($raw || $this->request->isRegex($i)) {
-            return $keyword;
-        }
-
-        return $this->setupKeyword($keyword);
+        return $this->request->columnKeyword($i);
     }
 
     protected function getColumnNameByIndex(int $index): string

--- a/tests/Unit/QueryDataTableTest.php
+++ b/tests/Unit/QueryDataTableTest.php
@@ -260,6 +260,34 @@ class QueryDataTableTest extends TestCase
 
         $sql = $dataTable->getQuery()->toSql();
         $this->assertStringContainsString('name', strtolower($sql));
+        $this->assertSame(['%john%'], $dataTable->getQuery()->getBindings());
+    }
+
+    #[Test]
+    public function it_handles_starts_with_column_name_search()
+    {
+        config(['datatables.search.starts_with' => true]);
+
+        app('datatables.request')->merge([
+            'columns' => [
+                [
+                    'name' => '',
+                    'data' => 'name',
+                    'searchable' => 'true',
+                    'orderable' => 'false',
+                    'search' => ['value' => 'john', 'regex' => 'false'],
+                ],
+            ],
+        ]);
+
+        /** @var QueryDataTable $dataTable */
+        $dataTable = app('datatables')->of(
+            DB::table('users')->select('users.*')
+        );
+
+        $dataTable->columnSearch();
+
+        $this->assertSame(['john%'], $dataTable->getQuery()->getBindings());
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

Fixes column search keyword preparation so the configured wildcard behavior is applied exactly once.

## Root cause

Column search was passing non-regex keywords through `setupKeyword()` before `compileQuerySearch()` called `prepareKeyword()`. With smart search enabled, that produced `%%keyword%%`; with starts-with search enabled, it produced `%keyword%%`.

## Changes

- Return the raw column search keyword for normal column searches and let `prepareKeyword()` handle search configuration once.
- Add regression assertions for smart column search and starts-with column search bindings.

Fixes #3144.

## Checks

- `composer pr`