### PR TITLE
fix: keep the relation constraints when joining an eager loaded relation

### DIFF
--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -11,6 +11,8 @@ use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
 use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Query\Builder as BaseQueryBuilder;
+use Illuminate\Database\Query\JoinClause;
 use Yajra\DataTables\Exceptions\Exception;
 
 /**
@@ -291,7 +293,7 @@ class EloquentDataTable extends QueryDataTable
                 default:
                     throw new Exception('Relation '.$model::class.' is not yet supported.');
             }
-            $this->performJoin($table, $foreign, $other);
+            $this->performRelationJoin($model, $table, $tableAlias, $foreign, $other);
             $lastQuery = $model->getQuery();
         }
 
@@ -321,14 +323,112 @@ class EloquentDataTable extends QueryDataTable
      */
     protected function performJoin($table, $foreign, $other, $type = 'left'): void
     {
+        if ($this->isJoined($table)) {
+            return;
+        }
+
+        $this->getBaseQueryBuilder()->join($table, $foreign, '=', $other, $type);
+    }
+
+    /**
+     * Perform the join of a relation, keeping the constraints it was declared with.
+     *
+     * A relation like hasOne(Translation::class)->where('lang', 'en') would
+     * otherwise be joined on its keys only, returning the rows of every language.
+     *
+     * @param  Relation<Model, Model, mixed>  $relation
+     */
+    protected function performRelationJoin(
+        Relation $relation,
+        string $table,
+        string $alias,
+        string $foreign,
+        string $other,
+        string $type = 'left'
+    ): void {
+        $constraints = $this->getRelationConstraints($relation, $alias);
+
+        if (! $constraints) {
+            $this->performJoin($table, $foreign, $other, $type);
+
+            return;
+        }
+
+        if ($this->isJoined($table)) {
+            return;
+        }
+
+        $this->getBaseQueryBuilder()->join(
+            $table,
+            function (JoinClause $join) use ($foreign, $other, $constraints) {
+                $join->on($foreign, '=', $other)
+                    ->mergeWheres($constraints['wheres'], $constraints['bindings']);
+            },
+            null,
+            null,
+            $type
+        );
+    }
+
+    /**
+     * Get the constraints a relation was declared with, if any.
+     *
+     * The relation is resolved without constraints, so its query only holds the
+     * conditions of the relation itself and not the ones on the related keys.
+     *
+     * @param  Relation<Model, Model, mixed>  $relation
+     * @return array{wheres: array, bindings: array}|null
+     */
+    protected function getRelationConstraints(Relation $relation, string $alias): ?array
+    {
+        $query = $relation->getQuery()->getQuery();
+
+        if (empty($query->wheres)) {
+            return null;
+        }
+
+        return [
+            'wheres' => $this->qualifyRelationWheres($query->wheres, $alias),
+            'bindings' => $query->getRawBindings()['where'] ?? [],
+        ];
+    }
+
+    /**
+     * Qualify the columns of the given wheres with the table of the joined relation.
+     */
+    protected function qualifyRelationWheres(array $wheres, string $alias): array
+    {
+        foreach ($wheres as $index => $where) {
+            $nested = $where['query'] ?? null;
+
+            if (($where['type'] ?? null) === 'Nested' && $nested instanceof BaseQueryBuilder) {
+                $nested = clone $nested;
+                $nested->wheres = $this->qualifyRelationWheres($nested->wheres, $alias);
+                $wheres[$index]['query'] = $nested;
+
+                continue;
+            }
+
+            $column = $where['column'] ?? null;
+
+            if (is_string($column) && ! str_contains($column, '.')) {
+                $wheres[$index]['column'] = $alias.'.'.$column;
+            }
+        }
+
+        return $wheres;
+    }
+
+    /**
+     * Check if the given table is already joined.
+     */
+    protected function isJoined(string $table): bool
+    {
         $joins = [];
-        $builder = $this->getBaseQueryBuilder();
-        foreach ($builder->joins ?? [] as $join) {
+        foreach ($this->getBaseQueryBuilder()->joins ?? [] as $join) {
             $joins[] = $join->table;
         }
 
-        if (! in_array($table, $joins)) {
-            $this->getBaseQueryBuilder()->join($table, $foreign, '=', $other, $type);
-        }
+        return in_array($table, $joins);
     }
 }

