### PR TITLE
feat: add processWith() to run a callback on each row before processing

### DIFF
--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -104,6 +104,13 @@ abstract class DataTableAbstract implements DataTable
     protected $orderCallback = null;
 
     /**
+     * Callback to run against each row before it gets processed.
+     *
+     * @var callable|null
+     */
+    protected $processCallback = null;
+
+    /**
      * Skip pagination as needed.
      */
     protected bool $skipPaging = false;
@@ -462,6 +469,21 @@ abstract class DataTableAbstract implements DataTable
     public function order(callable $closure): static
     {
         $this->orderCallback = $closure;
+
+        return $this;
+    }
+
+    /**
+     * Process each row with the given callback before it gets converted to array.
+     *
+     * The row instance is passed to the callback so it can be mutated before
+     * being processed, e.g. setting a relation to avoid an n+1 query.
+     *
+     * @return $this
+     */
+    public function processWith(callable $callback): static
+    {
+        $this->processCallback = $callback;
 
         return $this;
     }
@@ -840,6 +862,10 @@ abstract class DataTableAbstract implements DataTable
             $this->templates,
             $this->request->start()
         );
+
+        if ($this->processCallback) {
+            $processor->processWith($this->processCallback);
+        }
 
         return $processor->process($object);
     }

--- a/src/Processors/DataProcessor.php
+++ b/src/Processors/DataProcessor.php
@@ -49,6 +49,13 @@ class DataProcessor
 
     protected string $indexColumn;
 
