### PR TITLE
feat: add a max_length config to cap the records per request

### DIFF
--- a/src/DataTableAbstract.php
+++ b/src/DataTableAbstract.php
@@ -1044,6 +1044,21 @@ abstract class DataTableAbstract implements DataTable
         return $this;
     }
 
+    /**
+     * Ignore the maximum length configured via datatables.max_length.
+     *
+     * Use it when all the records are needed no matter the configured
+     * maximum, e.g. when exporting every filtered record.
+     *
+     * @return $this
+     */
+    public function ignoreMaxLength(): static
+    {
+        $this->request->ignoreMaxLength();
+
+        return $this;
+    }
+
     protected function validateMinLengthSearch(): void
     {
         if ($this->request->isSearchable()

--- a/src/DataTablesServiceProvider.php
+++ b/src/DataTablesServiceProvider.php
@@ -26,6 +26,7 @@ class DataTablesServiceProvider extends ServiceProvider
         $this->app->alias('datatables', DataTables::class);
         $this->app->singleton('datatables', fn () => new DataTables);
 
+        $this->app->alias('datatables.request', Request::class);
         $this->app->singleton('datatables.request', fn () => new Request);
 
         $this->app->singleton('datatables.config', DataTablesConfig::class);

--- a/src/DataTablesServiceProvider.php
+++ b/src/DataTablesServiceProvider.php
@@ -26,8 +26,11 @@ class DataTablesServiceProvider extends ServiceProvider
         $this->app->alias('datatables', DataTables::class);
         $this->app->singleton('datatables', fn () => new DataTables);
 
+        // Scoped and not shared, so that the request state, e.g. the flag set
+        // by ignoreMaxLength(), does not leak into the next request of a long
+        // running worker such as Octane.
         $this->app->alias('datatables.request', Request::class);
-        $this->app->singleton('datatables.request', fn () => new Request);
+        $this->app->scoped('datatables.request', fn () => new Request);
 
         $this->app->singleton('datatables.config', DataTablesConfig::class);
     }

--- a/src/Utilities/Request.php
+++ b/src/Utilities/Request.php
@@ -11,6 +11,11 @@ use Illuminate\Support\Facades\Config;
 class Request
 {
     /**
+     * Flag to ignore the configured maximum length.
+     */
+    protected bool $ignoreMaxLength = false;
+
+    /**
      * Proxy non-existing method calls to base request class.
      *
      * @param  string  $name
@@ -259,9 +264,28 @@ class Request
      */
     public function maxLength(): int
     {
+        if ($this->ignoreMaxLength) {
+            return 0;
+        }
+
         $maxLength = Config::get('datatables.max_length');
 
         return is_numeric($maxLength) ? intval($maxLength) : 0;
+    }
+
+    /**
+     * Ignore the configured maximum length.
+     *
+     * Needed when all the records are wanted no matter the configured maximum,
+     * e.g. when exporting every filtered record.
+     *
+     * @return $this
+     */
+    public function ignoreMaxLength(bool $ignore = true): static
+    {
+        $this->ignoreMaxLength = $ignore;
+
+        return $this;
     }
 
     /**

--- a/src/Utilities/Request.php
+++ b/src/Utilities/Request.php
@@ -281,9 +281,9 @@ class Request
      *
      * @return $this
      */
-    public function ignoreMaxLength(bool $ignore = true): static
+    public function ignoreMaxLength(): static
     {
-        $this->ignoreMaxLength = $ignore;
+        $this->ignoreMaxLength = true;
 
         return $this;
     }

--- a/src/Utilities/Request.php
+++ b/src/Utilities/Request.php
@@ -3,6 +3,7 @@
 namespace Yajra\DataTables\Utilities;
 
 use Illuminate\Http\Request as BaseRequest;
+use Illuminate\Support\Facades\Config;
 
 /**
  * @mixin BaseRequest
@@ -210,6 +211,12 @@ class Request
      */
     public function isPaginationable(): bool
     {
+        // A maximum length is enforced on every request, including the ones
+        // asking for all the records by not sending any length at all.
+        if ($this->maxLength() > 0) {
+            return true;
+        }
+
         return ! is_null(request()->input('start')) &&
             ! is_null(request()->input('length')) &&
             request()->input('length') != -1;
@@ -236,8 +243,25 @@ class Request
     public function length(): int
     {
         $length = request()->input('length', 10);
+        $length = is_numeric($length) ? intval($length) : 10;
 
-        return is_numeric($length) ? intval($length) : 10;
+        $maxLength = $this->maxLength();
+
+        if ($maxLength > 0 && ($length < 1 || $length > $maxLength)) {
+            return $maxLength;
+        }
+
+        return $length;
+    }
+
+    /**
+     * Get the maximum number of records that can be requested per page.
+     */
+    public function maxLength(): int
+    {
+        $maxLength = Config::get('datatables.max_length');
+
+        return is_numeric($maxLength) ? intval($maxLength) : 0;
     }
 
     /**

--- a/src/config/datatables.php
+++ b/src/config/datatables.php
@@ -47,6 +47,13 @@ return [
     'index_column' => 'DT_RowIndex',
 
     /*
+     * Maximum number of records that can be requested per page.
+     * A request asking for more, or for all the records using a length of -1,
+     * is capped to this value. Set to null to allow any length.
+     */
+    'max_length' => null,
+
+    /*
      * List of available builders for DataTables.
      * This is where you can register your custom DataTables builder.
      */

--- a/tests/Integration/MaxLengthTest.php
+++ b/tests/Integration/MaxLengthTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\Test;
 use Yajra\DataTables\DataTables;
 use Yajra\DataTables\Tests\Models\User;
 use Yajra\DataTables\Tests\TestCase;
+use Yajra\DataTables\Utilities\Request;
 
 class MaxLengthTest extends TestCase
 {
@@ -108,6 +109,26 @@ class MaxLengthTest extends TestCase
         // This is how an export gets every filtered record, as done by
         // laravel-datatables-buttons before calling the ajax response.
         app('datatables.request')->ignoreMaxLength();
+
+        $response = $this->call('GET', '/max-length', ['start' => 0, 'length' => -1]);
+
+        $this->assertCount(20, $response->json()['data']);
+    }
+
+    #[Test]
+    public function it_resolves_the_same_request_instance_from_the_class_name()
+    {
+        // The request has to be shared, otherwise ignoreMaxLength() would be
+        // set on another instance than the one used by the engines.
+        $this->assertSame(app('datatables.request'), app(Request::class));
+    }
+
+    #[Test]
+    public function it_can_ignore_the_maximum_through_the_request_class_name()
+    {
+        config(['datatables.max_length' => 5]);
+
+        app(Request::class)->ignoreMaxLength();
 
         $response = $this->call('GET', '/max-length', ['start' => 0, 'length' => -1]);
 

--- a/tests/Integration/MaxLengthTest.php
+++ b/tests/Integration/MaxLengthTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Yajra\DataTables\Tests\Integration;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Yajra\DataTables\DataTables;
+use Yajra\DataTables\Tests\Models\User;
+use Yajra\DataTables\Tests\TestCase;
+
+class MaxLengthTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_returns_all_records_when_no_max_length_is_set()
+    {
+        $response = $this->call('GET', '/max-length');
+
+        $response->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 20,
+            'recordsFiltered' => 20,
+        ]);
+
+        $this->assertCount(20, $response->json()['data']);
+    }
+
+    #[Test]
+    public function it_caps_a_request_without_a_length()
+    {
+        config(['datatables.max_length' => 5]);
+
+        $response = $this->call('GET', '/max-length');
+
+        $response->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 20,
+            'recordsFiltered' => 20,
+        ]);
+
+        $this->assertCount(5, $response->json()['data']);
+    }
+
+    #[Test]
+    public function it_caps_a_request_asking_for_all_the_records()
+    {
+        config(['datatables.max_length' => 5]);
+
+        $response = $this->call('GET', '/max-length', ['start' => 0, 'length' => -1]);
+
+        $this->assertCount(5, $response->json()['data']);
+    }
+
+    #[Test]
+    public function it_caps_a_length_that_is_over_the_maximum()
+    {
+        config(['datatables.max_length' => 5]);
+
+        $response = $this->call('GET', '/max-length', ['start' => 0, 'length' => 100]);
+
+        $this->assertCount(5, $response->json()['data']);
+    }
+
+    #[Test]
+    public function it_keeps_a_length_that_is_below_the_maximum()
+    {
+        config(['datatables.max_length' => 5]);
+
+        $response = $this->call('GET', '/max-length', ['start' => 0, 'length' => 2]);
+
+        $this->assertCount(2, $response->json()['data']);
+    }
+
+    #[Test]
+    public function it_still_paginates_from_the_requested_start()
+    {
+        config(['datatables.max_length' => 5]);
+
+        $response = $this->call('GET', '/max-length', ['start' => 5, 'length' => -1]);
+
+        $data = $response->json()['data'];
+
+        $this->assertCount(5, $data);
+        $this->assertEquals('Record-6', $data[0]['name']);
+    }
+
+    #[Test]
+    public function it_caps_a_collection_data_table_as_well()
+    {
+        config(['datatables.max_length' => 5]);
+
+        $this->app['router']->get('/max-length-collection', fn (DataTables $datatables) => $datatables
+            ->collection(User::all())
+            ->toJson());
+
+        $response = $this->call('GET', '/max-length-collection', ['start' => 0, 'length' => -1]);
+
+        $this->assertCount(5, $response->json()['data']);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app['router']->get('/max-length', fn (DataTables $datatables) => $datatables
+            ->eloquent(User::query())
+            ->toJson());
+    }
+}