--- a/tests/Integration/RelationConstraintTest.php
+++ b/tests/Integration/RelationConstraintTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Yajra\DataTables\Tests\Integration;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Yajra\DataTables\EloquentDataTable;
+use Yajra\DataTables\Tests\Models\User;
+use Yajra\DataTables\Tests\TestCase;
+
+class RelationConstraintTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_applies_the_relation_constraints_on_the_join()
+    {
+        $sql = $this->orderedQuery()->toSql();
+
+        $this->assertStringContainsString(
+            'left join "hearts" on "hearts"."user_id" = "users"."id" and "hearts"."size" = ?',
+            $sql
+        );
+    }
+
+    #[Test]
+    public function it_binds_the_relation_constraints_of_the_join()
+    {
+        $this->assertEquals(['heart-2'], $this->orderedQuery()->getBindings());
+    }
+
+    #[Test]
+    public function it_only_joins_the_rows_matching_the_relation_constraints()
+    {
+        $response = $this->call('GET', '/relations/constrained', [
+            'columns' => [
+                [
+                    'data' => 'filtered_heart.size',
+                    'name' => 'filteredHeart.size',
+                    'searchable' => 'true',
+                    'orderable' => 'true',
+                ],
+            ],
+            'order' => [['column' => 0, 'dir' => 'desc']],
+            'start' => 0,
+            'length' => 10,
+            'draw' => 1,
+        ]);
+
+        $response->assertJson([
+            'draw' => 1,
+            'recordsTotal' => 20,
+            'recordsFiltered' => 20,
+        ]);
+
+        $data = $response->json()['data'];
+
+        // Only the heart matching the relation constraint is joined, so it is
+        // the only row with a value to sort on and comes first descending.
+        $this->assertCount(10, $data);
+        $this->assertEquals('Record-2', $data[0]['name']);
+        $this->assertEquals('heart-2', $data[0]['filtered_heart']['size']);
+
+        foreach (array_slice($data, 1) as $row) {
+            $this->assertNull($row['filtered_heart']);
+        }
+    }
+
+    #[Test]
+    public function it_applies_the_nested_constraints_of_a_relation()
+    {
+        request()->merge([
+            'columns' => [
+                [
+                    'data' => 'nested_filtered_heart.size',
+                    'name' => 'nestedFilteredHeart.size',
+                    'searchable' => 'true',
+                    'orderable' => 'true',
+                ],
+            ],
+            'order' => [['column' => 0, 'dir' => 'desc']],
+        ]);
+
+        $dataTable = new EloquentDataTable(User::with('nestedFilteredHeart')->select('users.*'));
+        $dataTable->ordering();
+
+        $this->assertStringContainsString(
+            'left join "hearts" on "hearts"."user_id" = "users"."id" and ("hearts"."size" = ? or "hearts"."size" = ?)',
+            $dataTable->getQuery()->toSql()
+        );
+        $this->assertEquals(['heart-2', 'heart-3'], $dataTable->getQuery()->getBindings());
+    }
+
+    #[Test]
+    public function it_keeps_joining_a_relation_without_constraints()
+    {
+        request()->merge([
+            'columns' => [
+                ['data' => 'heart.size', 'name' => 'heart.size', 'searchable' => 'true', 'orderable' => 'true'],
+            ],
+            'order' => [['column' => 0, 'dir' => 'asc']],
+        ]);
+
+        $dataTable = new EloquentDataTable(User::with('heart')->select('users.*'));
+        $dataTable->ordering();
+
+        $this->assertStringContainsString(
+            'left join "hearts" on "hearts"."user_id" = "users"."id"',
+            $dataTable->getQuery()->toSql()
+        );
+        $this->assertEmpty($dataTable->getQuery()->getBindings());
+    }
+
+    protected function orderedQuery()
+    {
+        request()->merge([
+            'columns' => [
+                [
+                    'data' => 'filtered_heart.size',
+                    'name' => 'filteredHeart.size',
+                    'searchable' => 'true',
+                    'orderable' => 'true',
+                ],
+            ],
+            'order' => [['column' => 0, 'dir' => 'desc']],
+        ]);
+
+        $dataTable = new EloquentDataTable(User::with('filteredHeart')->select('users.*'));
+        $dataTable->ordering();
+
+        return $dataTable->getQuery();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app['router']->get('/relations/constrained', fn () => (new EloquentDataTable(
+            User::with('filteredHeart')->select('users.*')
+        ))->toJson());
+    }
+}

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -18,6 +18,18 @@ class User extends Model
         return $this->hasOne(Heart::class);
     }
 