+    /**
+     * Callback to run against each row before it gets converted to array.
+     *
+     * @var callable|null
+     */
+    protected $processCallback = null;
+
     public function __construct(protected iterable $results, array $columnDef, protected array $templates, protected int $start = 0)
     {
         $this->appendColumns = $columnDef['append'] ?? [];
@@ -65,6 +72,18 @@ class DataProcessor
     }
 
     /**
+     * Set the callback to run against each row before it gets converted to array.
+     *
+     * @return $this
+     */
+    public function processWith(callable $callback): static
+    {
+        $this->processCallback = $callback;
+
+        return $this;
+    }
+
+    /**
      * Process data to output on browser.
      *
      * @param  bool  $object
@@ -74,6 +93,10 @@ class DataProcessor
         $this->output = [];
 
         foreach ($this->results as $row) {
+            if ($this->processCallback) {
+                call_user_func($this->processCallback, $row);
+            }
+
             $data = Helper::convertToArray($row, ['hidden' => $this->makeHidden, 'visible' => $this->makeVisible, 'ignore_getters' => $this->ignoreGetters]);
             $value = $this->addColumns($data, $row);
             $value = $this->editColumns($value, $row);

--- a/tests/Integration/ProcessWithTest.php
+++ b/tests/Integration/ProcessWithTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Yajra\DataTables\Tests\Integration;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
+use Yajra\DataTables\DataTables;
+use Yajra\DataTables\Tests\Models\Post;
+use Yajra\DataTables\Tests\Models\User;
+use Yajra\DataTables\Tests\TestCase;
+
+class ProcessWithTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_runs_the_callback_on_each_row()
+    {
+        $processed = 0;
+
+        $this->app['router']->get('/process-with', function (DataTables $datatables) use (&$processed) {
+            return $datatables->eloquent(User::query())
+                ->processWith(function (User $user) use (&$processed) {
+                    $processed++;
+                    $user->name = 'Processed-'.$user->getKey();
+                })
+                ->toJson();
+        });
+
+        $response = $this->call('GET', '/process-with');
+
+        $this->assertEquals(20, $processed);
+        $this->assertCount(20, $response->json()['data']);
+
+        foreach ($response->json()['data'] as $row) {
+            $this->assertEquals('Processed-'.$row['id'], $row['name']);
+        }
+    }
+
+    #[Test]
+    public function it_does_not_query_the_database_for_a_relation_set_via_process_with()
+    {
+        $user = User::query()->firstOrFail();
+
+        $this->app['router']->get('/process-with-relation', fn (DataTables $datatables) => $datatables->eloquent(Post::query())
+            ->processWith(fn (Post $post) => $post->setRelation('user', $user))
+            ->addColumn('user_name', fn (Post $post) => $post->user->name)
+            ->toJson());
+
+        $queries = [];
+        DB::listen(function ($query) use (&$queries) {
+            $queries[] = $query->sql;
+        });
+
+        $response = $this->call('GET', '/process-with-relation');
+
+        $this->assertCount(60, $response->json()['data']);
+        $this->assertEquals($user->name, $response->json()['data'][0]['user_name']);
+        $this->assertEmpty(array_filter($queries, fn ($sql) => str_contains($sql, '"users"')));
+    }
+
+    #[Test]
+    public function it_can_process_rows_of_a_query_data_table()
+    {
+        $this->app['router']->get('/process-with-query', fn (DataTables $datatables) => $datatables->query(DB::table('users'))
+            ->processWith(function (\stdClass $user) {
+                $user->name = strtoupper($user->name);
+            })
+            ->toJson());
+
+        $response = $this->call('GET', '/process-with-query');
+
+        $this->assertCount(20, $response->json()['data']);
+
+        foreach ($response->json()['data'] as $row) {
+            $this->assertEquals(strtoupper($row['name']), $row['name']);
+            $this->assertStringStartsWith('RECORD-', $row['name']);
+        }
+    }
+
+    #[Test]
+    public function it_can_process_rows_of_a_collection_data_table()
+    {
+        $this->app['router']->get('/process-with-collection', fn (DataTables $datatables) => $datatables->collection(User::all())
+            ->processWith(function (User $user) {
+                $user->name = 'Processed-'.$user->getKey();
+            })
+            ->toJson());
+
+        $response = $this->call('GET', '/process-with-collection');
+
+        $this->assertCount(20, $response->json()['data']);
+
+        foreach ($response->json()['data'] as $row) {
+            $this->assertEquals('Processed-'.$row['id'], $row['name']);
+        }
+    }
+
+    #[Test]
+    public function it_is_not_called_when_not_set()
+    {
+        $this->app['router']->get('/process-with-none', fn (DataTables $datatables) => $datatables->eloquent(User::query())->toJson());
+
+        $response = $this->call('GET', '/process-with-none');
+
+        $this->assertCount(20, $response->json()['data']);
+        $this->assertEquals('Record-1', $response->json()['data'][0]['name']);
+    }
+}


### PR DESCRIPTION
Closes #2862

## Problem

There is currently no way to interact with each row instance before it gets processed. Doing so requires extending both the engine (to override `processResults()`) and `DataProcessor` (to override `process()`), which is a lot of boilerplate for a one line hook.

The main use case is setting an already known relation on every row so accessing it inside `addColumn()` / `editColumn()` does not trigger an n+1 query.

## Solution

Adds `->processWith(callable $callback)` on `DataTableAbstract`, as suggested in the issue discussion. The callback receives each row instance right before it is converted to an array, so any mutation on it is reflected on the response.

```php
public function dataTable($query): EloquentDataTable
{
    return (new EloquentDataTable($query))
        ->processWith(function (PriceListEntry $entry) {
            $entry->setRelation('priceList', $this->priceList);
        })
        ->addColumn('price_list', fn (PriceListEntry $entry) => $entry->priceList->name);
}
```

Because the hook lives in `DataProcessor::process()`, it works for every engine that goes through `processResults()`: eloquent, query, collection, resource and paginator.

## Changes

- `DataTableAbstract::processWith()` stores the callback and passes it to the processor in `processResults()`.
- `DataProcessor::processWith()` sets the callback, which is then invoked for each row at the top of the `process()` loop.
- Added `tests/Integration/ProcessWithTest.php` covering the eloquent, query and collection engines, plus an assertion that a relation set through `processWith()` results in no extra query.

## Notes

- Fully backwards compatible: nothing changes when the callback is not set.
- The callback runs before `Helper::convertToArray()`, so mutations (including a set relation) are part of the row data. Use `makeHidden()` if the relation should stay out of the response.
- `composer stan` passes, and the test suite passes.
