### PR TITLE
perf: group global search columns of the same relation into one sub-query

### DIFF
--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as BaseQueryBuilder;
 use Illuminate\Database\Query\JoinClause;
+use Illuminate\Support\Collection;
 use Yajra\DataTables\Exceptions\Exception;
 
 /**
@@ -84,56 +85,127 @@ class EloquentDataTable extends QueryDataTable
      */
     protected function compileQuerySearch($query, string $column, string $keyword, string $boolean = 'or', bool $nested = false): void
     {
-        if (substr_count($column, '.') > 1) {
-            if ($this->isTableQualifiedColumn($query, $column)) {
-                parent::compileQuerySearch($query, $column, $keyword, $boolean);
+        $relation = $this->resolveSearchableRelation($query, $column, $nested);
 
-                return;
-            }
-
-            $parts = explode('.', $column);
-            $firstRelation = array_shift($parts);
-            $column = implode('.', $parts);
-
-            if ($this->isMorphRelation($firstRelation)) {
-                $query->{$boolean.'WhereHasMorph'}(
-                    $firstRelation,
-                    '*',
-                    function (EloquentBuilder $query) use ($column, $keyword) {
-                        parent::compileQuerySearch($query, $column, $keyword, '');
-                    }
-                );
-            } else {
-                $query->{$boolean.'WhereHas'}($firstRelation, function (EloquentBuilder $query) use ($column, $keyword) {
-                    self::compileQuerySearch($query, $column, $keyword, '', true);
-                });
-            }
-
-            return;
-        }
-
-        $parts = explode('.', $column);
-        $newColumn = array_pop($parts);
-        $relation = implode('.', $parts);
-
-        if (! $nested && $this->isNotEagerLoaded($relation)) {
+        if (! $relation) {
             parent::compileQuerySearch($query, $column, $keyword, $boolean);
 
             return;
         }
 
-        if ($this->isMorphRelation($relation)) {
-            $query->{$boolean.'WhereHasMorph'}(
-                $relation,
-                '*',
-                function (EloquentBuilder $query) use ($newColumn, $keyword) {
-                    parent::compileQuerySearch($query, $newColumn, $keyword, '');
+        $this->compileRelationSearch($query, $relation['relation'], [$relation['column']], $keyword, $boolean);
+    }
+
+    /**
+     * Resolve the relation that should be searched for the given column.
+     *
+     * Returns null when the column can be searched on the query itself,
+     * e.g. when its relation is not eager loaded and is therefore joined.
+     *
+     * @param  QueryBuilder|EloquentBuilder  $query
+     * @return array{relation: string, column: string}|null
+     */
+    protected function resolveSearchableRelation($query, string $column, bool $nested = false): ?array
+    {
+        $parts = explode('.', $column);
+
+        if (count($parts) > 2) {
+            if ($this->isTableQualifiedColumn($query, $column)) {
+                return null;
+            }
+
+            $relation = array_shift($parts);
+
+            return ['relation' => $relation, 'column' => implode('.', $parts)];
+        }
+
+        $columnName = array_pop($parts);
+        $relation = implode('.', $parts);
+
+        if (! $relation || (! $nested && $this->isNotEagerLoaded($relation))) {
+            return null;
+        }
+
+        return ['relation' => $relation, 'column' => $columnName];
+    }
+
+    /**
+     * Compile a single relation search query for the given related columns.
+     *
+     * All columns of the same relation are compiled into one where has query
+     * so a single sub-query is used instead of one per column.
+     *
+     * @param  QueryBuilder|EloquentBuilder  $query
+     * @param  array<int, string>  $columns
+     */
+    protected function compileRelationSearch($query, string $relation, array $columns, string $keyword, string $boolean = 'or'): void
+    {
+        $isMorph = $this->isMorphRelation($relation);
+
+        $search = function (EloquentBuilder $query) use ($columns, $keyword, $isMorph) {
+            foreach (array_values($columns) as $index => $column) {
+                $boolean = $index === 0 ? '' : 'or';
+
+                if (! $isMorph && str_contains($column, '.')) {
+                    self::compileQuerySearch($query, $column, $keyword, $boolean, true);
+                } else {
+                    parent::compileQuerySearch($query, $column, $keyword, $boolean);
                 }
-            );
+            }
+        };
+
+        // A single column does not need to be grouped as it cannot be
+        // mixed up with the relation constraint of the where has query.
+        $callback = count($columns) > 1
+            ? fn (EloquentBuilder $query) => $query->where($search)
+            : $search;
+
+        if ($isMorph) {
+            $query->{$boolean.'WhereHasMorph'}($relation, '*', $callback);
         } else {
-            $query->{$boolean.'WhereHas'}($relation, function (EloquentBuilder $query) use ($newColumn, $keyword) {
-                parent::compileQuerySearch($query, $newColumn, $keyword, '');
-            });
+            $query->{$boolean.'WhereHas'}($relation, $callback);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function compileGlobalSearch($query, Collection $columns, string $keyword): void
+    {
+        /** @var array<int, string|null> $relations */
+        $relations = [];
+
+        /** @var array<int, array<int, string>> $groups */
+        $groups = [];
+
+        foreach ($columns as $column) {
+            $relation = $this->hasFilterColumn($column)
+                ? null
+                : $this->resolveSearchableRelation($query, $column);
+
+            if (! $relation) {
+                $relations[] = null;
+                $groups[] = [$column];
+
+                continue;
+            }
+
+            $index = array_search($relation['relation'], $relations, true);
+
+            if ($index === false) {
+                $relations[] = $relation['relation'];
+                $groups[] = [$relation['column']];
+            } else {
+                $groups[$index][] = $relation['column'];
+            }
+        }
+
+        foreach ($relations as $index => $relation) {
+            if ($relation === null) {
+                $this->compileGlobalSearchColumn($query, $groups[$index][0], $keyword);
+            } else {
+                $this->compileRelationSearch($query, $relation, $groups[$index], $keyword);
+            }
         }
     }
 

--- a/src/QueryDataTable.php
+++ b/src/QueryDataTable.php
@@ -929,18 +929,38 @@ class QueryDataTable extends DataTableAbstract
         }
 
         $this->query->where(function ($query) use ($keyword) {
-            collect($this->request->searchableColumnIndex())
+            $columns = collect($this->request->searchableColumnIndex())
                 ->map(fn ($index) => $this->getColumnName($index))
                 ->filter()
-                ->reject(fn ($column) => $this->isBlacklisted($column) && ! $this->hasFilterColumn($column))
-                ->each(function ($column) use ($keyword, $query) {
-                    if ($this->hasFilterColumn($column)) {
-                        $this->applyFilterColumn($query, $column, $keyword, 'or');
-                    } else {
-                        $this->compileQuerySearch($query, $column, $keyword);
-                    }
-                });
+                ->reject(fn ($column) => $this->isBlacklisted($column) && ! $this->hasFilterColumn($column));
+
+            $this->compileGlobalSearch($query, $columns, $keyword);
         });
+    }
+
+    /**
+     * Compile the global search query for the given searchable columns.
+     *
+     * @param  QueryBuilder|EloquentBuilder  $query
+     * @param  Collection<array-key, string>  $columns
+     */
+    protected function compileGlobalSearch($query, Collection $columns, string $keyword): void
+    {
+        $columns->each(fn ($column) => $this->compileGlobalSearchColumn($query, $column, $keyword));
+    }
+
+    /**
+     * Compile the global search query for a single searchable column.
+     *
+     * @param  QueryBuilder|EloquentBuilder  $query
+     */
+    protected function compileGlobalSearchColumn($query, string $column, string $keyword): void
+    {
+        if ($this->hasFilterColumn($column)) {
+            $this->applyFilterColumn($query, $column, $keyword, 'or');
+        } else {
+            $this->compileQuerySearch($query, $column, $keyword);
+        }
     }
 
     /**

--- a/tests/Unit/GlobalSearchRelationTest.php
+++ b/tests/Unit/GlobalSearchRelationTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Yajra\DataTables\Tests\Unit;
+
+use Illuminate\Database\Eloquent\Builder;
+use PHPUnit\Framework\Attributes\Test;
+use Yajra\DataTables\EloquentDataTable;
+use Yajra\DataTables\Tests\Models\Post;
+use Yajra\DataTables\Tests\TestCase;
+
+class GlobalSearchRelationTest extends TestCase
+{
+    #[Test]
+    public function it_groups_columns_of_the_same_relation_into_a_single_sub_query()
+    {
+        $sql = $this->globalSearchSql(Post::with('user')->select('posts.*'), [
+            'user.name',
+            'user.email',
+            'posts.title',
+        ]);
+
+        $this->assertEquals(1, substr_count($sql, 'exists (select'));
+        $this->assertStringContainsString('"users"."name"', $sql);
+        $this->assertStringContainsString('"users"."email"', $sql);
+        $this->assertStringContainsString('"posts"."title"', $sql);
+    }
+
+    #[Test]
+    public function it_uses_a_single_sub_query_per_relation()
+    {
+        $sql = $this->globalSearchSql(Post::with(['user', 'heart'])->select('posts.*'), [
+            'user.name',
+            'heart.size',
+            'user.email',
+        ]);
+
+        $this->assertEquals(2, substr_count($sql, 'exists (select'));
+        $this->assertStringContainsString('"users"."name"', $sql);
+        $this->assertStringContainsString('"users"."email"', $sql);
+        $this->assertStringContainsString('"hearts"."size"', $sql);
+    }
+
+    #[Test]
+    public function it_does_not_use_a_sub_query_when_the_relation_is_not_eager_loaded()
+    {
+        $sql = $this->globalSearchSql(Post::query()->select('posts.*'), [
+            'user.name',
+            'user.email',
+        ]);
+
+        $this->assertStringNotContainsString('exists (select', $sql);
+        $this->assertStringContainsString('"user"."name"', $sql);
+        $this->assertStringContainsString('"user"."email"', $sql);
+    }
+
+    #[Test]
+    public function it_keeps_the_relation_constraint_and_the_searched_columns_grouped()
+    {
+        $sql = $this->globalSearchSql(Post::with('user')->select('posts.*'), [
+            'user.name',
+            'user.email',
+        ]);
+
+        // The relation constraint must be joined with "and" to the grouped
+        // column conditions, otherwise the "or" would leak out of it.
+        $this->assertMatchesRegularExpression(
+            '/and \(lower\("users"\."name"\) LIKE \? or lower\("users"\."email"\) LIKE \?\)/i',
+            $sql
+        );
+    }
+
+    #[Test]
+    public function it_returns_the_same_records_as_an_ungrouped_search()
+    {
+        $this->mergeRequest(['user.name', 'user.email'], 'Email-19@example.com');
+
+        $dataTable = new EloquentDataTable(Post::with('user')->select('posts.*'));
+        $dataTable->filtering();
+
+        $this->assertCount(3, $dataTable->getQuery()->get());
+    }
+
+    /**
+     * @param  array<int, string>  $columns
+     */
+    protected function globalSearchSql(Builder $query, array $columns, string $keyword = 'foo'): string
+    {
+        $this->mergeRequest($columns, $keyword);
+
+        $dataTable = new EloquentDataTable($query);
+        $dataTable->filtering();
+
+        return $dataTable->getQuery()->toSql();
+    }
+
+    /**
+     * @param  array<int, string>  $columns
+     */
+    protected function mergeRequest(array $columns, string $keyword): void
+    {
+        app('datatables.request')->merge([
+            'columns' => array_map(fn ($column) => [
+                'data' => $column,
+                'name' => $column,
+                'searchable' => 'true',
+                'orderable' => 'true',
+                'search' => ['value' => null, 'regex' => 'false'],
+            ], $columns),
+            'search' => ['value' => $keyword, 'regex' => 'false'],
+        ]);
+    }
+}


### PR DESCRIPTION
Closes #2519

## Problem

Global search compiles one query per searchable column. For an eager loaded relation that means one `exists` sub-query per column, all hitting the same table:

```sql
where (
    exists (select * from "users" where "posts"."user_id" = "users"."id" and lower("users"."name") like ?)
    or exists (select * from "users" where "posts"."user_id" = "users"."id" and lower("users"."email") like ?)
)
```

Column search and ordering already resolve relation columns once, so global search was the odd one out, and the cost grows with every searchable column of the relation.

## Solution

Searchable columns are now grouped per relation before being compiled, so each relation produces a single sub-query:

```sql
where exists (
    select * from "users"
    where "posts"."user_id" = "users"."id"
    and (lower("users"."name") like ? or lower("users"."email") like ?)
)
```

The column conditions are wrapped in a nested `where` so the `or` cannot leak out of the relation constraint. That wrapper is only added when a relation has more than one searchable column, keeping the generated SQL identical to before for every single column case.

The original suggestion in the issue was to call `resolveRelationColumn()` in `globalSearch()`. That turns the sub-query into a join, which also multiplies rows for `hasMany` / `belongsToMany` relations and changes `recordsFiltered`. Grouping keeps the current semantics and only removes the duplicated sub-queries, which is what was agreed on in the discussion.

## Changes

- `QueryDataTable::globalSearch()` now delegates to `compileGlobalSearch()`, which loops the searchable columns through `compileGlobalSearchColumn()`. Behaviour is unchanged for the query engine.
- `EloquentDataTable::compileGlobalSearch()` groups the columns by relation, preserving the order of first appearance, and compiles each group into one `whereHas` / `whereHasMorph`.
- `EloquentDataTable::compileQuerySearch()` was split into `resolveSearchableRelation()` (which relation, if any, a column belongs to) and `compileRelationSearch()` (compile one relation with n columns), so single column search and grouped global search share one code path.

## Notes

- Not affected: column search, ordering, `filterColumn()` callbacks, columns of relations that are not eager loaded, and morph relations keep their existing per relation handling.
- `tests/Unit/GlobalSearchRelationTest.php` covers the grouping, one sub-query per relation, the untouched non eager loaded case, the `and (... or ...)` precedence, and that the result set is unchanged. Three of these tests fail on the current implementation.
- `composer stan` passes and the existing relation tests (`BelongsTo`, `HasMany`, `HasOne`, `HasOneThrough`, `BelongsToMany`, `MorphTo`, `DeepRelation`, `ArrayNotationRelation`) pass unchanged.