--- a/tests/Integration/MaxLengthTest.php
+++ b/tests/Integration/MaxLengthTest.php
@@ -116,6 +116,22 @@ class MaxLengthTest extends TestCase
     }
 
     #[Test]
+    public function it_does_not_keep_ignoring_the_maximum_on_the_next_request()
+    {
+        config(['datatables.max_length' => 5]);
+
+        app('datatables.request')->ignoreMaxLength();
+
+        // A long running worker, e.g. Octane, reuses the container between
+        // requests, so the flag must not survive into the next one.
+        $this->app->forgetScopedInstances();
+
+        $response = $this->call('GET', '/max-length', ['start' => 0, 'length' => -1]);
+
+        $this->assertCount(5, $response->json()['data']);
+    }
+
+    #[Test]
     public function it_resolves_the_same_request_instance_from_the_class_name()
     {
         // The request has to be shared, otherwise ignoreMaxLength() would be

--- a/tests/Integration/MaxLengthTest.php
+++ b/tests/Integration/MaxLengthTest.php
@@ -86,6 +86,35 @@ class MaxLengthTest extends TestCase
     }
 
     #[Test]
+    public function it_can_ignore_the_maximum_on_the_data_table()
+    {
+        config(['datatables.max_length' => 5]);
+
+        $this->app['router']->get('/max-length-ignored', fn (DataTables $datatables) => $datatables
+            ->eloquent(User::query())
+            ->ignoreMaxLength()
+            ->toJson());
+
+        $response = $this->call('GET', '/max-length-ignored', ['start' => 0, 'length' => -1]);
+
+        $this->assertCount(20, $response->json()['data']);
+    }
+
+    #[Test]
+    public function it_can_ignore_the_maximum_on_the_request()
+    {
+        config(['datatables.max_length' => 5]);
+
+        // This is how an export gets every filtered record, as done by
+        // laravel-datatables-buttons before calling the ajax response.
+        app('datatables.request')->ignoreMaxLength();
+
+        $response = $this->call('GET', '/max-length', ['start' => 0, 'length' => -1]);
+
+        $this->assertCount(20, $response->json()['data']);
+    }
+
+    #[Test]
     public function it_caps_a_collection_data_table_as_well()
     {
         config(['datatables.max_length' => 5]);


### PR DESCRIPTION
Closes #2493
Closes #1597

## Problem

There is no way to cap how many records a single request can pull. A client can send `length=-1`, or simply omit `start` and `length`, and get the whole table back. On a public endpoint that is an easy way to put load on the server, and it is the reason both issues were opened.

The suggested workaround was a middleware rewriting the request:

```php
if (request('length') > 100) {
    request()->merge(['length' => 100]);
}
```

That has to be repeated per project and still does not cover a request that sends no length at all.

## Solution

A `max_length` config option, `null` by default so nothing changes unless it is set:

```php
/*
 * Maximum number of records that can be requested per page.
 * A request asking for more, or for all the records using a length of -1,
 * is capped to this value. Set to null to allow any length.
 */
'max_length' => null,
```

When set, it caps every response:

| request | without max_length | with `max_length => 100` |
| --- | --- | --- |
| `length=25` | 25 records | 25 records |
| `length=5000` | 5000 records | 100 records |
| `length=-1` | all records | 100 records |
| no `start` / `length` | all records | 100 records |

The requested `start` is still honoured, so paging keeps working against the capped length.

## Opting out, for exports

You raised the export case, and it was a real regression: buttons forces `length => -1` in `getAjaxResponseData()` to collect every filtered record, so the cap would have truncated every export. There is now an escape hatch:

```php
app('datatables.request')->ignoreMaxLength(); // or $dataTable->ignoreMaxLength();
```

It is set on the request object rather than derived from the request input, so a client cannot send something to bypass the configured maximum. The matching one line change for buttons is yajra/laravel-datatables-buttons#214.

Two things were needed to make that work correctly:

- `Utilities\Request` is now aliased to `datatables.request`. The engines resolve the request from `datatables.request` while buttons resolves it from the class name, and those were two different instances, so the flag would never have reached the engine.
- The binding is `scoped` instead of `singleton`. `ignoreMaxLength()` is the first state ever held on the request object, and a shared instance would keep the cap disabled for every later request of a long running worker such as Octane.

## Changes

- `Request::maxLength()` reads the config value, returning 0 when unset or when ignored.
- `Request::length()` returns the maximum when the requested length is above it or is a "give me everything" value.
- `Request::isPaginationable()` returns true when a maximum is configured, so that a request with `length=-1` or no paging parameters at all is paginated instead of returning the full table.
- `Request::ignoreMaxLength()` and the fluent `DataTableAbstract::ignoreMaxLength()` opt a request out.
- `tests/Integration/MaxLengthTest.php` covers the unset default, a request with no parameters, `length=-1`, a length above and below the maximum, paging from a non zero start, the collection engine, both opt out entry points, that the request resolves to the same instance under both keys, and that the opt out does not survive into the next request.

## Notes

- Default is `null`, so the behaviour of existing applications is unchanged until they opt in.
- The cap lives in `Utilities\Request`, so every engine that pages through `request->length()` (eloquent, query, collection, resource, paginator) is covered by the same rule.
- `recordsTotal` and `recordsFiltered` still report the real counts, so the client side pager stays correct.
- `composer stan` passes and the existing test suite is unchanged.