+    public function filteredHeart()
+    {
+        return $this->hasOne(Heart::class)->where('size', 'heart-2');
+    }
+
+    public function nestedFilteredHeart()
+    {
+        return $this->hasOne(Heart::class)->where(
+            fn ($query) => $query->where('size', 'heart-2')->orWhere('size', 'heart-3')
+        );
+    }
+
     public function roles()
     {
         return $this->belongsToMany(Role::class);


### PR DESCRIPTION
Closes #1325

## Problem

`joinEagerLoadedColumn()` joins an eager loaded relation on its keys only and drops the constraints the relation was declared with. A relation like

```php
public function translate()
{
    return $this->hasOne(FoodTranslator::class, 'food_id')->where('lang', app()->getLocale());
}
```

is joined as

```sql
left join "food_translator" on "food_translator"."food_id" = "foods"."id"
```

so sorting or searching on `translate.title` sees the rows of every language, not just the current one. The eager load itself still applies the constraint, which is why the data looks right while the ordering does not, and why a row can appear more than once.

## Solution

The constraints of the relation are merged into the `on` clause of the join:

```sql
left join "food_translator"
    on "food_translator"."food_id" = "foods"."id"
    and "food_translator"."lang" = ?
```

They go in the `on` clause and not in the `where` clause on purpose: a `where` on the joined table would turn the left join into an inner join and silently drop the parent rows that have no matching relation.

The relation is resolved through `Builder::getRelation()`, which builds it with `Relation::noConstraints()`, so its query holds the conditions declared on the relation itself and not the key conditions of the parent row. That is exactly the set that is missing from the join today. Unqualified columns are prefixed with the joined table, or its alias when `enableEagerJoinAliases()` is used.

## Changes

- `EloquentDataTable::performRelationJoin()` joins a relation with its own constraints, falling back to `performJoin()` when there are none, so a relation without constraints produces exactly the same SQL as before.
- `EloquentDataTable::getRelationConstraints()` reads the wheres and their bindings off the relation query.
- `EloquentDataTable::qualifyRelationWheres()` prefixes unqualified columns with the joined table, recursing into nested where groups.
- `EloquentDataTable::isJoined()` is the existing duplicate join guard, extracted so both join paths share it.
- `tests/Integration/RelationConstraintTest.php` covers the generated `on` clause, its bindings, a nested closure constraint, the resulting row set when ordering, and that a relation without constraints is untouched. Four of the five fail on the current implementation.

## Notes

- `performJoin()` keeps its signature, so an override of it in an application keeps working and is still used for every unconstrained join.
- Constraints already written with a table prefix, such as those added by `wherePivot()`, are left as they are.
- `composer stan` passes and the existing relation tests (`BelongsTo`, `HasOne`, `HasMany`, `HasOneThrough`, `BelongsToMany`, `MorphTo`, `DeepRelation`) pass unchanged.
