### PR TITLE
fix: resolve eager loaded relations written in snake case

### DIFF
--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as BaseQueryBuilder;
 use Illuminate\Database\Query\JoinClause;
+use Illuminate\Support\Str;
 use Yajra\DataTables\Exceptions\Exception;
 
 /**
@@ -92,7 +93,7 @@ class EloquentDataTable extends QueryDataTable
             }
 
             $parts = explode('.', $column);
-            $firstRelation = array_shift($parts);
+            $firstRelation = $this->resolveRelationName(array_shift($parts));
             $column = implode('.', $parts);
 
             if ($this->isMorphRelation($firstRelation)) {
@@ -114,7 +115,7 @@ class EloquentDataTable extends QueryDataTable
 
         $parts = explode('.', $column);
         $newColumn = array_pop($parts);
-        $relation = implode('.', $parts);
+        $relation = $this->resolveRelationName(implode('.', $parts));
 
         if (! $nested && $this->isNotEagerLoaded($relation)) {
             parent::compileQuerySearch($query, $column, $keyword, $boolean);
@@ -135,6 +136,24 @@ class EloquentDataTable extends QueryDataTable
                 parent::compileQuerySearch($query, $newColumn, $keyword, '');
             });
         }
+    }
+
+    /**
+     * Resolve the name of an eager loaded relation.
+     *
+     * Column names are usually written in snake case, e.g. "child_table.name",
+     * while the relation itself is defined in camel case. The camel case
+     * relation is therefore used when it is the eager loaded one.
+     */
+    protected function resolveRelationName(string $relation): string
+    {
+        if (! $relation || array_key_exists($relation, $this->query->getEagerLoads())) {
+            return $relation;
+        }
+
+        $camel = Str::camel($relation);
+
+        return array_key_exists($camel, $this->query->getEagerLoads()) ? $camel : $relation;
     }
 
     /**
@@ -190,7 +209,9 @@ class EloquentDataTable extends QueryDataTable
     {
         $parts = explode('.', $column);
         $columnName = array_pop($parts);
-        $relation = preg_replace('/\[.*?\]/', '', implode('.', $parts));
+        $relation = $this->resolveRelationName(
+            (string) preg_replace('/\[.*?\]/', '', implode('.', $parts))
+        );
 
         if ($this->isNotEagerLoaded($relation)) {
             return parent::resolveRelationColumn($column);

--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -167,9 +167,52 @@ class EloquentDataTable extends QueryDataTable
             return $relation;
         }
 
-        $camel = Str::camel($relation);
+        $resolved = null;
+        $resolvedScore = -1;
 
-        return array_key_exists($camel, $this->query->getEagerLoads()) ? $camel : $relation;
+        foreach (array_keys($this->query->getEagerLoads()) as $eagerRelation) {
+            $score = $this->relationNameMatchScore($relation, (string) $eagerRelation);
+
+            if ($score !== null && $score > $resolvedScore) {
+                $resolved = (string) $eagerRelation;
+                $resolvedScore = $score;
+            }
+        }
+
+        return $resolved ?? $relation;
+    }
+
+    /**
+     * Score how well a relation matches an eager loaded one, segment by segment.
+     *
+     * Null means the two cannot be the same relation, otherwise the score is the
+     * number of segments that matched literally, so that an eager load spelled
+     * exactly like the column wins over one that only matches in camel case.
+     */
+    protected function relationNameMatchScore(string $relation, string $eagerRelation): ?int
+    {
+        $parts = explode('.', $relation);
+        $eagerParts = explode('.', $eagerRelation);
+
+        if (count($parts) !== count($eagerParts)) {
+            return null;
+        }
+
+        $score = 0;
+
+        foreach ($parts as $index => $part) {
+            if ($part === $eagerParts[$index]) {
+                $score++;
+
+                continue;
+            }
+
+            if (Str::camel($part) !== $eagerParts[$index]) {
+                return null;
+            }
+        }
+
+        return $score;
     }
 
     /**
@@ -177,13 +220,13 @@ class EloquentDataTable extends QueryDataTable
      */
     protected function resolveRelationNameOf(Model $model, string $relation): string
     {
-        if (method_exists($model, $relation)) {
+        if ($model->isRelation($relation)) {
             return $relation;
         }
 
         $camel = Str::camel($relation);
 
-        return method_exists($model, $camel) ? $camel : $relation;
+        return $model->isRelation($camel) ? $camel : $relation;
     }
 
     /**

--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -4,6 +4,7 @@ namespace Yajra\DataTables;
 
 use Illuminate\Contracts\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Contracts\Database\Query\Builder as QueryBuilder;
+use Illuminate\Database\Eloquent\Builder as BaseEloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -93,7 +94,7 @@ class EloquentDataTable extends QueryDataTable
             }
 
             $parts = explode('.', $column);
-            $firstRelation = $this->resolveRelationName(array_shift($parts));
+            $firstRelation = $this->resolveRelationName(array_shift($parts), $nested ? $query : null);
             $column = implode('.', $parts);
 
             if ($this->isMorphRelation($firstRelation)) {
@@ -115,7 +116,7 @@ class EloquentDataTable extends QueryDataTable
 
         $parts = explode('.', $column);
         $newColumn = array_pop($parts);
-        $relation = $this->resolveRelationName(implode('.', $parts));
+        $relation = $this->resolveRelationName(implode('.', $parts), $nested ? $query : null);
 
         if (! $nested && $this->isNotEagerLoaded($relation)) {
             parent::compileQuerySearch($query, $column, $keyword, $boolean);
@@ -144,16 +145,45 @@ class EloquentDataTable extends QueryDataTable
      * Column names are usually written in snake case, e.g. "child_table.name",
      * while the relation itself is defined in camel case. The camel case
      * relation is therefore used when it is the eager loaded one.
+     *
+     * Pass the query of a where has callback to resolve a nested relation. The
+     * eager loads of the root query are keyed by their full path, e.g.
+     * "user.childTable", so a nested name is resolved against the related
+     * model it belongs to instead.
+     *
+     * @param  QueryBuilder|EloquentBuilder|null  $query
      */
-    protected function resolveRelationName(string $relation): string
+    protected function resolveRelationName(string $relation, $query = null): string
     {
-        if (! $relation || array_key_exists($relation, $this->query->getEagerLoads())) {
+        if (! $relation) {
+            return $relation;
+        }
+
+        if ($query instanceof BaseEloquentBuilder) {
+            return $this->resolveRelationNameOf($query->getModel(), $relation);
+        }
+
+        if (array_key_exists($relation, $this->query->getEagerLoads())) {
             return $relation;
         }
 
         $camel = Str::camel($relation);
 
         return array_key_exists($camel, $this->query->getEagerLoads()) ? $camel : $relation;
+    }
+
+    /**
+     * Resolve the name of a relation against the model that declares it.
+     */
+    protected function resolveRelationNameOf(Model $model, string $relation): string
+    {
+        if (method_exists($model, $relation)) {
+            return $relation;
+        }
+
+        $camel = Str::camel($relation);
+
+        return method_exists($model, $camel) ? $camel : $relation;
     }
 
     /**

--- a/tests/Integration/MixedCaseRelationTest.php
+++ b/tests/Integration/MixedCaseRelationTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Yajra\DataTables\Tests\Integration;
+
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Yajra\DataTables\DataTables;
+use Yajra\DataTables\Tests\Models\Heart;
+use Yajra\DataTables\Tests\Models\Post;
+use Yajra\DataTables\Tests\Models\User;
+use Yajra\DataTables\Tests\TestCase;
+
+class MixedCaseRelationTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_can_sort_on_a_path_mixing_a_literal_snake_case_and_a_camel_case_relation()
+    {
+        $this->app['router']->get('/relations/mixedCase', fn (DataTables $datatables) => $datatables
+            ->eloquent(Post::with('post_user.nestedFilteredHeart')->select('posts.*'))
+            ->toJson());
+
+        $response = $this->call('GET', '/relations/mixedCase', [
+            'columns' => [
+                [
+                    'data' => 'post_user.nested_filtered_heart.size',
+                    'name' => 'post_user.nested_filtered_heart.size',
+                    'searchable' => 'true',
+                    'orderable' => 'true',
+                ],
+            ],
+            'order' => [['column' => 0, 'dir' => 'desc']],
+            'start' => 0,
+            'length' => 10,
+            'draw' => 1,
+        ]);
+
+        $response->assertJson([
+            'draw' => 1,
+            'recordsTotal' => 60,
+            'recordsFiltered' => 60,
+        ]);
+
+        $this->assertEquals(
+            'heart-3',
+            $response->json()['data'][0]['post_user']['nested_filtered_heart']['size']
+        );
+    }
+
+    #[Test]
+    public function it_can_search_a_relation_registered_with_resolve_relation_using()
+    {
+        User::resolveRelationUsing(
+            'dynamicHeartRelation',
+            fn (User $user): HasOne => $user->hasOne(Heart::class),
+        );
+
+        $this->app['router']->get('/relations/dynamic', fn (DataTables $datatables) => $datatables
+            ->eloquent(Post::with('post_user.dynamicHeartRelation')->select('posts.*'))
+            ->toJson());
+
+        $response = $this->call('GET', '/relations/dynamic', [
+            'columns' => [
+                [
+                    'data' => 'post_user.dynamic_heart_relation.size',
+                    'name' => 'post_user.dynamic_heart_relation.size',
+                    'searchable' => 'true',
+                    'orderable' => 'true',
+                ],
+            ],
+            // Matches a single heart, as "heart-2" would also match "heart-20".
+            'search' => ['value' => 'heart-20'],
+        ]);
+
+        $response->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 60,
+            'recordsFiltered' => 3,
+        ]);
+    }
+}

--- a/tests/Integration/SnakeCaseRelationTest.php
+++ b/tests/Integration/SnakeCaseRelationTest.php
@@ -94,6 +94,103 @@ class SnakeCaseRelationTest extends TestCase
         ]);
     }
 
+    #[Test]
+    public function it_can_perform_global_search_on_a_nested_snake_case_relation_name()
+    {
+        $response = $this->call('GET', '/relations/nestedSnakeCase', [
+            'columns' => [
+                [
+                    'data' => 'user.nested_filtered_heart.size',
+                    'name' => 'user.nested_filtered_heart.size',
+                    'searchable' => 'true',
+                    'orderable' => 'true',
+                ],
+            ],
+            'search' => ['value' => 'heart-2'],
+        ]);
+
+        $response->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 60,
+            'recordsFiltered' => 3,
+        ]);
+    }
+
+    #[Test]
+    public function it_can_perform_column_search_on_a_nested_snake_case_relation_name()
+    {
+        $response = $this->call('GET', '/relations/nestedSnakeCase', [
+            'columns' => [
+                [
+                    'data' => 'user.nested_filtered_heart.size',
+                    'name' => 'user.nested_filtered_heart.size',
+                    'searchable' => 'true',
+                    'orderable' => 'true',
+                    'search' => ['value' => 'heart-2'],
+                ],
+            ],
+        ]);
+
+        $response->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 60,
+            'recordsFiltered' => 3,
+        ]);
+    }
+
+    #[Test]
+    public function it_can_sort_on_a_nested_snake_case_relation_name()
+    {
+        $response = $this->call('GET', '/relations/nestedSnakeCase', [
+            'columns' => [
+                [
+                    'data' => 'user.nested_filtered_heart.size',
+                    'name' => 'user.nested_filtered_heart.size',
+                    'searchable' => 'true',
+                    'orderable' => 'true',
+                ],
+            ],
+            'order' => [['column' => 0, 'dir' => 'desc']],
+            'start' => 0,
+            'length' => 10,
+            'draw' => 1,
+        ]);
+
+        $response->assertJson([
+            'draw' => 1,
+            'recordsTotal' => 60,
+            'recordsFiltered' => 60,
+        ]);
+
+        $this->assertEquals('heart-3', $response->json()['data'][0]['user']['nested_filtered_heart']['size']);
+    }
+
+    #[Test]
+    public function it_can_search_a_nested_snake_case_relation_that_is_not_eager_loaded()
+    {
+        $this->app['router']->get('/relations/nestedNotEagerLoaded', fn (DataTables $datatables) => $datatables
+            ->eloquent(Post::with('user')->select('posts.*'))
+            ->toJson());
+
+        $response = $this->call('GET', '/relations/nestedNotEagerLoaded', [
+            'columns' => [
+                [
+                    'data' => 'user.nested_filtered_heart.size',
+                    'name' => 'user.nested_filtered_heart.size',
+                    'searchable' => 'true',
+                    'orderable' => 'true',
+                ],
+            ],
+            'search' => ['value' => 'heart-2'],
+        ]);
+
+        $response->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 60,
+            'recordsFiltered' => 3,
+        ]);
+    }
+
     protected function getJsonResponse(array $params = [])
     {
         $data = [
@@ -116,6 +213,10 @@ class SnakeCaseRelationTest extends TestCase
 
         $this->app['router']->get('/relations/snakeCase', fn (DataTables $datatables) => $datatables
             ->eloquent(Post::with('postUser')->select('posts.*'))
+            ->toJson());
+
+        $this->app['router']->get('/relations/nestedSnakeCase', fn (DataTables $datatables) => $datatables
+            ->eloquent(Post::with('user.nestedFilteredHeart')->select('posts.*'))
             ->toJson());
     }
 }

--- a/tests/Integration/SnakeCaseRelationTest.php
+++ b/tests/Integration/SnakeCaseRelationTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Yajra\DataTables\Tests\Integration;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Yajra\DataTables\DataTables;
+use Yajra\DataTables\Tests\Models\Post;
+use Yajra\DataTables\Tests\TestCase;
+
+class SnakeCaseRelationTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_can_perform_global_search_on_a_snake_case_relation_name()
+    {
+        $response = $this->getJsonResponse([
+            'search' => ['value' => 'Email-19@example.com'],
+        ]);
+
+        $response->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 60,
+            'recordsFiltered' => 3,
+        ]);
+
+        $this->assertCount(3, $response->json()['data']);
+    }
+
+    #[Test]
+    public function it_can_perform_column_search_on_a_snake_case_relation_name()
+    {
+        $response = $this->getJsonResponse([
+            'columns' => [
+                [
+                    'data' => 'post_user.email',
+                    'name' => 'post_user.email',
+                    'searchable' => 'true',
+                    'orderable' => 'true',
+                    'search' => ['value' => 'Email-19@example.com'],
+                ],
+            ],
+        ]);
+
+        $response->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 60,
+            'recordsFiltered' => 3,
+        ]);
+
+        $this->assertCount(3, $response->json()['data']);
+    }
+
+    #[Test]
+    public function it_can_sort_on_a_snake_case_relation_name()
+    {
+        $response = $this->getJsonResponse([
+            'order' => [
+                ['column' => 0, 'dir' => 'desc'],
+            ],
+            'length' => 10,
+            'start' => 0,
+            'draw' => 1,
+        ]);
+
+        $response->assertJson([
+            'draw' => 1,
+            'recordsTotal' => 60,
+            'recordsFiltered' => 60,
+        ]);
+
+        $this->assertEquals('Email-9@example.com', $response->json()['data'][0]['post_user']['email']);
+    }
+
+    #[Test]
+    public function it_still_resolves_a_relation_that_is_named_in_snake_case()
+    {
+        $this->app['router']->get('/relations/snakeCaseDefined', fn (DataTables $datatables) => $datatables
+            ->eloquent(Post::with('user')->select('posts.*'))
+            ->toJson());
+
+        $response = $this->call('GET', '/relations/snakeCaseDefined', [
+            'columns' => [
+                ['data' => 'user.email', 'name' => 'user.email', 'searchable' => 'true', 'orderable' => 'true'],
+            ],
+            'search' => ['value' => 'Email-19@example.com'],
+        ]);
+
+        $response->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 60,
+            'recordsFiltered' => 3,
+        ]);
+    }
+
+    protected function getJsonResponse(array $params = [])
+    {
+        $data = [
+            'columns' => [
+                [
+                    'data' => 'post_user.email',
+                    'name' => 'post_user.email',
+                    'searchable' => 'true',
+                    'orderable' => 'true',
+                ],
+            ],
+        ];
+
+        return $this->call('GET', '/relations/snakeCase', array_merge($data, $params));
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app['router']->get('/relations/snakeCase', fn (DataTables $datatables) => $datatables
+            ->eloquent(Post::with('postUser')->select('posts.*'))
+            ->toJson());
+    }
+}

--- a/tests/Models/Post.php
+++ b/tests/Models/Post.php
@@ -18,6 +18,11 @@ class Post extends Model
         return $this->belongsTo(User::class);
     }
 
+    public function postUser()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
     public function heart()
     {
         return $this->hasOneThrough(Heart::class, User::class, 'id', 'user_id', 'user_id', 'id');

--- a/tests/Models/Post.php
+++ b/tests/Models/Post.php
@@ -23,6 +23,11 @@ class Post extends Model
         return $this->belongsTo(User::class, 'user_id');
     }
 
+    public function post_user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
     public function heart()
     {
         return $this->hasOneThrough(Heart::class, User::class, 'id', 'user_id', 'user_id', 'id');


### PR DESCRIPTION
Closes #2324

## Problem

Eager loaded relations are matched against the column name as given, but relations are defined in camel case while column names are usually written in snake case. A column named `child_table.name` is looked up as the relation `child_table`, which is never in `getEagerLoads()`, so the column falls through to the plain query search and produces an unknown column or missing table error.

The workaround is to write the name twice on the JS side:

```js
{data: 'child_table.name', name: 'childTable.name'}
```

## Solution

When the relation taken from the column name is not eager loaded, its camel case form is used if that one is. As suggested in the issue discussion, this makes both spellings work:

```js
{data: 'child_table.name', name: 'childTable.name'} // still works
{data: 'child_table.name'}                          // now works too
```

The fallback only applies when the literal name is not an eager loaded relation, so a relation genuinely defined as `child_table()` keeps resolving to itself and nothing that works today changes.

## Changes

- `EloquentDataTable::resolveRelationName()` resolves a relation name against the eager loads, falling back to `Str::camel()`.
- Applied in `compileQuerySearch()` (global and column search, including nested relations) and `resolveRelationColumn()` (ordering and joins), so search and ordering behave the same way.
- `tests/Integration/SnakeCaseRelationTest.php` covers global search, column search, and ordering on a snake case column name, plus a regression test that a relation resolving under its literal name is untouched. Three of these fail on the current implementation.

## Notes

- Nested relations are handled as well, since `Str::camel('child_table.sub_table')` resolves to `childTable.subTable`.
- A `postUser` relation was added to the `Post` test model to have a relation whose camel case name differs from the column name.
- `composer stan` passes and the existing test suite is unchanged.
