### PR TITLE
perf: resolve collection sort columns once instead of per comparison

### DIFF
--- a/src/CollectionDataTable.php
+++ b/src/CollectionDataTable.php
@@ -277,17 +277,7 @@ class CollectionDataTable extends DataTableAbstract
         if (! empty($criteria)) {
             $sorter = $this->getSorter($criteria);
 
-            $this->collection = $this->collection
-                ->map(fn ($data) => Arr::dot($data))
-                ->sort($sorter)
-                ->map(function ($data) {
-                    foreach ($data as $key => $value) {
-                        unset($data[$key]);
-                        Arr::set($data, $key, $value);
-                    }
-
-                    return $data;
-                });
+            $this->collection = $this->collection->sort($sorter);
         }
     }
 
@@ -296,9 +286,16 @@ class CollectionDataTable extends DataTableAbstract
      */
     protected function getSorter(array $criteria): Closure
     {
+        // The column names are resolved once instead of on every comparison,
+        // as sorting calls the sorter n log n times.
+        $criteria = array_map(fn ($orderable) => [
+            'column' => $this->getColumnName($orderable['column']),
+            'direction' => $orderable['direction'],
+        ], $criteria);
+
         return function ($a, $b) use ($criteria) {
             foreach ($criteria as $orderable) {
-                $column = $this->getColumnName($orderable['column']);
+                $column = $orderable['column'];
                 $direction = $orderable['direction'];
                 if ($direction === 'desc') {
                     $first = $b;
@@ -307,18 +304,16 @@ class CollectionDataTable extends DataTableAbstract
                     $first = $a;
                     $second = $b;
                 }
-                if (is_numeric($first[$column] ?? null) && is_numeric($second[$column] ?? null)) {
-                    if ($first[$column] < $second[$column]) {
-                        $cmp = -1;
-                    } elseif ($first[$column] > $second[$column]) {
-                        $cmp = 1;
-                    } else {
-                        $cmp = 0;
-                    }
+
+                $firstValue = Arr::get($first, $column);
+                $secondValue = Arr::get($second, $column);
+
+                if (is_numeric($firstValue) && is_numeric($secondValue)) {
+                    $cmp = $firstValue <=> $secondValue;
                 } elseif ($this->config->isCaseInsensitive()) {
-                    $cmp = strnatcasecmp($first[$column] ?? '', $second[$column] ?? '');
+                    $cmp = strnatcasecmp($firstValue ?? '', $secondValue ?? '');
                 } else {
-                    $cmp = strnatcmp($first[$column] ?? '', $second[$column] ?? '');
+                    $cmp = strnatcmp($firstValue ?? '', $secondValue ?? '');
                 }
                 if ($cmp != 0) {
                     return $cmp;

--- a/tests/Integration/CollectionOrderingTest.php
+++ b/tests/Integration/CollectionOrderingTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Yajra\DataTables\Tests\Integration;
+
+use Illuminate\Http\JsonResponse;
+use PHPUnit\Framework\Attributes\Test;
+use Yajra\DataTables\Tests\TestCase;
+
+class CollectionOrderingTest extends TestCase
+{
+    #[Test]
+    public function it_can_sort_on_a_nested_column()
+    {
+        $this->orderBy('user.name');
+
+        $collection = collect([
+            ['id' => 1, 'user' => ['name' => 'Charlie']],
+            ['id' => 2, 'user' => ['name' => 'Alice']],
+            ['id' => 3, 'user' => ['name' => 'Bob']],
+        ]);
+
+        $this->assertEquals([
+            ['id' => 2, 'user' => ['name' => 'Alice']],
+            ['id' => 3, 'user' => ['name' => 'Bob']],
+            ['id' => 1, 'user' => ['name' => 'Charlie']],
+        ], $this->sortedData($collection));
+    }
+
+    #[Test]
+    public function it_keeps_the_structure_of_a_row_that_is_not_sorted_on()
+    {
+        $this->orderBy('name');
+
+        $collection = collect([
+            ['name' => 'B', 'roles' => [['role' => 'User']], 'meta' => []],
+            ['name' => 'A', 'roles' => [['role' => 'Administrator']], 'meta' => []],
+        ]);
+
+        $this->assertEquals([
+            ['name' => 'A', 'roles' => [['role' => 'Administrator']], 'meta' => []],
+            ['name' => 'B', 'roles' => [['role' => 'User']], 'meta' => []],
+        ], $this->sortedData($collection));
+    }
+
+    #[Test]
+    public function it_can_sort_numeric_values_of_a_nested_column()
+    {
+        $this->orderBy('user.amount');
+
+        $collection = collect([
+            ['user' => ['amount' => '100']],
+            ['user' => ['amount' => '9']],
+            ['user' => ['amount' => '10']],
+        ]);
+
+        $this->assertEquals([
+            ['user' => ['amount' => '9']],
+            ['user' => ['amount' => '10']],
+            ['user' => ['amount' => '100']],
+        ], $this->sortedData($collection));
+    }
+
+    protected function orderBy(string $column, string $direction = 'asc'): void
+    {
+        config()->set('app.debug', false);
+
+        request()->merge([
+            'columns' => [
+                ['data' => $column, 'name' => $column, 'searchable' => 'true', 'orderable' => 'true'],
+            ],
+            'order' => [['column' => 0, 'dir' => $direction]],
+            'start' => 0,
+            'length' => 10,
+            'draw' => 1,
+        ]);
+    }
+
+    protected function sortedData($collection): array
+    {
+        /** @var JsonResponse $response */
+        $response = app('datatables')->collection($collection)->toJson();
+
+        return $response->getData(true)['data'];
+    }
+}


### PR DESCRIPTION
Closes #1437

## Problem

Ordering a large collection is slow. Profiling a 15k row collection on PHP 8.4, the whole response takes about 1350 ms, of which roughly 1200 ms is the ordering alone. The same collection without ordering takes 163 ms.

The cost is not where it looks. `getSorter()` returns a comparator that calls `getColumnName()` for every criteria on every comparison, and `sort()` calls the comparator n log n times. For 15k rows that is a few hundred thousand calls, each doing a request lookup, two `preg` calls and a `Str::upper()`.

## Solution

Resolve the column names once when the sorter is built, instead of inside the comparator:

```php
$criteria = array_map(fn ($orderable) => [
    'column' => $this->getColumnName($orderable['column']),
    'direction' => $orderable['direction'],
], $criteria);
```

Measured on the same 15k row collection, ordered on a single column, two runs each:

| | before | after |
| --- | --- | --- |
| full response | 1327 ms / 1372 ms | 646 ms / 593 ms |

While in there, the flatten/sort/rebuild dance is also gone. `Arr::dot()` was only needed so the comparator could read a nested column as `$row['user.name']`, which `Arr::get()` does directly, so the two extra full passes over the collection are no longer necessary.

To be upfront about it: removing those two passes alone made no measurable difference in my runs. The entire win above comes from hoisting `getColumnName()` out of the comparator. The flatten removal is kept because it drops two rebuilds of every row for no benefit, not because it shows up in the numbers.

## Changes

- `CollectionDataTable::getSorter()` resolves the column names once, up front.
- `CollectionDataTable::defaultOrdering()` sorts the collection directly, and the comparator reads values through `Arr::get()`.
- The numeric branch of the comparator uses the spaceship operator instead of the manual if/elseif/else, which is the same comparison.
- `tests/Integration/CollectionOrderingTest.php` covers sorting on a nested column, sorting numeric values of a nested column, and that rows not being sorted on keep their structure.

## Notes

- Output is unchanged: the existing collection tests, including case insensitive and numeric string sorting, pass untouched.
- `composer stan` passes.
