### PR TITLE
Fix ErrorException when searchPanes sent for unregistered column

### DIFF
--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -816,11 +816,11 @@ class QueryDataTable extends DataTableAbstract
         $columns = (array) $this->request->searchPanes;
 
         foreach ($columns as $column => $values) {
-            if ($this->isBlacklisted($column)) {
+            if ($this->isBlacklisted($column) || ! isset($this->searchPanes[$column])) {
                 continue;
             }
 
-            if ($this->searchPanes[$column] && $callback = $this->searchPanes[$column]['builder']) {
+            if ($callback = $this->searchPanes[$column]['builder']) {
                 $callback($this->query, $values);
             } else {
                 $this->query->whereIn($column, $values);

--- a/tests/Integration/QueryDataTableTest.php
+++ b/tests/Integration/QueryDataTableTest.php
@@ -363,6 +363,22 @@ class QueryDataTableTest extends TestCase
     }
 
     #[Test]
+    public function it_ignores_search_panes_for_unregistered_columns()
+    {
+        $crawler = $this->call('GET', '/query/search-panes', [
+            'searchPanes' => [
+                'email' => ['foo@example.com'],
+            ],
+        ]);
+
+        $crawler->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 20,
+            'recordsFiltered' => 20,
+        ]);
+    }
+
+    #[Test]
     public function it_allows_column_search_added_column_with_custom_filter_handler()
     {
         $crawler = $this->call('GET', '/query/blacklisted-filter', [


### PR DESCRIPTION
  ## Bug

  `QueryDataTable::searchPanesSearch()` accesses `$this->searchPanes[$column]`
  for every column name present in the incoming `searchPanes` request
  parameter, but that array is only populated for columns explicitly
  registered via `->searchPane('column', $options)`.

  If a request includes a `searchPanes` entry for a column that was never
  registered (stale saved DataTables state in the browser, a typo, etc.),
  PHP throws `Undefined array key "..."`. In a typical Laravel app this
  becomes an `ErrorException`, which gets caught by the generic exception
  handler in `make()`, so the entire DataTable response fails
  (`recordsFiltered` drops to 0, no rows returned) instead of the request
  simply ignoring that one irrelevant filter.

  ## Fix

  Skip columns in `searchPanesSearch()` that aren't registered via
  `searchPane()`, the same way already-blacklisted columns are skipped.

  ## Testing

  - Added a regression test: `it_ignores_search_panes_for_unregistered_columns`
  - Full test suite passes (160 tests)
  - Pint and PHPStan clean on the changed file
