### PR TITLE
fix: resolve a nested relation morph check against its own model

### DIFF
--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as BaseQueryBuilder;
 use Illuminate\Database\Query\JoinClause;
+use Illuminate\Support\Str;
 use Yajra\DataTables\Exceptions\Exception;
 
 /**
@@ -92,7 +93,7 @@ class EloquentDataTable extends QueryDataTable
             }
 
             $parts = explode('.', $column);
-            $firstRelation = array_shift($parts);
+            $firstRelation = $this->resolveRelationName(array_shift($parts));
             $column = implode('.', $parts);
 
             if ($this->isMorphRelation($firstRelation)) {
@@ -114,7 +115,7 @@ class EloquentDataTable extends QueryDataTable
 
         $parts = explode('.', $column);
         $newColumn = array_pop($parts);
-        $relation = implode('.', $parts);
+        $relation = $this->resolveRelationName(implode('.', $parts));
 
         if (! $nested && $this->isNotEagerLoaded($relation)) {
             parent::compileQuerySearch($query, $column, $keyword, $boolean);
@@ -135,6 +136,24 @@ class EloquentDataTable extends QueryDataTable
                 parent::compileQuerySearch($query, $newColumn, $keyword, '');
             });
         }
+    }
+
+    /**
+     * Resolve the name of an eager loaded relation.
+     *
+     * Column names are usually written in snake case, e.g. "child_table.name",
+     * while the relation itself is defined in camel case. The camel case
+     * relation is therefore used when it is the eager loaded one.
+     */
+    protected function resolveRelationName(string $relation): string
+    {
+        if (! $relation || array_key_exists($relation, $this->query->getEagerLoads())) {
+            return $relation;
+        }
+
+        $camel = Str::camel($relation);
+
+        return array_key_exists($camel, $this->query->getEagerLoads()) ? $camel : $relation;
     }
 
     /**
@@ -190,7 +209,9 @@ class EloquentDataTable extends QueryDataTable
     {
         $parts = explode('.', $column);
         $columnName = array_pop($parts);
-        $relation = preg_replace('/\[.*?\]/', '', implode('.', $parts));
+        $relation = $this->resolveRelationName(
+            (string) preg_replace('/\[.*?\]/', '', implode('.', $parts))
+        );
 
         if ($this->isNotEagerLoaded($relation)) {
             return parent::resolveRelationColumn($column);

--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -269,7 +269,7 @@ class EloquentDataTable extends QueryDataTable
         $parts = explode('.', $relation);
         $firstRelation = array_shift($parts);
 
-        return method_exists($model, $firstRelation) && $model->$firstRelation() instanceof MorphTo;
+        return $model->isRelation($firstRelation) && $model->$firstRelation() instanceof MorphTo;
     }
 
     /**

--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -86,6 +86,10 @@ class EloquentDataTable extends QueryDataTable
      */
     protected function compileQuerySearch($query, string $column, string $keyword, string $boolean = 'or', bool $nested = false): void
     {
+        // Inside a where has callback the relations belong to the related
+        // model, and no longer to the one the data table was built from.
+        $context = $nested ? $query : null;
+
         if (substr_count($column, '.') > 1) {
             if ($this->isTableQualifiedColumn($query, $column)) {
                 parent::compileQuerySearch($query, $column, $keyword, $boolean);
@@ -94,10 +98,10 @@ class EloquentDataTable extends QueryDataTable
             }
 
             $parts = explode('.', $column);
-            $firstRelation = $this->resolveRelationName(array_shift($parts), $nested ? $query : null);
+            $firstRelation = $this->resolveRelationName(array_shift($parts), $context);
             $column = implode('.', $parts);
 
-            if ($this->isMorphRelation($firstRelation)) {
+            if ($this->isMorphRelationOf($this->modelOf($context), $firstRelation)) {
                 $query->{$boolean.'WhereHasMorph'}(
                     $firstRelation,
                     '*',
@@ -116,7 +120,7 @@ class EloquentDataTable extends QueryDataTable
 
         $parts = explode('.', $column);
         $newColumn = array_pop($parts);
-        $relation = $this->resolveRelationName(implode('.', $parts), $nested ? $query : null);
+        $relation = $this->resolveRelationName(implode('.', $parts), $context);
 
         if (! $nested && $this->isNotEagerLoaded($relation)) {
             parent::compileQuerySearch($query, $column, $keyword, $boolean);
@@ -124,7 +128,7 @@ class EloquentDataTable extends QueryDataTable
             return;
         }
 
-        if ($this->isMorphRelation($relation)) {
+        if ($this->isMorphRelationOf($this->modelOf($context), $relation)) {
             $query->{$boolean.'WhereHasMorph'}(
                 $relation,
                 '*',
@@ -250,15 +254,32 @@ class EloquentDataTable extends QueryDataTable
      */
     protected function isMorphRelation($relation)
     {
-        $isMorph = false;
-        if ($relation !== null && $relation !== '') {
-            $relationParts = explode('.', $relation);
-            $firstRelation = array_shift($relationParts);
-            $model = $this->query->getModel();
-            $isMorph = method_exists($model, $firstRelation) && $model->$firstRelation() instanceof MorphTo;
+        return $this->isMorphRelationOf($this->query->getModel(), (string) $relation);
+    }
+
+    /**
+     * Check if a relation of the given model is a morphed one or not.
+     */
+    protected function isMorphRelationOf(Model $model, string $relation): bool
+    {
+        if ($relation === '') {
+            return false;
         }
 
-        return $isMorph;
+        $parts = explode('.', $relation);
+        $firstRelation = array_shift($parts);
+
+        return method_exists($model, $firstRelation) && $model->$firstRelation() instanceof MorphTo;
+    }
+
+    /**
+     * Get the model the given query belongs to, defaulting to the root one.
+     *
+     * @param  QueryBuilder|EloquentBuilder|null  $query
+     */
+    protected function modelOf($query = null): Model
+    {
+        return $query instanceof BaseEloquentBuilder ? $query->getModel() : $this->query->getModel();
     }
 
     /**

--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -167,9 +167,52 @@ class EloquentDataTable extends QueryDataTable
             return $relation;
         }
 
-        $camel = Str::camel($relation);
+        $resolved = null;
+        $resolvedScore = -1;
 
-        return array_key_exists($camel, $this->query->getEagerLoads()) ? $camel : $relation;
+        foreach (array_keys($this->query->getEagerLoads()) as $eagerRelation) {
+            $score = $this->relationNameMatchScore($relation, (string) $eagerRelation);
+
+            if ($score !== null && $score > $resolvedScore) {
+                $resolved = (string) $eagerRelation;
+                $resolvedScore = $score;
+            }
+        }
+
+        return $resolved ?? $relation;
+    }
+
+    /**
+     * Score how well a relation matches an eager loaded one, segment by segment.
+     *
+     * Null means the two cannot be the same relation, otherwise the score is the
+     * number of segments that matched literally, so that an eager load spelled
+     * exactly like the column wins over one that only matches in camel case.
+     */
+    protected function relationNameMatchScore(string $relation, string $eagerRelation): ?int
+    {
+        $parts = explode('.', $relation);
+        $eagerParts = explode('.', $eagerRelation);
+
+        if (count($parts) !== count($eagerParts)) {
+            return null;
+        }
+
+        $score = 0;
+
+        foreach ($parts as $index => $part) {
+            if ($part === $eagerParts[$index]) {
+                $score++;
+
+                continue;
+            }
+
+            if (Str::camel($part) !== $eagerParts[$index]) {
+                return null;
+            }
+        }
+
+        return $score;
     }
 
     /**
@@ -177,13 +220,13 @@ class EloquentDataTable extends QueryDataTable
      */
     protected function resolveRelationNameOf(Model $model, string $relation): string
     {
-        if (method_exists($model, $relation)) {
+        if ($model->isRelation($relation)) {
             return $relation;
         }
 
         $camel = Str::camel($relation);
 
-        return method_exists($model, $camel) ? $camel : $relation;
+        return $model->isRelation($camel) ? $camel : $relation;
     }
 
     /**

--- a/src/EloquentDataTable.php
+++ b/src/EloquentDataTable.php
@@ -4,6 +4,7 @@ namespace Yajra\DataTables;
 
 use Illuminate\Contracts\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Contracts\Database\Query\Builder as QueryBuilder;
+use Illuminate\Database\Eloquent\Builder as BaseEloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -93,7 +94,7 @@ class EloquentDataTable extends QueryDataTable
             }
 
             $parts = explode('.', $column);
-            $firstRelation = $this->resolveRelationName(array_shift($parts));
+            $firstRelation = $this->resolveRelationName(array_shift($parts), $nested ? $query : null);
             $column = implode('.', $parts);
 
             if ($this->isMorphRelation($firstRelation)) {
@@ -115,7 +116,7 @@ class EloquentDataTable extends QueryDataTable
 
         $parts = explode('.', $column);
         $newColumn = array_pop($parts);
-        $relation = $this->resolveRelationName(implode('.', $parts));
+        $relation = $this->resolveRelationName(implode('.', $parts), $nested ? $query : null);
 
         if (! $nested && $this->isNotEagerLoaded($relation)) {
             parent::compileQuerySearch($query, $column, $keyword, $boolean);
@@ -144,16 +145,45 @@ class EloquentDataTable extends QueryDataTable
      * Column names are usually written in snake case, e.g. "child_table.name",
      * while the relation itself is defined in camel case. The camel case
      * relation is therefore used when it is the eager loaded one.
+     *
+     * Pass the query of a where has callback to resolve a nested relation. The
+     * eager loads of the root query are keyed by their full path, e.g.
+     * "user.childTable", so a nested name is resolved against the related
+     * model it belongs to instead.
+     *
+     * @param  QueryBuilder|EloquentBuilder|null  $query
      */
-    protected function resolveRelationName(string $relation): string
+    protected function resolveRelationName(string $relation, $query = null): string
     {
-        if (! $relation || array_key_exists($relation, $this->query->getEagerLoads())) {
+        if (! $relation) {
+            return $relation;
+        }
+
+        if ($query instanceof BaseEloquentBuilder) {
+            return $this->resolveRelationNameOf($query->getModel(), $relation);
+        }
+
+        if (array_key_exists($relation, $this->query->getEagerLoads())) {
             return $relation;
         }
 
         $camel = Str::camel($relation);
 
         return array_key_exists($camel, $this->query->getEagerLoads()) ? $camel : $relation;
+    }
+
+    /**
+     * Resolve the name of a relation against the model that declares it.
+     */
+    protected function resolveRelationNameOf(Model $model, string $relation): string
+    {
+        if (method_exists($model, $relation)) {
+            return $relation;
+        }
+
+        $camel = Str::camel($relation);
+
+        return method_exists($model, $camel) ? $camel : $relation;
     }
 
     /**

--- a/tests/Integration/MixedCaseRelationTest.php
+++ b/tests/Integration/MixedCaseRelationTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Yajra\DataTables\Tests\Integration;
+
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Yajra\DataTables\DataTables;
+use Yajra\DataTables\Tests\Models\Heart;
+use Yajra\DataTables\Tests\Models\Post;
+use Yajra\DataTables\Tests\Models\User;
+use Yajra\DataTables\Tests\TestCase;
+
+class MixedCaseRelationTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_can_sort_on_a_path_mixing_a_literal_snake_case_and_a_camel_case_relation()
+    {
+        $this->app['router']->get('/relations/mixedCase', fn (DataTables $datatables) => $datatables
+            ->eloquent(Post::with('post_user.nestedFilteredHeart')->select('posts.*'))
+            ->toJson());
+
+        $response = $this->call('GET', '/relations/mixedCase', [
+            'columns' => [
+                [
+                    'data' => 'post_user.nested_filtered_heart.size',
+                    'name' => 'post_user.nested_filtered_heart.size',
+                    'searchable' => 'true',
+                    'orderable' => 'true',
+                ],
+            ],
+            'order' => [['column' => 0, 'dir' => 'desc']],
+            'start' => 0,
+            'length' => 10,
+            'draw' => 1,
+        ]);
+
+        $response->assertJson([
+            'draw' => 1,
+            'recordsTotal' => 60,
+            'recordsFiltered' => 60,
+        ]);
+
+        $this->assertEquals(
+            'heart-3',
+            $response->json()['data'][0]['post_user']['nested_filtered_heart']['size']
+        );
+    }
+
+    #[Test]
+    public function it_can_search_a_relation_registered_with_resolve_relation_using()
+    {
+        User::resolveRelationUsing(
+            'dynamicHeartRelation',
+            fn (User $user): HasOne => $user->hasOne(Heart::class),
+        );
+
+        $this->app['router']->get('/relations/dynamic', fn (DataTables $datatables) => $datatables
+            ->eloquent(Post::with('post_user.dynamicHeartRelation')->select('posts.*'))
+            ->toJson());
+
+        $response = $this->call('GET', '/relations/dynamic', [
+            'columns' => [
+                [
+                    'data' => 'post_user.dynamic_heart_relation.size',
+                    'name' => 'post_user.dynamic_heart_relation.size',
+                    'searchable' => 'true',
+                    'orderable' => 'true',
+                ],
+            ],
+            // Matches a single heart, as "heart-2" would also match "heart-20".
+            'search' => ['value' => 'heart-20'],
+        ]);
+
+        $response->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 60,
+            'recordsFiltered' => 3,
+        ]);
+    }
+}

--- a/tests/Integration/NestedMorphRelationTest.php
+++ b/tests/Integration/NestedMorphRelationTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Yajra\DataTables\Tests\Integration;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Yajra\DataTables\DataTables;
+use Yajra\DataTables\Tests\Models\Post;
+use Yajra\DataTables\Tests\Models\User;
+use Yajra\DataTables\Tests\TestCase;
+
+class NestedMorphRelationTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_does_not_treat_a_nested_relation_as_a_morph_of_the_root_model()
+    {
+        // User::user() is a morph relation while Post::user() is not, so the
+        // nested relation must be resolved against the post and not the user.
+        $this->app['router']->get('/relations/nestedNotMorph', fn (DataTables $datatables) => $datatables
+            ->eloquent(User::with('posts.user')->select('users.*'))
+            ->toJson());
+
+        $response = $this->call('GET', '/relations/nestedNotMorph', [
+            'columns' => [
+                [
+                    'data' => 'posts.user.name',
+                    'name' => 'posts.user.name',
+                    'searchable' => 'true',
+                    'orderable' => 'true',
+                ],
+            ],
+            'search' => ['value' => 'Record-19'],
+        ]);
+
+        $response->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 20,
+            'recordsFiltered' => 1,
+        ]);
+
+        $this->assertEquals('Record-19', $response->json()['data'][0]['name']);
+    }
+
+    #[Test]
+    public function it_still_searches_a_nested_morph_relation()
+    {
+        $this->app['router']->get('/relations/nestedMorph', fn (DataTables $datatables) => $datatables
+            ->eloquent(Post::with('user.user')->select('posts.*'))
+            ->toJson());
+
+        $response = $this->call('GET', '/relations/nestedMorph', [
+            'columns' => [
+                [
+                    'data' => 'user.user.name',
+                    'name' => 'user.user.name',
+                    'searchable' => 'true',
+                    'orderable' => 'true',
+                ],
+            ],
+            'search' => ['value' => 'Human'],
+        ]);
+
+        $response->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 60,
+            'recordsFiltered' => 30,
+        ]);
+    }
+}

--- a/tests/Integration/SnakeCaseRelationTest.php
+++ b/tests/Integration/SnakeCaseRelationTest.php
@@ -94,6 +94,103 @@ class SnakeCaseRelationTest extends TestCase
         ]);
     }
 
+    #[Test]
+    public function it_can_perform_global_search_on_a_nested_snake_case_relation_name()
+    {
+        $response = $this->call('GET', '/relations/nestedSnakeCase', [
+            'columns' => [
+                [
+                    'data' => 'user.nested_filtered_heart.size',
+                    'name' => 'user.nested_filtered_heart.size',
+                    'searchable' => 'true',
+                    'orderable' => 'true',
+                ],
+            ],
+            'search' => ['value' => 'heart-2'],
+        ]);
+
+        $response->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 60,
+            'recordsFiltered' => 3,
+        ]);
+    }
+
+    #[Test]
+    public function it_can_perform_column_search_on_a_nested_snake_case_relation_name()
+    {
+        $response = $this->call('GET', '/relations/nestedSnakeCase', [
+            'columns' => [
+                [
+                    'data' => 'user.nested_filtered_heart.size',
+                    'name' => 'user.nested_filtered_heart.size',
+                    'searchable' => 'true',
+                    'orderable' => 'true',
+                    'search' => ['value' => 'heart-2'],
+                ],
+            ],
+        ]);
+
+        $response->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 60,
+            'recordsFiltered' => 3,
+        ]);
+    }
+
+    #[Test]
+    public function it_can_sort_on_a_nested_snake_case_relation_name()
+    {
+        $response = $this->call('GET', '/relations/nestedSnakeCase', [
+            'columns' => [
+                [
+                    'data' => 'user.nested_filtered_heart.size',
+                    'name' => 'user.nested_filtered_heart.size',
+                    'searchable' => 'true',
+                    'orderable' => 'true',
+                ],
+            ],
+            'order' => [['column' => 0, 'dir' => 'desc']],
+            'start' => 0,
+            'length' => 10,
+            'draw' => 1,
+        ]);
+
+        $response->assertJson([
+            'draw' => 1,
+            'recordsTotal' => 60,
+            'recordsFiltered' => 60,
+        ]);
+
+        $this->assertEquals('heart-3', $response->json()['data'][0]['user']['nested_filtered_heart']['size']);
+    }
+
+    #[Test]
+    public function it_can_search_a_nested_snake_case_relation_that_is_not_eager_loaded()
+    {
+        $this->app['router']->get('/relations/nestedNotEagerLoaded', fn (DataTables $datatables) => $datatables
+            ->eloquent(Post::with('user')->select('posts.*'))
+            ->toJson());
+
+        $response = $this->call('GET', '/relations/nestedNotEagerLoaded', [
+            'columns' => [
+                [
+                    'data' => 'user.nested_filtered_heart.size',
+                    'name' => 'user.nested_filtered_heart.size',
+                    'searchable' => 'true',
+                    'orderable' => 'true',
+                ],
+            ],
+            'search' => ['value' => 'heart-2'],
+        ]);
+
+        $response->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 60,
+            'recordsFiltered' => 3,
+        ]);
+    }
+
     protected function getJsonResponse(array $params = [])
     {
         $data = [
@@ -116,6 +213,10 @@ class SnakeCaseRelationTest extends TestCase
 
         $this->app['router']->get('/relations/snakeCase', fn (DataTables $datatables) => $datatables
             ->eloquent(Post::with('postUser')->select('posts.*'))
+            ->toJson());
+
+        $this->app['router']->get('/relations/nestedSnakeCase', fn (DataTables $datatables) => $datatables
+            ->eloquent(Post::with('user.nestedFilteredHeart')->select('posts.*'))
             ->toJson());
     }
 }

--- a/tests/Integration/SnakeCaseRelationTest.php
+++ b/tests/Integration/SnakeCaseRelationTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Yajra\DataTables\Tests\Integration;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Yajra\DataTables\DataTables;
+use Yajra\DataTables\Tests\Models\Post;
+use Yajra\DataTables\Tests\TestCase;
+
+class SnakeCaseRelationTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_can_perform_global_search_on_a_snake_case_relation_name()
+    {
+        $response = $this->getJsonResponse([
+            'search' => ['value' => 'Email-19@example.com'],
+        ]);
+
+        $response->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 60,
+            'recordsFiltered' => 3,
+        ]);
+
+        $this->assertCount(3, $response->json()['data']);
+    }
+
+    #[Test]
+    public function it_can_perform_column_search_on_a_snake_case_relation_name()
+    {
+        $response = $this->getJsonResponse([
+            'columns' => [
+                [
+                    'data' => 'post_user.email',
+                    'name' => 'post_user.email',
+                    'searchable' => 'true',
+                    'orderable' => 'true',
+                    'search' => ['value' => 'Email-19@example.com'],
+                ],
+            ],
+        ]);
+
+        $response->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 60,
+            'recordsFiltered' => 3,
+        ]);
+
+        $this->assertCount(3, $response->json()['data']);
+    }
+
+    #[Test]
+    public function it_can_sort_on_a_snake_case_relation_name()
+    {
+        $response = $this->getJsonResponse([
+            'order' => [
+                ['column' => 0, 'dir' => 'desc'],
+            ],
+            'length' => 10,
+            'start' => 0,
+            'draw' => 1,
+        ]);
+
+        $response->assertJson([
+            'draw' => 1,
+            'recordsTotal' => 60,
+            'recordsFiltered' => 60,
+        ]);
+
+        $this->assertEquals('Email-9@example.com', $response->json()['data'][0]['post_user']['email']);
+    }
+
+    #[Test]
+    public function it_still_resolves_a_relation_that_is_named_in_snake_case()
+    {
+        $this->app['router']->get('/relations/snakeCaseDefined', fn (DataTables $datatables) => $datatables
+            ->eloquent(Post::with('user')->select('posts.*'))
+            ->toJson());
+
+        $response = $this->call('GET', '/relations/snakeCaseDefined', [
+            'columns' => [
+                ['data' => 'user.email', 'name' => 'user.email', 'searchable' => 'true', 'orderable' => 'true'],
+            ],
+            'search' => ['value' => 'Email-19@example.com'],
+        ]);
+
+        $response->assertJson([
+            'draw' => 0,
+            'recordsTotal' => 60,
+            'recordsFiltered' => 3,
+        ]);
+    }
+
+    protected function getJsonResponse(array $params = [])
+    {
+        $data = [
+            'columns' => [
+                [
+                    'data' => 'post_user.email',
+                    'name' => 'post_user.email',
+                    'searchable' => 'true',
+                    'orderable' => 'true',
+                ],
+            ],
+        ];
+
+        return $this->call('GET', '/relations/snakeCase', array_merge($data, $params));
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app['router']->get('/relations/snakeCase', fn (DataTables $datatables) => $datatables
+            ->eloquent(Post::with('postUser')->select('posts.*'))
+            ->toJson());
+    }
+}

--- a/tests/Models/Post.php
+++ b/tests/Models/Post.php
@@ -18,6 +18,11 @@ class Post extends Model
         return $this->belongsTo(User::class);
     }
 
+    public function postUser()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
     public function heart()
     {
         return $this->hasOneThrough(Heart::class, User::class, 'id', 'user_id', 'user_id', 'id');

--- a/tests/Models/Post.php
+++ b/tests/Models/Post.php
@@ -23,6 +23,11 @@ class Post extends Model
         return $this->belongsTo(User::class, 'user_id');
     }
 
+    public function post_user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
     public function heart()
     {
         return $this->hasOneThrough(Heart::class, User::class, 'id', 'user_id', 'user_id', 'id');


### PR DESCRIPTION
Follow up to the note on #3300. Depends on #3300, so it is stacked on that branch and its two commits show up here until #3300 is merged. The morph fix itself is the last commit.

## Problem

`isMorphRelation()` always resolves the relation against the model the data table was built from, even when it is called for a nested relation inside a `whereHas()` callback. At that point the relation belongs to the related model, not to the root one.

When the root model happens to declare a morph relation under the same name as a plain relation of the nested model, the nested one is treated as a morph and `whereHasMorph()` is called on a relation that is not morphed:

```
Call to undefined method Illuminate\Database\Eloquent\Relations\HasOne::getMorphType()
```

Repro with the test models: `User::user()` is a `morphTo` while `Post::user()` is a `belongsTo`, so searching `posts.user.name` on `User::with('posts.user')` fatals.

The opposite direction, a genuine nested morph not being detected, turns out to be harmless. Laravel's `has()` already routes a `MorphTo` to `hasMorph($relation, '*')`, so `whereHas()` produces the same per type existence queries. There is a test for that case so it stays that way.

## Solution

The morph check now resolves against the model of the query being compiled: the related model inside a `whereHas()` callback, the root model otherwise. This is the same context that #3300 introduced for resolving relation names, so both now agree on which model a nested segment belongs to.

## Changes

- `isMorphRelationOf()` performs the check against a given model, and `isMorphRelation()` keeps its signature and delegates using the root model, so an override of it in an application keeps working.
- `modelOf()` returns the model of the query being compiled, defaulting to the root one.
- `compileQuerySearch()` resolves the context once and uses it for both the relation name and the morph check.
- `tests/Integration/NestedMorphRelationTest.php` covers the fatal case and a genuine nested morph relation. The first one fails without the fix.

## Notes

- Nothing changes at depth 1, where the relation already belongs to the root model.
- `composer stan` passes and the existing `MorphToRelationTest` passes unchanged.
